### PR TITLE
fix(sdk): add runtime config type validation in PythonRuntimeEnv

### DIFF
--- a/rock/sdk/sandbox/runtime_env/python_runtime_env.py
+++ b/rock/sdk/sandbox/runtime_env/python_runtime_env.py
@@ -74,6 +74,8 @@ class PythonRuntimeEnv(RuntimeEnv):
         version = runtime_env_config.version
         if version not in ("3.11", "3.12", "default"):
             raise ValueError(f"Unsupported Python version: {version}. Supported versions: 3.11, 3.12, default")
+        if not isinstance(runtime_env_config, PythonRuntimeEnvConfig):
+            runtime_env_config = PythonRuntimeEnvConfig.model_validate(runtime_env_config.model_dump())
 
         # Create base config with resolved version (extra="ignore" handles 'pip' and 'pip_index_url' fields)
         super().__init__(sandbox=sandbox, runtime_env_config=runtime_env_config)


### PR DESCRIPTION
```
(EnvironmentWorker(train_env-0) pid=746905) 2026-03-19T17:41:53.502+08:00 INFO:rock_agent.py:382 [rock.sdk.sandbox.agent.rock_agent] [] [] -- [240498b70e464981a6cfc7165776dc31] Start to Initializing ModelService
(EnvironmentWorker(train_env-0) pid=746905) 2026-03-19T17:41:53.503+08:00 ERROR:rock_agent.py:224 [rock.sdk.sandbox.agent.rock_agent] [] [] -- [240498b70e464981a6cfc7165776dc31] Agent initialization failed - 'RuntimeEnvConfig' object has no attribute 'pip' (elapsed: 0.50s),
```

I asked LLM, it gives me the following reason:

> 问题分析
在 RuntimeEnv.create() 方法（第 64 行）中：
python
runtime_env = runtime_class(sandbox=sandbox, runtime_env_config=runtime_env_config)
这里 runtime_class 是 PythonRuntimeEnv，但它的构造函数签名是：
python
def __init__(self, sandbox: Sandbox, runtime_env_config: PythonRuntimeEnvConfig) -> None:
而传入的 runtime_env_config 实际上是 RuntimeEnvConfig 基类对象（不是 PythonRuntimeEnvConfig）。
根本原因
当 RockAgentConfig 被创建时，runtime_env_config 字段的默认值是：
python
runtime_env_config: RuntimeEnvConfigType | None = Field(default_factory=PythonRuntimeEnvConfig)
但如果配置是从 YAML/字典加载的，Pydantic 可能会将字典解析为基类 RuntimeEnvConfig 而不是 PythonRuntimeEnvConfig。

And the solution:

```
def __init__(self, sandbox: Sandbox, runtime_env_config: PythonRuntimeEnvConfig) -> None:
    # 确保是 PythonRuntimeEnvConfig 类型
    if not isinstance(runtime_env_config, PythonRuntimeEnvConfig):
        runtime_env_config = PythonRuntimeEnvConfig.model_validate(runtime_env_config.model_dump())
    ...
```

The problem is solved with the solution.

fix #651 