### PR TITLE
chore: apply ruff format and translate Chinese comments to English

### DIFF
--- a/rock/admin/core/db_provider.py
+++ b/rock/admin/core/db_provider.py
@@ -57,5 +57,5 @@ class DatabaseProvider:
             return url.replace("sqlite:///", "sqlite+aiosqlite:///", 1)
         if url.startswith("postgresql://") or url.startswith("postgres://"):
             prefix = "postgresql://" if url.startswith("postgresql://") else "postgres://"
-            return "postgresql+asyncpg://" + url[len(prefix):]
+            return "postgresql+asyncpg://" + url[len(prefix) :]
         return url

--- a/rock/admin/core/schema.py
+++ b/rock/admin/core/schema.py
@@ -13,7 +13,6 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.types import JSON
 
-
 _JSONB_VARIANT = JSON().with_variant(JSONB(), "postgresql")
 
 

--- a/rock/admin/main.py
+++ b/rock/admin/main.py
@@ -14,14 +14,14 @@ from starlette.responses import JSONResponse
 
 from rock import env_vars
 from rock.admin.core.db_provider import DatabaseProvider
-from rock.admin.core.sandbox_table import SandboxTable
 from rock.admin.core.ray_service import RayService
+from rock.admin.core.sandbox_table import SandboxTable
 from rock.admin.entrypoints.sandbox_api import sandbox_router, set_sandbox_manager
 from rock.admin.entrypoints.sandbox_proxy_api import sandbox_proxy_router, set_sandbox_proxy_service
 from rock.admin.entrypoints.warmup_api import set_warmup_service, warmup_router
 from rock.admin.gem.api import gem_router, set_env_service
 from rock.admin.scheduler.scheduler import SchedulerThread
-from rock.config import RockConfig, DatabaseConfig
+from rock.config import DatabaseConfig, RockConfig
 from rock.logger import init_logger
 from rock.sandbox.gem_manager import GemManager
 from rock.sandbox.operator.factory import OperatorContext, OperatorFactory

--- a/rock/admin/metrics/monitor.py
+++ b/rock/admin/metrics/monitor.py
@@ -48,7 +48,7 @@ class MetricsMonitor:
         pod = get_instance_id()
         env = env_vars.ROCK_ADMIN_ENV
         role = env_vars.ROCK_ADMIN_ROLE
-        logger.info(f"Initializing MetricsCollector with host={host}, port={port}, " f"env={env}, role={role}")
+        logger.info(f"Initializing MetricsCollector with host={host}, port={port}, env={env}, role={role}")
         return cls(
             host=host,
             port=port,

--- a/rock/admin/proto/request.py
+++ b/rock/admin/proto/request.py
@@ -118,7 +118,7 @@ class BatchSandboxStatusRequest(BaseModel):
 
 
 class SandboxQueryParams(TypedDict, total=False):
-    """Sandbox列表查询参数"""
+    """Query parameters for sandbox list."""
 
     page: str
     page_size: str

--- a/rock/rocklet/local_api.py
+++ b/rock/rocklet/local_api.py
@@ -186,7 +186,7 @@ async def portforward(websocket: WebSocket, port: int):
             f"local_addr={writer.get_extra_info('sockname')}"
         )
     except asyncio.TimeoutError:
-        logger.error(f"[Portforward] TCP connection timeout: target_port={port}, " f"timeout={TCP_CONNECT_TIMEOUT}s")
+        logger.error(f"[Portforward] TCP connection timeout: target_port={port}, timeout={TCP_CONNECT_TIMEOUT}s")
         await websocket.close(code=1011, reason=f"Connection to port {port} timed out")
         return
     except OSError as e:
@@ -198,7 +198,7 @@ async def portforward(websocket: WebSocket, port: int):
         return
     except Exception as e:
         logger.error(
-            f"[Portforward] Unexpected TCP error: target_port={port}, " f"error_type={type(e).__name__}, error={e}"
+            f"[Portforward] Unexpected TCP error: target_port={port}, error_type={type(e).__name__}, error={e}"
         )
         await websocket.close(code=1011, reason=f"Unexpected error: {e}")
         return
@@ -227,9 +227,7 @@ async def portforward(websocket: WebSocket, port: int):
         except WebSocketDisconnect as e:
             logger.info(f"[Portforward] ws->tcp: client disconnected: target_port={port}, code={e.code}")
         except Exception as e:
-            logger.debug(
-                f"[Portforward] ws->tcp error: target_port={port}, " f"error_type={type(e).__name__}, error={e}"
-            )
+            logger.debug(f"[Portforward] ws->tcp error: target_port={port}, error_type={type(e).__name__}, error={e}")
         finally:
             writer.close()
 
@@ -250,9 +248,7 @@ async def portforward(websocket: WebSocket, port: int):
                     f"bytes={len(data)}, total_msgs={tcp_to_ws_msgs}, total_bytes={tcp_to_ws_bytes}"
                 )
         except Exception as e:
-            logger.debug(
-                f"[Portforward] tcp->ws error: target_port={port}, " f"error_type={type(e).__name__}, error={e}"
-            )
+            logger.debug(f"[Portforward] tcp->ws error: target_port={port}, error_type={type(e).__name__}, error={e}")
         finally:
             try:
                 await websocket.close()
@@ -263,9 +259,7 @@ async def portforward(websocket: WebSocket, port: int):
     try:
         await asyncio.gather(ws_to_tcp(), tcp_to_ws())
     except Exception as e:
