### PR TITLE
fix: centralize test data directories to project_root/.tmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 nacos-data/
 data/
 tmp/
+.tmp/
 *.log
 data/
 node_modules

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import uuid
 from pathlib import Path
 
@@ -6,22 +7,48 @@ import pytest
 
 from rock import env_vars
 
+# Set test data directories at import time (before test collection triggers
+# module-level constants in production code like TRAJ_FILE in config.py).
+_project_root = Path(__file__).parent.parent
+_workdir = _project_root / ".tmp" / "test_data"
+_workdir.mkdir(parents=True, exist_ok=True)
+
+_dirs = {
+    "ROCK_MODEL_SERVICE_DATA_DIR": str(_workdir / "model"),
+    "ROCK_SCHEDULER_STATUS_DIR": str(_workdir / "scheduler"),
+    "ROCK_LOGGING_PATH": str(_workdir / "logs"),
+    "ROCK_SERVICE_STATUS_DIR": str(_workdir / "status"),
+}
+
+for _key, _value in _dirs.items():
+    setattr(env_vars, _key, _value)
+    os.environ[_key] = _value
+
 
 @pytest.fixture(autouse=True, scope="session")
-def configure_logging():
-    """Automatically configure logging for all tests"""
+def test_workdir():
+    """Unified test data directory under project_root/.tmp/test_data.
+
+    Redirects all ROCK directory env vars to avoid PermissionError
+    on non-container environments (e.g. /data/logs -> .tmp/test_data/model).
+
+    The actual env var setup happens at module level above (before collection),
+    this fixture exposes the workdir path for tests that need it.
+    """
+    yield _workdir
+
+
+@pytest.fixture(autouse=True, scope="session")
+def configure_logging(test_workdir):
+    """Automatically configure logging for all tests.
+
+    Depends on test_workdir to ensure ROCK_LOGGING_PATH is set first.
+    """
     logging.basicConfig(
         level=logging.DEBUG,
         format="%(asctime)s %(levelname)s %(filename)s:%(lineno)d -- %(message)s",
-        force=True,  # Force reconfiguration
+        force=True,
     )
-    log_dir = env_vars.ROCK_LOGGING_PATH
-    if log_dir and not Path(log_dir).is_absolute():
-        # Relative to project root directory
-        project_root = Path(__file__).parent.parent  # Project root directory
-        log_dir = str(project_root / log_dir)
-        env_vars.ROCK_LOGGING_PATH = log_dir
-
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("httpcore").setLevel(logging.WARNING)
 

--- a/tests/integration/cli/test_model_service.py
+++ b/tests/integration/cli/test_model_service.py
@@ -13,10 +13,7 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.asyncio
 async def test_model_service():
-    os.environ["ROCK_MODEL_SERVICE_DATA_DIR"] = "/tmp/rock_model_service_test_data"
-
     model_env = os.environ.copy()
-    model_env["ROCK_LOGGING_PATH"] = "/tmp/rock_model_service_test_data"
     model_env["ROCK_LOGGING_FILE_NAME"] = "model_service.log"
     subprocess.run(["rock", "model-service", "start"], env=model_env)
 

--- a/tests/integration/sdk/sandbox/test_close_session.py
+++ b/tests/integration/sdk/sandbox/test_close_session.py
@@ -1,12 +1,8 @@
 import pytest
-import os
-from pathlib import Path
-from rock.sdk.sandbox.client import Sandbox
-from rock.actions import CreateBashSessionRequest, CloseBashSessionRequest, BashAction
-from tests.integration.conftest import SKIP_IF_NO_DOCKER
 
-# Set writable status directory for sandbox deployment
-os.environ["ROCK_SERVICE_STATUS_DIR"] = "/tmp/rock_status"
+from rock.actions import CloseBashSessionRequest, CreateBashSessionRequest
+from rock.sdk.sandbox.client import Sandbox
+from tests.integration.conftest import SKIP_IF_NO_DOCKER
 
 
 @pytest.mark.need_admin

--- a/tests/unit/test_envs.py
+++ b/tests/unit/test_envs.py
@@ -16,11 +16,17 @@ def test_envs_project_root():
 
 def test_service_status_dir_default():
     """ROCK_SERVICE_STATUS_DIR 默认值应为 /tmp"""
-    # 清除可能已设置的环境变量
-    original = os.environ.pop("ROCK_SERVICE_STATUS_DIR", None)
+    # 清除可能已设置的环境变量和模块属性缓存
+    original_env = os.environ.pop("ROCK_SERVICE_STATUS_DIR", None)
+    # Delete the cached attribute so __getattr__ re-evaluates the default
+    try:
+        delattr(env_vars, "ROCK_SERVICE_STATUS_DIR")
+    except AttributeError:
+        pass
     try:
         status_dir = env_vars.ROCK_SERVICE_STATUS_DIR
         assert status_dir == "/tmp", f"Expected /tmp, got {status_dir}"
     finally:
-        if original is not None:
-            os.environ["ROCK_SERVICE_STATUS_DIR"] = original
+        if original_env is not None:
+            os.environ["ROCK_SERVICE_STATUS_DIR"] = original_env
+            env_vars.ROCK_SERVICE_STATUS_DIR = original_env


### PR DESCRIPTION
## Summary
- Add `test_workdir` session fixture in root `conftest.py` that redirects all `ROCK_*_DIR` env vars to `project_root/.tmp/test_data/`
- Fix `PermissionError: [Errno 13] Permission denied: '/data'` in unit tests (e.g. `test_chat_completions_routing_success`)
- Remove scattered per-file env overrides from `test_model_service.py` and `test_close_session.py`

## Test plan
- [x] `test_chat_completions_routing_success` passes (was failing with PermissionError)
- [x] Full unit test suite: 190 passed, 0 failed
- [x] Lint clean (`ruff check`)

fixes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)