### PR TITLE
ci: add support for release/v1.0 branch in CI config

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -2,9 +2,13 @@ name: Python CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - release/v1.0
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - release/v1.0
 
 jobs:
   test:


### PR DESCRIPTION
closes #314 