### PR TITLE
fix(job): pass job_name to harbor YAML and migrate demo to new Job path

### DIFF
--- a/examples/harbor/harbor_demo.py
+++ b/examples/harbor/harbor_demo.py
@@ -1,15 +1,12 @@
-"""Harbor benchmark demo using ROCK Job SDK.
+"""Harbor benchmark demo using ROCK Job SDK (new path).
 
-Run Harbor benchmark tasks inside a ROCK sandbox via the Job SDK.
-Configuration is loaded from a YAML file and passed to ``harbor jobs start``
-inside the sandbox.
+Uses ``rock.sdk.job.Job`` with ``HarborJobConfig`` — the recommended path
+with full feature parity (G1-G7 fixed) and scatter / multiple trial types.
 
-Example config templates:
-    - ``examples/harbor/swe_job_config.yaml.template`` — SWE-bench-verified
-    - ``examples/harbor/tb_job_config.yaml.template`` — Terminal Bench 2
+For the legacy path (``rock.sdk.bench.Job``), see ``harbor_demo_legacy.py``.
 
 Usage:
-    python examples/harbor/harbor_demo.py -c examples/harbor/job_config.yaml
+    python examples/harbor/harbor_demo.py -c examples/harbor/swe.intern.yaml
     python examples/harbor/harbor_demo.py -c examples/harbor/tb_job_config.yaml -t mailman
 
 Required environment variables (OSS_* are auto-forwarded into the sandbox):
@@ -32,7 +29,8 @@ import logging
 import os
 import sys
 
-from rock.sdk.bench import HarborJobConfig, Job
+from rock.sdk.bench import HarborJobConfig
+from rock.sdk.job import Job
 
 _REQUIRED_ENV_VARS = [
     "OSS_ACCESS_KEY_ID",

--- a/rock/sdk/bench/models/job/config.py
+++ b/rock/sdk/bench/models/job/config.py
@@ -249,13 +249,17 @@ class HarborJobConfig(_BaseJobConfig):
     def to_harbor_yaml(self) -> str:
         """Serialize Harbor-native fields to YAML for ``harbor jobs start -c``.
 
-        Base JobConfig fields (environment, job_name, setup_commands, etc.)
-        are excluded. Harbor environment fields (force_build, override_cpus, etc.)
+        Base JobConfig fields (environment, setup_commands, etc.) are excluded.
+        ``job_name`` is re-injected so harbor uses it as the job directory name
+        instead of its default timestamp-based naming.
+        Harbor environment fields (force_build, override_cpus, etc.)
         are re-injected under ``environment``.
         """
         import yaml
 
         data = self.model_dump(mode="json", exclude=self._BASE_FIELDS, exclude_none=True)
+        if self.job_name:
+            data["job_name"] = self.job_name
         harbor_env = self.environment.to_harbor_environment()
         if harbor_env:
             data["environment"] = harbor_env

--- a/tests/unit/sdk/agent/test_job_config_serialization.py
+++ b/tests/unit/sdk/agent/test_job_config_serialization.py
@@ -111,8 +111,9 @@ class TestHarborJobConfigToHarborYaml:
         yaml_str = cfg.to_harbor_yaml()
         data = yaml.safe_load(yaml_str)
 
-        # Base fields (job_name, experiment_id, etc.) are excluded from harbor YAML
-        assert "job_name" not in data
+        # job_name is re-injected so harbor uses it as the directory name
+        assert data["job_name"] == "test-job"
+        # Other base fields (experiment_id, etc.) are excluded from harbor YAML
         assert "experiment_id" not in data
         assert data["n_attempts"] == 2
         assert data["agents"][0]["name"] == "terminus-2"
@@ -165,7 +166,7 @@ class TestHarborJobConfigToHarborYaml:
         data = yaml.safe_load(yaml_str)
 
         assert "labels" not in data
-        assert "job_name" not in data
+        assert data["job_name"] == "labeled-job"
 
     def test_path_fields_serialized_as_strings(self):
         cfg = HarborJobConfig(
@@ -206,7 +207,7 @@ class TestHarborJobConfigToHarborYaml:
         yaml_str = cfg.to_harbor_yaml()
         data = yaml.safe_load(yaml_str)
 
-        assert "job_name" not in data  # base field excluded
+        assert data["job_name"] == "full-test"
         assert data["environment"]["type"] == "docker"
         assert data["environment"]["force_build"] is True
         assert data["environment"]["override_cpus"] == 4

--- a/tests/unit/sdk/job/test_config.py
+++ b/tests/unit/sdk/job/test_config.py
@@ -199,8 +199,9 @@ class TestHarborJobConfigToHarborYaml:
         yaml_str = cfg.to_harbor_yaml()
         data = yaml.safe_load(yaml_str)
         # Rock-only fields must be absent from Harbor YAML
+        # job_name is re-injected so harbor uses it as the directory name
+        assert data["job_name"] == "should-not-appear"
         rock_only = {
-            "job_name",
             "namespace",
             "experiment_id",
             "labels",


### PR DESCRIPTION
Harbor was using timestamp-based directory names because job_name was excluded from the serialized YAML config. Re-inject job_name in to_harbor_yaml() so harbor uses it as the job directory name, allowing result collection via {jobs_dir}/{job_name} to work correctly.

Also migrate harbor_demo.py from deprecated rock.sdk.bench.Job to rock.sdk.job.Job.