### PR TITLE
feat(sdk): optimize arun method for PID extraction and large file handling - Fixes #84

### DIFF
--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/References/Python SDK References/sandbox.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/current/References/Python SDK References/sandbox.md
@@ -2,7 +2,7 @@
 
 ## `arun`
 `arun()` 方法新增 `response_limited_bytes_in_nohup` 参数(int型)，解决response过长导致的请求超时问题。
-该参数用于限制 nohup 模式下返回的 output 字符数，默认值为 `None`，表示不限制。
+该参数用于限制 nohup 模式下返回的 output 字节数，默认值为 `None`，启用智能模式：当文件超过 1MB 时，返回前 512KB 和后 512KB 的内容，并附带截断提示，同时保留开头上下文和末尾的重要错误信息。
 
 ```python
 from rock.sdk.sandbox.client import Sandbox

--- a/docs/rock/References/Python SDK References/sandbox.md
+++ b/docs/rock/References/Python SDK References/sandbox.md
@@ -3,7 +3,7 @@
 ## `arun`
 
 The `arun()` method now supports a new parameter: `response_limited_bytes_in_nohup` (integer type), which resolves request timeout issues caused by excessively long responses.  
-This parameter limits the number of characters returned in the output when running in `nohup` mode. The default value is `None`, meaning no limit is applied.
+This parameter limits the number of bytes returned in the output when running in `nohup` mode. The default value is `None`, which enables smart mode: when file size exceeds 1MB, it returns the first 512KB and last 512KB with a truncation notice to preserve both the beginning context and important error messages at the end.
 
 ```python
 from rock.sdk.sandbox.client import Sandbox

--- a/rock/utils/system.py
+++ b/rock/utils/system.py
@@ -7,7 +7,7 @@ import time
 from pathlib import Path
 from threading import Lock
 
-from rock.sdk.common.constants import PID_PREFIX
+from rock.sdk.common.constants import PID_PREFIX, PID_SUFFIX
 
 logger = logging.getLogger(__name__)
 
@@ -73,11 +73,16 @@ def extract_nohup_pid(nohup_output: str) -> int:
         nohup_output: Output string from nohup command.
 
     Returns:
-        Process ID as string, or empty string if extraction fails.
+        Process ID as int, or None if extraction fails.
     """
     try:
+        # Use both PREFIX and SUFFIX for more robust PID extraction
+        pid = re.findall(f"{PID_PREFIX}([0-9]+){PID_SUFFIX}", nohup_output)
+        if pid:
+            return int(pid[0])
+        # Fallback: try matching with just PREFIX for backward compatibility
         pid = re.findall(f"{PID_PREFIX}([0-9]+)", nohup_output)
-        return int(pid[0])
+        return int(pid[0]) if pid else None
     except Exception:
         return None
 


### PR DESCRIPTION
## 修复问题
Fixes https://github.com/alibaba/ROCK/issues/84

## 改动内容
- **PID 提取可靠性**：`extract_nohup_pid` 现在会同时匹配 `PID_PREFIX` 与 `PID_SUFFIX`，确保 nohup 输出中只有合法的 PID 被解析；若缺少后缀仍会回退到旧逻辑。
- **默认输出策略升级**：在 `arun(mode="nohup")` 中，当调用方未显式设置`response_limited_bytes_in_nohup` 且日志超过 1MB 时，会自动返回首尾各 512KB，并附带截断提示与文件路径。
- **自定义限流行为明确**：如果调用方提供 `response_limited_bytes_in_nohup`，则严格按指定字节数读取，不再额外检查文件大小，方便在特控制带宽或日志量定场景下控制带宽或日志量。