### PR TITLE
docs: add v1.2.5 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ ROCK adopts a client-server architecture, supports different levels of isolation
 ## 📢 News
 | 📣 Update |
 |:--|
+| **[02/28/2026]** 🎉 ROCK v1.2.5 Released! Custom metrics endpoint, user-defined metric tags, and Aliyun MSE Nacos support. |
 | **[01/01/2026]** 🎉 Our [Let It Flow: Agentic Crafting on Rock and Roll](https://arxiv.org/abs/2512.24873) report released! Introducing ALE ecosystem and ROME, an open-source agentic model with novel IPA algorithm. |
 ---
 
@@ -161,7 +162,7 @@ if __name__ == "__main__":
 
 | 📣 Update Content |
 |:-----------|
-| **[Latest]** 🎉 ROCK v0.2.0 Released |
+| **[Latest]** 🎉 ROCK v1.2.5 Released |
 
 ---
 

--- a/docs/versioned_docs/version-1.2.x/Release Notes/index.md
+++ b/docs/versioned_docs/version-1.2.x/Release Notes/index.md
@@ -2,5 +2,6 @@
 sidebar_position: 1
 ---
 # Release Notes
-* [release v1.2.0](v1.2.0.md)
+* [release v1.2.5](v1.2.5.md)
 * [release v1.2.1](v1.2.1.md)
+* [release v1.2.0](v1.2.0.md)

--- a/docs/versioned_docs/version-1.2.x/Release Notes/v1.2.5.md
+++ b/docs/versioned_docs/version-1.2.x/Release Notes/v1.2.5.md
@@ -1,0 +1,53 @@
+# v1.2.5
+
+## Release Date
+February 28, 2026
+
+## Overview
+This release focuses on monitoring and metrics enhancements, adding support for custom OTLP endpoints, user-defined metric tags, and Aliyun MSE Nacos connectivity.
+
+---
+
+## Admin
+
+### New Features
+
+#### Custom Metrics Endpoint
+- **NEW**: Support specifying a custom OTLP metrics endpoint via `metrics_endpoint` in `RuntimeConfig`. Previously the endpoint was hardcoded to `http://{host}:{port}/v1/metrics`; now it can be configured to any OTLP-compatible collector.
+
+**Configuration Example:**
+```yaml
+runtime:
+  metrics_endpoint: "http://my-otel-collector:4317/v1/metrics"
+```
+
+#### User-Defined Metric Tags
+- **NEW**: Support adding custom tags to all metrics via `user_defined_tags` in `RuntimeConfig`. These tags are merged into the base attributes of every metric emitted by Admin, SandboxProxyService, and SandboxActor.
+
+**Configuration Example:**
+```yaml
+runtime:
+  user_defined_tags:
+    cluster: "prod-cluster"
+    region: "cn-hz"
+    service: "rock-sandbox"
+```
+
+#### Metrics IP Tag
+- **NEW**: Added `ip` field to metrics base attributes for better instance identification in monitoring dashboards.
+
+#### Actor Metrics Endpoint
+- **NEW**: Exposed `metrics_endpoint` configuration to `SandboxActor`, allowing Ray actors to report metrics to custom OTLP endpoints. The endpoint is propagated from `RuntimeConfig` to actors during sandbox creation.
+
+### Enhancements
+
+#### Nacos Configuration
+- **NEW**: Added `server_addresses` field to `NacosConfig`, enabling direct connection to Nacos servers (e.g., Aliyun MSE) without relying solely on the `endpoint` parameter.
+
+**Configuration Example:**
+```yaml
+nacos:
+  server_addresses: "mse-xxx.nacos.mse.aliyuncs.com:8848"
+  group: "DEFAULT_GROUP"
+  data_id: "rock-config"
+```


### PR DESCRIPTION
## Summary
- Add v1.2.5 release notes documenting monitoring/metrics enhancements and Aliyun MSE Nacos support
- Update release notes index with v1.2.5 entry
- Update README.md news section and latest updates to reflect v1.2.5

fixes #533

## Test plan
- [ ] Verify release notes render correctly in Docusaurus
- [ ] Verify README.md news table displays properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)