### PR TITLE
fix(job): BashTrial.collect should populate raw_output and exit_code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ docs/superpowers/
 *.db
 *.intern.yaml
 *.intern.md
+.worktrees/

--- a/rock/sdk/job/trial/bash.py
+++ b/rock/sdk/job/trial/bash.py
@@ -37,6 +37,8 @@ class BashTrial(AbstractTrial):
         return TrialResult(
             task_name=self._config.job_name or "",
             exception_info=exception_info,
+            raw_output=output,
+            exit_code=exit_code,
         )
 
 


### PR DESCRIPTION
## Summary

- `BashTrial.collect` was ignoring the `output` and `exit_code` parameters passed by the executor, leaving both fields at default values in `TrialResult`
- Now passes them directly, making the intent explicit rather than relying on executor G5 backfill

## Test Plan

- [x] Existing unit tests pass (`tests/unit/sdk/job/` — 116 passed)

fixes #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)