### PR TITLE
Add remove_container parameter to sandbox configuration

### DIFF
--- a/rock/admin/proto/request.py
+++ b/rock/admin/proto/request.py
@@ -33,6 +33,8 @@ class SandboxStartRequest(BaseModel):
     """Password for Docker registry authentication. When both username and password are provided, docker login will be performed before pulling the image."""
     use_kata_runtime: bool = False
     """Whether to use kata container runtime (io.containerd.kata.v2) instead of --privileged mode."""
+    remove_container: bool = True
+    """Whether to remove the container after it stops running."""
 
 
 class SandboxCommand(Command):

--- a/rock/sdk/sandbox/config.py
+++ b/rock/sdk/sandbox/config.py
@@ -42,6 +42,7 @@ class SandboxConfig(BaseConfig):
     registry_username: str | None = None
     registry_password: str | None = None
     use_kata_runtime: bool = False
+    remove_container: bool = True
 
 
 class SandboxGroupConfig(SandboxConfig):


### PR DESCRIPTION
Add a remove_container parameter to automatically remove containers after they stop running. This feature adds a remove_container boolean parameter to sandbox configuration with a default value of True, allowing containers to be automatically cleaned up after they finish execution. Fixes #593
