### PR TITLE
chore: bump version number to 1.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 authors = [{ name = "chatos@alibaba" }]
 requires-python = "<4.0,>=3.10"
 name = "rl-rock"
-version = "1.2.0"
+version = "1.2.2"
 description = "ROCK-Reinforcement Open Construction Kit"
 readme = "README.md"
 dependencies = [


### PR DESCRIPTION
closes #447 