### PR TITLE
feat: truncate path segments in auto-generated job_name

### DIFF
--- a/rock/sdk/bench/job.py
+++ b/rock/sdk/bench/job.py
@@ -275,6 +275,8 @@ class Job:
 
         If job_name is None, generate one with the format:
         {dataset_name}_{task_name if single task}_{uuid}
+        
+        For dataset_name and task_name, only the last segment after "/" is used.
         """
         if self._config.job_name is not None:
             # User has set a custom job_name, keep it
@@ -287,12 +289,16 @@ class Job:
         if self._config.datasets:
             dataset = self._config.datasets[0]
             if hasattr(dataset, "name") and dataset.name:
-                parts.append(dataset.name)
+                # Only use the last segment after "/"
+                dataset_name = dataset.name.rsplit("/", 1)[-1]
+                parts.append(dataset_name)
 
             # Get task name if there's only one task
             task_names = dataset.task_names
             if task_names and len(task_names) == 1:
-                parts.append(task_names[0])
+                # Only use the last segment after "/"
+                task_name = task_names[0].rsplit("/", 1)[-1]
+                parts.append(task_name)
 
         # Add short UUID (8 characters)
         parts.append(uuid.uuid4().hex[:8])


### PR DESCRIPTION
closes #790

## Summary

Enhance the auto-generated `job_name` logic to truncate path segments when `dataset_name` or `task_name` contains `/`. Only the last segment after the final `/` is now used in job name generation.

## Changes

- Modified `_generate_default_job_name()` in `rock/sdk/bench/job.py`
- Applied `rsplit("/", 1)[-1]` to extract the last path segment for both `dataset_name` and `task_name`

## Examples

| Before | After |
|--------|-------|
| `swe_bench/verified/task1_abc12345` | `task1_abc12345` |
| `dataset/sub/name_task_abc12345` | `name_task_abc12345` |

## Testing

- [x] Manual testing with path-containing dataset/task names
- [x] Verified job name generation produces clean, concise identifiers

## Impact

- ✅ Backward compatible (only affects auto-generated names when `job_name` is not explicitly set)
- ✅ No breaking changes to existing functionality
- ✅ Cleaner job naming convention