### PR TITLE
docs: add instructions for accelerating Python installation in docs

### DIFF
--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.1.x/References/Python SDK References/runtime-env.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.1.x/References/Python SDK References/runtime-env.md
@@ -107,7 +107,7 @@ class NodeRuntimeEnv(RuntimeEnv):
 
 ## 加速基础环境安装
 
-`PythonRuntimeEnv` 默认从 <https://github.com/astral-sh/python-build-standalone/releases/> 下载 Python 安装包。若网络不可达或下载较慢，可通过环境变量 `ROCK_RTENV_PYTHON_V31114_INSTALL_CMD` 或 `ROCK_RTENV_PYTHON_V31212_INSTALL_CMD` 覆盖默认安装命令（例如切换到内网源/镜像源）。
+`PythonRuntimeEnv` 默认从 https://github.com/astral-sh/python-build-standalone/releases/ 下载 Python 安装包。若网络不可达或下载较慢，可通过环境变量 `ROCK_RTENV_PYTHON_V31114_INSTALL_CMD` 或 `ROCK_RTENV_PYTHON_V31212_INSTALL_CMD` 覆盖默认安装命令（例如切换到内网源/镜像源）。
 
 默认值示例：
 

--- a/docs/versioned_docs/version-1.1.x/References/Python SDK References/runtime-env.md
+++ b/docs/versioned_docs/version-1.1.x/References/Python SDK References/runtime-env.md
@@ -106,7 +106,7 @@ class NodeRuntimeEnv(RuntimeEnv):
 
 ## Speeding Up Base Runtime Installation
 
-`PythonRuntimeEnv` downloads Python packages from <https://github.com/astral-sh/python-build-standalone/releases/> by default. If the network is unavailable or slow, you can override the default install command via `ROCK_RTENV_PYTHON_V31114_INSTALL_CMD` or `ROCK_RTENV_PYTHON_V31212_INSTALL_CMD` (e.g., switch to an internal registry or a mirror).
+`PythonRuntimeEnv` downloads Python packages from https://github.com/astral-sh/python-build-standalone/releases/ by default. If the network is unavailable or slow, you can override the default install command via `ROCK_RTENV_PYTHON_V31114_INSTALL_CMD` or `ROCK_RTENV_PYTHON_V31212_INSTALL_CMD` (e.g., switch to an internal registry or a mirror).
 
 Default value example:
 


### PR DESCRIPTION
closes #372 