### PR TITLE
fix(job): update timeout sentinel and tests after default increased to 7200s

### DIFF
--- a/rock/sdk/bench/models/job/config.py
+++ b/rock/sdk/bench/models/job/config.py
@@ -259,8 +259,8 @@ class HarborJobConfig(_BaseJobConfig):
         """
         from rock.sdk.bench.constants import DEFAULT_WAIT_TIMEOUT
 
-        # 3600 is the base JobConfig default; treat as "user didn't touch it".
-        if self.timeout != 3600:
+        # 7200 is the base JobConfig default; treat as "user didn't touch it".
+        if self.timeout != 7200:
             return self
 
         multiplier = self.timeout_multiplier or 1.0

--- a/tests/unit/sdk/job/test_config.py
+++ b/tests/unit/sdk/job/test_config.py
@@ -35,7 +35,7 @@ class TestJobConfig:
         assert cfg.namespace is None
         assert cfg.experiment_id is None
         assert cfg.labels == {}
-        assert cfg.timeout == 3600
+        assert cfg.timeout == 7200
         assert cfg.environment.auto_stop is False
         assert cfg.environment.uploads == []
         assert cfg.environment.env == {}
@@ -84,7 +84,7 @@ class TestBashJobConfig:
     def test_defaults(self):
         cfg = BashJobConfig()
         # Inherited defaults
-        assert cfg.timeout == 3600
+        assert cfg.timeout == 7200
         assert cfg.labels == {}
         # Own defaults
         assert cfg.script is None


### PR DESCRIPTION
## Summary

- `HarborJobConfig._compute_effective_timeout` used `!= 3600` as sentinel to detect "user didn't touch timeout"; after #806 raised the default to 7200, this sentinel was always true and the validator short-circuited — agent `max_timeout_sec` / `override_timeout_sec` were silently ignored
- Update sentinel `3600 → 7200` and align two test assertions in `test_config.py`

## Test Plan

- [x] `tests/unit/sdk/job/test_config.py` — 44 passed (was 6 failing)

fixes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)