-        logger.debug(
-            f"[Portforward] Forwarding error: target_port={port}, " f"error_type={type(e).__name__}, error={e}"
-        )
+        logger.debug(f"[Portforward] Forwarding error: target_port={port}, error_type={type(e).__name__}, error={e}")
     finally:
         writer.close()
         try:

--- a/rock/sandbox/base_actor.py
+++ b/rock/sandbox/base_actor.py
@@ -85,7 +85,7 @@ class BaseActor:
         env = self._env
         role = self._role
         self.host = host
-        logger.info(f"Initializing MetricsCollector with host={host}, port={port}, " f"env={env}, role={role}")
+        logger.info(f"Initializing MetricsCollector with host={host}, port={port}, env={env}, role={role}")
         endpoint = self._metrics_endpoint or f"http://{host}:{port}/v1/metrics"
         self.otlp_exporter = OTLPMetricExporter(endpoint=endpoint)
         self.metric_reader = PeriodicExportingMetricReader(

--- a/rock/sandbox/base_manager.py
+++ b/rock/sandbox/base_manager.py
@@ -108,7 +108,7 @@ class BaseManager:
         logger.debug(f"Metrics overall report rt:{overall_duration:.4f}s")
 
     async def _report_system_resource_metrics(self):
-        """汇报系统资源指标"""
+        """Report system resource metrics."""
         total_cpu, total_mem, available_cpu, available_mem = await self._collect_system_resource_metrics()
         self.metrics_monitor.record_gauge_by_name(MetricsConstants.TOTAL_CPU_RESOURCE, total_cpu)
         self.metrics_monitor.record_gauge_by_name(MetricsConstants.TOTAL_MEM_RESOURCE, total_mem)
@@ -116,7 +116,7 @@ class BaseManager:
         self.metrics_monitor.record_gauge_by_name(MetricsConstants.AVAILABLE_MEM_RESOURCE, available_mem)
 
     async def _collect_system_resource_metrics(self):
-        """收集系统资源指标"""
+        """Collect system resource metrics."""
         cluster_resources = ray.cluster_resources()
         available_resources = ray.available_resources()
         total_cpu = cluster_resources.get("CPU", 0)

--- a/rock/sandbox/base_manager.py
+++ b/rock/sandbox/base_manager.py
@@ -10,8 +10,8 @@ from rock.admin.metrics.monitor import MetricsMonitor, aggregate_metrics
 from rock.config import RockConfig
 from rock.deployments.manager import DeploymentManager
 from rock.logger import init_logger
-from rock.utils import get_executor
 from rock.sandbox.sandbox_meta_store import SandboxMetaStore
+from rock.utils import get_executor
 
 logger = init_logger(__name__)
 

--- a/rock/sandbox/gem_manager.py
+++ b/rock/sandbox/gem_manager.py
@@ -20,6 +20,7 @@ from rock.sandbox.sandbox_actor import SandboxActor
 from rock.sandbox.sandbox_manager import SandboxManager
 from rock.sandbox.sandbox_meta_store import SandboxMetaStore
 
+
 class GemManager(SandboxManager):
     def __init__(
         self,

--- a/rock/sandbox/operator/factory.py
+++ b/rock/sandbox/operator/factory.py
@@ -77,4 +77,4 @@ class OperatorFactory:
                 k8s_operator.set_nacos_provider(context.nacos_provider)
             return k8s_operator
         else:
-            raise ValueError(f"Unsupported operator type: {operator_type}. " f"Supported types: ray, kubernetes")
+            raise ValueError(f"Unsupported operator type: {operator_type}. Supported types: ray, kubernetes")

--- a/rock/sandbox/operator/k8s/api_client.py
+++ b/rock/sandbox/operator/k8s/api_client.py
@@ -11,7 +11,8 @@ The Informer pattern reduces API Server load by maintaining a local cache.
 """
 
 import asyncio
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from aiolimiter import AsyncLimiter
 from kubernetes import client
@@ -24,6 +25,7 @@ logger = init_logger(__name__)
 
 # User-Agent for K8s API requests
 USER_AGENT = "rock-k8s-client/v1.0.0"
+
 
 def _make_list_func(
     custom_api: client.CustomObjectsApi,
@@ -120,9 +122,7 @@ class K8sApiClient:
         self._rate_limiter = AsyncLimiter(max_rate=qps, time_period=1.0)
 
         # Create SharedInformer with custom list function
-        list_func = _make_list_func(
-            self._custom_api, group, version, plural
-        )
+        list_func = _make_list_func(self._custom_api, group, version, plural)
         self._informer = SharedInformer(
             list_func=list_func,
             namespace=namespace,

--- a/rock/sandbox/operator/k8s/provider.py
+++ b/rock/sandbox/operator/k8s/provider.py
@@ -11,7 +11,7 @@ from kubernetes import config as k8s_config
 from rock.actions.sandbox.config import RemoteSandboxRuntimeConfig
 from rock.actions.sandbox.sandbox_info import SandboxInfo
 from rock.config import K8sConfig, PoolConfig
-from rock.deployments.config import DeploymentConfig, DockerDeploymentConfig
+from rock.deployments.config import DockerDeploymentConfig
 from rock.deployments.constants import Port
 from rock.logger import init_logger
 from rock.sandbox.operator.k8s.api_client import K8sApiClient

--- a/rock/sandbox/sandbox_manager.py
+++ b/rock/sandbox/sandbox_manager.py
@@ -35,12 +35,10 @@ from rock.sandbox.operator.abstract import AbstractOperator
 from rock.sandbox.sandbox_actor import SandboxActor
 from rock.sandbox.sandbox_meta_store import SandboxMetaStore
 from rock.sandbox.service.sandbox_proxy_service import SandboxProxyService
+from rock.sandbox.utils.timeout import SandboxTimeoutHelper
 from rock.sdk.common.exceptions import BadRequestRockError, InternalServerRockError
 from rock.utils.crypto_utils import AESEncryption
-from rock.sandbox.utils.timeout import SandboxTimeoutHelper
 from rock.utils.format import convert_to_gb, parse_size_to_bytes
-from rock.utils.providers.redis_provider import RedisProvider
-from rock.utils.service import build_sandbox_from_redis
 from rock.utils.system import get_iso8601_timestamp
 
 logger = init_logger(__name__)

--- a/rock/sandbox/sandbox_meta_store.py
+++ b/rock/sandbox/sandbox_meta_store.py
@@ -8,9 +8,7 @@ All DB operations are awaited for consistency.
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from typing import Any
-
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from rock.actions.sandbox.response import State
 from rock.actions.sandbox.sandbox_info import SandboxInfo

--- a/rock/sandbox/service/sandbox_proxy_service.py
+++ b/rock/sandbox/service/sandbox_proxy_service.py
@@ -161,9 +161,7 @@ class SandboxProxyService:
         return CommandResponse(**response)
 
     @monitor_sandbox_operation()
-    async def batch_get_sandbox_status(
-        self, sandbox_ids: list[str]
-    ) -> list[SandboxStatusResponse]:
+    async def batch_get_sandbox_status(self, sandbox_ids: list[str]) -> list[SandboxStatusResponse]:
         if sandbox_ids is None:
             raise BadRequestRockError(message="sandbox_ids is None")
         if len(sandbox_ids) > self._batch_get_status_max_count:
@@ -182,9 +180,7 @@ class SandboxProxyService:
         return results
 
     @monitor_sandbox_operation()
-    async def list_sandboxes(
-        self, query_params: SandboxQueryParams
-    ) -> SandboxListResponse:
+    async def list_sandboxes(self, query_params: SandboxQueryParams) -> SandboxListResponse:
         page = int(query_params.pop("page", "1"))
         page_size = int(query_params.pop("page_size", "500"))
         if page < 1 or page_size < 1:
@@ -720,9 +716,7 @@ class SandboxProxyService:
         if new_timeout is not None:
             await self._meta_store.update_timeout(sandbox_id, new_timeout)
 
-    async def list_all_sandboxes_by_query_params(
-        self, query_params: SandboxQueryParams
-    ):
+    async def list_all_sandboxes_by_query_params(self, query_params: SandboxQueryParams):
         all_ids = []
         async for sandbox_id in self._meta_store.iter_alive_sandbox_ids():
             all_ids.append(sandbox_id)

--- a/rock/sdk/job/result.py
+++ b/rock/sdk/job/result.py
@@ -13,12 +13,12 @@ from typing import Generic, TypeVar
 from pydantic import BaseModel, Field
 
 # ---------------------------------------------------------------------------
-# TrialResult base — 通用字段
+# TrialResult base — common fields
 # ---------------------------------------------------------------------------
 
 
 class ExceptionInfo(BaseModel):
-    """通用异常信息"""
+    """General exception info."""
 
     exception_type: str = ""
     exception_message: str = ""
@@ -27,10 +27,10 @@ class ExceptionInfo(BaseModel):
 
 
 class TrialResult(BaseModel):
-    """单次执行结果的基类 — 通用字段
+    """Base class for a single execution result — common fields.
 
-    Harbor 的 TrialResult 继承此类，添加 agent_info, verifier_result 等字段。
-    子类可 override score 和 status properties。
+    Harbor's TrialResult inherits this class and adds agent_info, verifier_result, etc.
+    Subclasses can override the score and status properties.
     """
 
     task_name: str = ""

--- a/rock/sdk/job/trial/abstract.py
+++ b/rock/sdk/job/trial/abstract.py
@@ -1,6 +1,6 @@
 """Trial abstract base class — three-phase interface (setup / build / collect).
 
-Trial 对象不管理 sandbox 生命周期；生命周期由 JobExecutor 负责。
+Trial objects do not manage sandbox lifecycle; lifecycle is managed by JobExecutor.
 """
 
 from __future__ import annotations
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 class AbstractTrial(ABC):
     """Trial base: three-phase interface (setup/build/collect).
 
-    Trial 不管理 sandbox 生命周期 (由 JobExecutor 负责)。
+    Trial does not manage sandbox lifecycle (managed by JobExecutor).
     """
 
     def __init__(self, config: JobConfig):

--- a/rock/sdk/sandbox/agent/openhands.py
+++ b/rock/sdk/sandbox/agent/openhands.py
@@ -2,6 +2,7 @@
 Solving software engineering(SWE) problem with [Openhands Benchmarks SDK](https://github.com/OpenHands/benchmarks.git).
 Implementation framework reference: `rock/sdk/sandbox/agent/swe_agent.py`
 """
+
 from __future__ import annotations
 
 import copy
@@ -466,8 +467,7 @@ class Openhands(DefaultAgent):
         except Exception as e:
             elapsed_total = time.time() - start_time
             logger.error(
-                f"[{sandbox_id}] Operation failed: Rollout execution failed - {str(e)} "
-                f"(elapsed: {elapsed_total:.2f}s)",
+                f"[{sandbox_id}] Operation failed: Rollout execution failed - {str(e)} (elapsed: {elapsed_total:.2f}s)",
                 exc_info=True,
             )
             raise

--- a/rock/sdk/sandbox/client.py
+++ b/rock/sdk/sandbox/client.py
@@ -944,7 +944,7 @@ class Sandbox(AbstractSandbox):
         await self.stop()
 
     def __str__(self):
-        """返回用户友好的字符串表示，包含主要成员变量"""
+        """Return user-friendly string representation with key attributes."""
         return (
             f"Sandbox(sandbox_id={self._sandbox_id}, "
             f"host_name={self._host_name!r}, "
@@ -954,7 +954,7 @@ class Sandbox(AbstractSandbox):
         )
 
     def __repr__(self):
-        """返回开发者友好的字符串表示，包含所有成员变量"""
+        """Return developer-friendly string representation with all attributes."""
         return (
             f"Sandbox("
             f"config={self.config!r}, "

--- a/rock/sdk/sandbox/deploy.py
+++ b/rock/sdk/sandbox/deploy.py
@@ -81,7 +81,7 @@ class Deploy:
             >>> deploy.format("cat <<working_dir>>/file")
             "cat /tmp/rock_workdir_abc123/file"
 
-            >>> deploy.format("echo $((3 << 2 >> 1))")  # 不受影响
+            >>> deploy.format("echo $((3 << 2 >> 1))")  # unaffected
             "echo $((3 << 2 >> 1))"
         """
         subs = {

--- a/rock/utils/k8s/informer/__init__.py
+++ b/rock/utils/k8s/informer/__init__.py
@@ -1,5 +1,5 @@
 from .cache import ObjectCache, _meta_namespace_key
-from .informer import SharedInformer, ADDED, MODIFIED, DELETED, BOOKMARK, ERROR
+from .informer import ADDED, BOOKMARK, DELETED, ERROR, MODIFIED, SharedInformer
 
 __all__ = [
     "ObjectCache",

--- a/rock/utils/k8s/informer/cache.py
+++ b/rock/utils/k8s/informer/cache.py
@@ -24,7 +24,7 @@ def _meta_namespace_key(obj):
             ns = meta.get("namespace") or ""
             name = meta.get("name") or ""
     if ns:
-        return "{}/{}".format(ns, name)
+        return f"{ns}/{name}"
     return name
 
 

--- a/rock/utils/k8s/informer/informer.py
+++ b/rock/utils/k8s/informer/informer.py
@@ -12,7 +12,7 @@ import time
 from kubernetes.client.exceptions import ApiException
 from kubernetes.watch import Watch
 
-from .cache import ObjectCache, _meta_namespace_key
+from .cache import ObjectCache
 
 logger = logging.getLogger(__name__)
 
@@ -102,7 +102,8 @@ class SharedInformer:
         if event_type not in self._handlers:
             raise ValueError(
                 "Unknown event_type {!r}. Use one of: {}".format(
-                    event_type, ", ".join(sorted(self._handlers)),
+                    event_type,
+                    ", ".join(sorted(self._handlers)),
                 )
             )
         with self._handler_lock:
@@ -171,9 +172,7 @@ class SharedInformer:
             try:
                 fn(obj)
             except Exception:
-                logger.exception(
-                    "Exception in informer handler for %s", event_type
-                )
+                logger.exception("Exception in informer handler for %s", event_type)
 
     def _initial_list(self):
         """List all objects and populate the cache, firing ADDED/MODIFIED/DELETED events.
@@ -294,9 +293,7 @@ class SharedInformer:
             except ApiException as exc:
                 if exc.status == 410:
                     # The stored resource version is too old; force a full re-list.
-                    logger.warning(
-                        "Watch expired (410 Gone); will re-list from scratch"
-                    )
+                    logger.warning("Watch expired (410 Gone); will re-list from scratch")
                     self._resource_version = None
                 else:
                     logger.warning(
@@ -312,11 +309,7 @@ class SharedInformer:
                 # (updated on every ADDED/MODIFIED/DELETED/BOOKMARK event) so
                 # that the next watch connection can resume without re-listing.
                 # Do not overwrite a None that was set by a 410 handler above.
-                if (
-                    self._resource_version is not None
-                    and self._watch is not None
-                    and self._watch.resource_version
-                ):
+                if self._resource_version is not None and self._watch is not None and self._watch.resource_version:
                     self._resource_version = self._watch.resource_version
                 self._watch = None
 

--- a/scripts/gen_ddl.py
+++ b/scripts/gen_ddl.py
@@ -15,9 +15,11 @@ from sqlalchemy.schema import CreateIndex, CreateTable
 def get_dialect(name: str):
     if name == "postgresql":
         from sqlalchemy.dialects import postgresql
+
         return postgresql.dialect()
     if name == "sqlite":
         from sqlalchemy.dialects import sqlite
+
         return sqlite.dialect()
     print(f"Unsupported dialect: {name}", file=sys.stderr)
     sys.exit(1)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -107,8 +107,7 @@ def admin_remote_server():
         parsed = urlparse(normalized)
         if not parsed.hostname or not parsed.port:
             raise ValueError(
-                "Invalid ROCK_TEST_ADMIN_BASE_URL. Expected host:port or http://host:port, "
-                f"got: {external_base_url!r}"
+                f"Invalid ROCK_TEST_ADMIN_BASE_URL. Expected host:port or http://host:port, got: {external_base_url!r}"
             )
         logger.info("Using external admin server from ROCK_TEST_ADMIN_BASE_URL=%s", external_base_url)
         yield RemoteServer(port=parsed.port, endpoint=f"{parsed.scheme}://{parsed.hostname}")

--- a/tests/unit/admin/core/test_sandbox_table.py
+++ b/tests/unit/admin/core/test_sandbox_table.py
@@ -152,10 +152,13 @@ class TestSandboxTableWithPostgres:
 
     async def test_update(self, db):
         sandbox_id = "test-sandbox-003"
-        await db.create(sandbox_id, {
-            "state": "PENDING",
-            "create_time": "2025-01-01T00:00:00Z",
-        })
+        await db.create(
+            sandbox_id,
+            {
+                "state": "PENDING",
+                "create_time": "2025-01-01T00:00:00Z",
+            },
+        )
 
         await db.update(sandbox_id, {"state": "RUNNING", "host_ip": "10.0.0.2"})
         record = await db.get(sandbox_id)

--- a/tests/unit/admin/core/test_schema_varchar_lengths.py
+++ b/tests/unit/admin/core/test_schema_varchar_lengths.py
@@ -9,7 +9,6 @@ Uses pg_container fixture (real PostgreSQL) so VARCHAR constraints are enforced.
 from __future__ import annotations
 
 import pytest
-from sqlalchemy.exc import DataError
 
 from rock.admin.core.db_provider import DatabaseProvider
 from rock.admin.core.sandbox_table import SandboxTable
@@ -43,10 +42,13 @@ class TestImageVarcharLength:
     async def test_insert_long_image(self, db):
         """A 196-char image string must be accepted by the ORM schema."""
         sandbox_id = "varchar-img-001"
-        await db.create(sandbox_id, {
-            "image": _LONG_IMAGE,
-            "create_time": "2026-04-14T00:00:00Z",
-        })
+        await db.create(
+            sandbox_id,
+            {
+                "image": _LONG_IMAGE,
+                "create_time": "2026-04-14T00:00:00Z",
+            },
+        )
         record = await db.get(sandbox_id)
         assert record is not None
         assert record["image"] == _LONG_IMAGE

--- a/tests/unit/admin/core/test_statement_cache.py
+++ b/tests/unit/admin/core/test_statement_cache.py
@@ -47,19 +47,20 @@ class TestBatchGetAfterDDL:
         # 1. populate and query — warms prepared statement cache
         ids = [f"cache-{i:03d}" for i in range(10)]
         for sid in ids:
-            await table.create(sid, {
-                "image": "python:3.11",
-                "create_time": "2026-04-14T00:00:00Z",
-            })
+            await table.create(
+                sid,
+                {
+                    "image": "python:3.11",
+                    "create_time": "2026-04-14T00:00:00Z",
+                },
+            )
         records = await table.list_by_in("sandbox_id", ids)
         assert len(records) == 10
 
         # 2. external DDL — simulates hotfix applied while app is running
         raw = await asyncpg.connect(pg_url)
         try:
-            await raw.execute(
-                "ALTER TABLE sandbox_record ALTER COLUMN image TYPE VARCHAR(1024)"
-            )
+            await raw.execute("ALTER TABLE sandbox_record ALTER COLUMN image TYPE VARCHAR(1024)")
         finally:
             await raw.close()
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -93,7 +93,11 @@ async def _memory_sandbox_table():
 
 @pytest.fixture
 async def sandbox_manager(
-    rock_config: RockConfig, redis_provider: RedisProvider, ray_init_shutdown, ray_service, ray_operator,
+    rock_config: RockConfig,
+    redis_provider: RedisProvider,
+    ray_init_shutdown,
+    ray_service,
+    ray_operator,
     _memory_sandbox_table: SandboxTable,
 ):
     meta_store = SandboxMetaStore(redis_provider=redis_provider, sandbox_table=_memory_sandbox_table)
@@ -283,12 +287,15 @@ _REDIS_PORT = 6379
 
 def _docker_keep_containers() -> bool:
     import os
+
     return os.getenv("ROCK_TEST_KEEP_DOCKER_CONTAINERS", "").lower() in {"1", "true", "yes", "on"}
 
 
 def _docker_detect_network(client) -> str | None:
     import socket
+
     import docker
+
     hostname = socket.gethostname()
     try:
         current = client.containers.get(hostname)
@@ -324,6 +331,7 @@ def _docker_start_container(client, image, name, network_name, internal_port, **
 def pg_container():
     """Start a PostgreSQL 16 Docker container for the test session."""
     import uuid
+
     import docker
 
     client = docker.from_env()
@@ -344,6 +352,7 @@ def pg_container():
     try:
         # wait for readiness
         import time as _t
+
         deadline = _t.time() + 30
         while _t.time() < deadline:
             code, _ = container.exec_run(f"pg_isready -U {_PG_USER}")
@@ -364,8 +373,11 @@ def pg_container():
 
         host, port = _docker_resolve_host_port(container, network_name, _PG_PORT)
         yield {
-            "host": host, "port": port,
-            "user": _PG_USER, "password": _PG_PASSWORD, "database": _PG_DB,
+            "host": host,
+            "port": port,
+            "user": _PG_USER,
+            "password": _PG_PASSWORD,
+            "database": _PG_DB,
             "url": f"postgresql://{_PG_USER}:{_PG_PASSWORD}@{host}:{port}/{_PG_DB}",
         }
     finally:
@@ -380,6 +392,7 @@ def pg_container():
 def redis_container():
     """Start a Redis Stack Docker container (with RedisJSON) for the test session."""
     import uuid
+
     import docker
 
     client = docker.from_env()
@@ -394,6 +407,7 @@ def redis_container():
     )
     try:
         import time as _t
+
         deadline = _t.time() + 30
         while _t.time() < deadline:
             code, output = container.exec_run("redis-cli ping")

--- a/tests/unit/sandbox/operator/test_k8s_api_client.py
+++ b/tests/unit/sandbox/operator/test_k8s_api_client.py
@@ -6,7 +6,7 @@ Tests cover:
 - CRUD operations on K8s custom resources
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -118,9 +118,7 @@ class TestK8sApiClient:
         with patch("asyncio.to_thread", new_callable=AsyncMock) as mock_thread:
             mock_thread.return_value = {"updated": True}
 
-            result = await k8s_api_client.update_custom_object(
-                name="test-sandbox", body={"spec": {"new": "value"}}
-            )
+            result = await k8s_api_client.update_custom_object(name="test-sandbox", body={"spec": {"new": "value"}})
 
             assert result == {"updated": True}
             mock_thread.assert_awaited_once()
@@ -128,7 +126,7 @@ class TestK8sApiClient:
     @pytest.mark.asyncio
     async def test_start_initializes_informer(self, k8s_api_client):
         """Test start() initializes the SharedInformer."""
-        with patch.object(k8s_api_client._informer, 'start') as mock_start:
+        with patch.object(k8s_api_client._informer, "start") as mock_start:
             await k8s_api_client.start()
 
             assert k8s_api_client._initialized is True
@@ -140,7 +138,7 @@ class TestK8sApiClient:
 
         Multiple start() calls should only initialize watch once.
         """
-        with patch.object(k8s_api_client._informer, 'start') as mock_start:
+        with patch.object(k8s_api_client._informer, "start") as mock_start:
             await k8s_api_client.start()
             await k8s_api_client.start()
 
@@ -150,8 +148,10 @@ class TestK8sApiClient:
     @pytest.mark.asyncio
     async def test_stop_informer(self, k8s_api_client):
         """Test stop() stops the SharedInformer."""
-        with patch.object(k8s_api_client._informer, 'start') as mock_start, \
-             patch.object(k8s_api_client._informer, 'stop') as mock_stop:
+        with (
+            patch.object(k8s_api_client._informer, "start") as _mock_start,
+            patch.object(k8s_api_client._informer, "stop") as mock_stop,
+        ):
             await k8s_api_client.start()
             await k8s_api_client.stop()
 

--- a/tests/unit/sandbox/operator/test_k8s_operator.py
+++ b/tests/unit/sandbox/operator/test_k8s_operator.py
@@ -181,7 +181,7 @@ class TestK8sOperator:
     async def test_get_status_not_found_in_redis(self, k8s_operator, mock_provider, redis_provider):
         """Test get_status raises error when sandbox not found in Redis."""
         k8s_operator.set_redis_provider(redis_provider)
-        
+
         # Mock provider returns sandbox info
         mock_sandbox_info = {
             "sandbox_id": "test-sandbox",
@@ -191,7 +191,7 @@ class TestK8sOperator:
             "port_mapping": {},
         }
         mock_provider.get_status = AsyncMock(return_value=SandboxInfo(**mock_sandbox_info))
-        
+
         # Sandbox not in Redis (no data stored)
         with pytest.raises(Exception, match="Sandbox test-sandbox not found in Redis"):
             await k8s_operator.get_status("test-sandbox")

--- a/tests/unit/sandbox/operator/test_k8s_provider.py
+++ b/tests/unit/sandbox/operator/test_k8s_provider.py
@@ -4,9 +4,9 @@ import pytest
 
 from rock.config import K8sConfig, PoolConfig
 from rock.deployments.config import DockerDeploymentConfig
+from rock.deployments.constants import Port
 from rock.sandbox.operator.k8s.constants import K8sConstants
 from rock.sandbox.operator.k8s.provider import BatchSandboxProvider, ResourceMatchingPoolSelector
-from rock.deployments.constants import Port
 
 BASIC_TEMPLATES = {
     "default": {
@@ -270,10 +270,10 @@ class MockNacosProvider:
 
 class MockK8sApiClient:
     """Mock K8s API client for testing."""
-    
+
     def __init__(self, custom_object: dict = None):
         self._custom_object = custom_object
-    
+
     async def get_custom_object(self, name: str) -> dict:
         if self._custom_object is None:
             raise Exception(f"Sandbox '{name}' not found")
@@ -339,16 +339,12 @@ class TestGetSandboxRuntimeInfo:
         """Raise exception when sandbox is being deleted."""
         provider = make_provider()
         provider._initialized = True
-        
+
         # Mock K8s API to return a resource with deletionTimestamp
-        provider._k8s_api = MockK8sApiClient({
-            "metadata": {
-                "name": "test-sandbox",
-                "deletionTimestamp": "2024-01-01T00:00:00Z",
-                "annotations": {}
-            }
-        })
-        
+        provider._k8s_api = MockK8sApiClient(
+            {"metadata": {"name": "test-sandbox", "deletionTimestamp": "2024-01-01T00:00:00Z", "annotations": {}}}
+        )
+
         with pytest.raises(Exception, match="is being deleted"):
             await provider._get_sandbox_runtime_info("test-sandbox")
 
@@ -356,18 +352,20 @@ class TestGetSandboxRuntimeInfo:
         """Return runtime info when sandbox is active."""
         provider = make_provider()
         provider._initialized = True
-        
+
         # Mock K8s API to return a normal resource
-        provider._k8s_api = MockK8sApiClient({
-            "metadata": {
-                "name": "test-sandbox",
-                "annotations": {
-                    K8sConstants.ANNOTATION_ENDPOINTS: '["10.0.0.1"]',
-                    K8sConstants.ANNOTATION_PORTS: '{"proxy": 8000, "server": 8080, "ssh": 22}'
+        provider._k8s_api = MockK8sApiClient(
+            {
+                "metadata": {
+                    "name": "test-sandbox",
+                    "annotations": {
+                        K8sConstants.ANNOTATION_ENDPOINTS: '["10.0.0.1"]',
+                        K8sConstants.ANNOTATION_PORTS: '{"proxy": 8000, "server": 8080, "ssh": 22}',
+                    },
                 }
             }
-        })
-        
+        )
+
         host_ip, port_mapping, resource_version = await provider._get_sandbox_runtime_info("test-sandbox")
         assert host_ip == "10.0.0.1"
         assert port_mapping[Port.PROXY] == 8000
@@ -381,16 +379,18 @@ class TestGetSandboxRuntimeInfo:
         provider._initialized = True
 
         # Mock K8s API to return a resource with resourceVersion
-        provider._k8s_api = MockK8sApiClient({
-            "metadata": {
-                "name": "test-sandbox",
-                "resourceVersion": "12345",
-                "annotations": {
-                    K8sConstants.ANNOTATION_ENDPOINTS: '["10.0.0.1"]',
-                    K8sConstants.ANNOTATION_PORTS: '{"proxy": 8000, "server": 8080, "ssh": 22}'
+        provider._k8s_api = MockK8sApiClient(
+            {
+                "metadata": {
+                    "name": "test-sandbox",
+                    "resourceVersion": "12345",
+                    "annotations": {
+                        K8sConstants.ANNOTATION_ENDPOINTS: '["10.0.0.1"]',
+                        K8sConstants.ANNOTATION_PORTS: '{"proxy": 8000, "server": 8080, "ssh": 22}',
+                    },
                 }
             }
-        })
+        )
 
         host_ip, port_mapping, resource_version = await provider._get_sandbox_runtime_info("test-sandbox")
         assert host_ip == "10.0.0.1"

--- a/tests/unit/sandbox/test_proxy_enhancements.py
+++ b/tests/unit/sandbox/test_proxy_enhancements.py
@@ -16,19 +16,16 @@ from starlette.responses import JSONResponse
 from rock.actions.sandbox.response import State
 from rock.admin.core.db_provider import DatabaseProvider
 from rock.admin.core.sandbox_table import SandboxTable
-from rock.config import DatabaseConfig, RockConfig
-from rock.sandbox.sandbox_meta_store import SandboxMetaStore
-from rock.sandbox.service.sandbox_proxy_service import SandboxProxyService
-from rock.utils.providers.redis_provider import RedisProvider
-
-from rock.admin.proto.response import SandboxListResponse
 from rock.admin.entrypoints.sandbox_proxy_api import (
     sandbox_proxy_router,
     set_sandbox_proxy_service,
     vnc_websocket_proxy,
     websocket_proxy,
 )
+from rock.config import DatabaseConfig, RockConfig
+from rock.sandbox.sandbox_meta_store import SandboxMetaStore
 from rock.sandbox.service.sandbox_proxy_service import SandboxProxyService
+from rock.utils.providers.redis_provider import RedisProvider
 
 
 def _make_mock_websocket(query_string: str = "", headers: dict | None = None) -> MagicMock:
@@ -1127,4 +1124,3 @@ class TestBatchGetLegacyStates:
         result = await svc.batch_get_sandbox_status(["sb-exists", "sb-ghost"])
         assert len(result) == 1
         assert result[0].sandbox_id == "sb-exists"
-

--- a/tests/unit/sandbox/test_sandbox_meta_store.py
+++ b/tests/unit/sandbox/test_sandbox_meta_store.py
@@ -53,7 +53,6 @@ def repo(redis, db):
     return SandboxMetaStore(redis_provider=redis, sandbox_table=db)
 
 
-
 @pytest.fixture
 def repo_with_memory_db(redis, db_memory):
     return SandboxMetaStore(redis_provider=redis, sandbox_table=db_memory)
@@ -267,9 +266,15 @@ class TestIterAliveSandboxIds:
 
     async def test_iter_alive_sandbox_ids_works_with_sqlite_memory(self, repo_with_memory_db):
         """iter_alive_sandbox_ids() should work with sqlite in-memory DB + Redis fallback."""
-        await repo_with_memory_db.create("sbx-running", {**SANDBOX_INFO, "sandbox_id": "sbx-running", "state": State.RUNNING})
-        await repo_with_memory_db.create("sbx-pending", {**SANDBOX_INFO, "sandbox_id": "sbx-pending", "state": State.PENDING})
-        await repo_with_memory_db.create("sbx-stopped", {**SANDBOX_INFO, "sandbox_id": "sbx-stopped", "state": "stopped"})
+        await repo_with_memory_db.create(
+            "sbx-running", {**SANDBOX_INFO, "sandbox_id": "sbx-running", "state": State.RUNNING}
+        )
+        await repo_with_memory_db.create(
+            "sbx-pending", {**SANDBOX_INFO, "sandbox_id": "sbx-pending", "state": State.PENDING}
+        )
+        await repo_with_memory_db.create(
+            "sbx-stopped", {**SANDBOX_INFO, "sandbox_id": "sbx-stopped", "state": "stopped"}
+        )
         await asyncio.sleep(0.1)
 
         ids = {sid async for sid in repo_with_memory_db.iter_alive_sandbox_ids()}

--- a/tests/unit/sdk/model/test_proxy.py
+++ b/tests/unit/sdk/model/test_proxy.py
@@ -110,8 +110,9 @@ async def test_perform_llm_request_retry_on_whitelist():
     client_post_path = "rock.sdk.model.server.api.proxy.http_client.post"
 
     # Patch asyncio.sleep inside the retry module to avoid actual waiting
-    with patch(client_post_path, new_callable=AsyncMock) as mock_post, patch(
-        "rock.utils.retry.asyncio.sleep", return_value=None
+    with (
+        patch(client_post_path, new_callable=AsyncMock) as mock_post,
+        patch("rock.utils.retry.asyncio.sleep", return_value=None),
     ):
         # 1. Setup Failed Response (429)
         resp_429 = MagicMock(spec=Response)
@@ -163,8 +164,9 @@ async def test_perform_llm_request_network_timeout_retry():
     """
     client_post_path = "rock.sdk.model.server.api.proxy.http_client.post"
 
-    with patch(client_post_path, new_callable=AsyncMock) as mock_post, patch(
-        "rock.utils.retry.asyncio.sleep", return_value=None
+    with (
+        patch(client_post_path, new_callable=AsyncMock) as mock_post,
+        patch("rock.utils.retry.asyncio.sleep", return_value=None),
     ):
         resp_200 = MagicMock(spec=Response)
         resp_200.status_code = 200
@@ -315,8 +317,9 @@ async def test_perform_llm_request_respects_custom_retryable_codes():
 
     client_post_path = "rock.sdk.model.server.api.proxy.http_client.post"
 
-    with patch(client_post_path, new_callable=AsyncMock) as mock_post, patch(
-        "rock.utils.retry.asyncio.sleep", return_value=None
+    with (
+        patch(client_post_path, new_callable=AsyncMock) as mock_post,
+        patch("rock.utils.retry.asyncio.sleep", return_value=None),
     ):
         # 502 should retry (in custom list)
         resp_502 = MagicMock(spec=Response)
@@ -460,8 +463,9 @@ def test_metrics_monitor_uses_env_endpoint():
 
     custom_endpoint = "http://my-otel-collector:4318/v1/metrics"
 
-    with patch("rock.sdk.model.server.utils.MetricsMonitor") as mock_cls, patch.dict(
-        "os.environ", {"ROCK_METRICS_ENDPOINT": custom_endpoint}
+    with (
+        patch("rock.sdk.model.server.utils.MetricsMonitor") as mock_cls,
+        patch.dict("os.environ", {"ROCK_METRICS_ENDPOINT": custom_endpoint}),
     ):
         mock_monitor = MagicMock()
         mock_cls.create.return_value = mock_monitor
@@ -508,8 +512,9 @@ async def test_record_traj_reports_rt_and_count():
 
     mock_monitor = MagicMock()
 
-    with patch("rock.sdk.model.server.utils.MetricsMonitor") as mock_cls, patch.dict(
-        "os.environ", {"ROCK_SANDBOX_ID": "sandbox-test-001"}
+    with (
+        patch("rock.sdk.model.server.utils.MetricsMonitor") as mock_cls,
+        patch.dict("os.environ", {"ROCK_SANDBOX_ID": "sandbox-test-001"}),
     ):
         mock_cls.create.return_value = mock_monitor
         utils_module._metrics_monitor = None


### PR DESCRIPTION
closes #811

## Summary

- **Ruff compliance**: Run `ruff check --fix` + `ruff format` on the full codebase. 35 files reformatted; also fixes 1 unused-variable warning (F841) in tests.
- **i18n cleanup**: Translate all remaining Chinese comments/docstrings in `rock/` to English across 6 files.

Main contributors who missed `ruff format` in recent PRs: `zjc462490` (#794, #730, #778), `Generalwin` (#744, #743, #765), `dengwx2026` (#716, #695).

## Commits

1. `chore: apply ruff check --fix and ruff format across codebase`
2. `chore: translate all Chinese comments and docstrings to English in rock/`

## Test plan

- [ ] CI lint step passes (`ruff check` clean)
- [ ] No Chinese characters remain in `rock/` (`grep -rP "[\x{4e00}-\x{9fff}]" rock/` returns empty)
- [ ] Fast tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)