### PR TITLE
feat(job): auto-detect job type from YAML via strict model validation

### DIFF
--- a/examples/evaluation/claw_eval/run_claw_eval.py
+++ b/examples/evaluation/claw_eval/run_claw_eval.py
@@ -15,12 +15,12 @@ import sys
 from pathlib import Path
 
 from rock.sdk.job import Job
-from rock.sdk.job.config import BashJobConfig
+from rock.sdk.job.config import JobConfig
 
 
 async def main() -> None:
     config_path = sys.argv[1] if len(sys.argv) > 1 else "claw_eval_bashjob.yaml"
-    config = BashJobConfig.from_yaml(config_path)
+    config = JobConfig.from_yaml(config_path)
     result = await Job(config).run()
     print(f"Job completed: status={result.status}, trials={len(result.trial_results)}")
 

--- a/examples/evaluation/claw_eval/run_claw_eval.py
+++ b/examples/evaluation/claw_eval/run_claw_eval.py
@@ -14,8 +14,7 @@ import os
 import sys
 from pathlib import Path
 
-from rock.sdk.job import Job
-from rock.sdk.job.config import JobConfig
+from rock.sdk.job import Job, JobConfig
 
 
 async def main() -> None:

--- a/examples/harbor/harbor_demo.py
+++ b/examples/harbor/harbor_demo.py
@@ -29,8 +29,8 @@ import logging
 import os
 import sys
 
-from rock.sdk.bench import HarborJobConfig
 from rock.sdk.job import Job
+from rock.sdk.job.config import JobConfig
 
 _REQUIRED_ENV_VARS = [
     "OSS_ACCESS_KEY_ID",
@@ -66,7 +66,7 @@ def parse_args() -> argparse.Namespace:
 
 
 async def async_main(args: argparse.Namespace) -> None:
-    config = HarborJobConfig.from_yaml(args.config)
+    config = JobConfig.from_yaml(args.config)
 
     # Override task_names if specified via CLI
     if args.task and config.datasets:

--- a/examples/harbor/harbor_demo.py
+++ b/examples/harbor/harbor_demo.py
@@ -29,8 +29,7 @@ import logging
 import os
 import sys
 
-from rock.sdk.job import Job
-from rock.sdk.job.config import JobConfig
+from rock.sdk.job import Job, JobConfig
 
 _REQUIRED_ENV_VARS = [
     "OSS_ACCESS_KEY_ID",

--- a/rock/sdk/bench/models/job/config.py
+++ b/rock/sdk/bench/models/job/config.py
@@ -294,15 +294,6 @@ class HarborJobConfig(_BaseJobConfig):
             data["environment"] = harbor_env
         return yaml.dump(data, default_flow_style=False, allow_unicode=True)
 
-    @classmethod
-    def from_yaml(cls, path: str) -> HarborJobConfig:
-        """Load HarborJobConfig from a Harbor YAML config file."""
-        import yaml
-
-        with open(path) as f:
-            data = yaml.safe_load(f)
-        return cls(**data)
-
     def enable_oss_mirror(
         self,
         *,

--- a/rock/sdk/bench/models/job/config.py
+++ b/rock/sdk/bench/models/job/config.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from rock.sdk.bench.constants import USER_DEFINED_LOGS
 from rock.sdk.bench.models.metric.config import MetricConfig
@@ -174,6 +174,11 @@ class HarborJobConfig(_BaseJobConfig):
     and passed to ``harbor jobs start -c``.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
+    # ── experiment_id is required for HarborJob (overrides nullable base field) ──
+    experiment_id: str = Field(min_length=1)
+
     # ── Override environment to use RockEnvironmentConfig (adds harbor env fields) ──
     environment: RockEnvironmentConfig = Field(default_factory=RockEnvironmentConfig)
 
@@ -197,8 +202,6 @@ class HarborJobConfig(_BaseJobConfig):
     @model_validator(mode="after")
     def _sync_experiment_id(self):
         """Sync experiment_id: JobConfig -> environment -> oss_mirror."""
-        if not self.experiment_id:
-            raise ValueError("experiment_id must not be empty")
         env_exp = self.environment.experiment_id
         if env_exp is not None and env_exp != self.experiment_id:
             raise ValueError(

--- a/rock/sdk/job/config.py
+++ b/rock/sdk/job/config.py
@@ -10,7 +10,7 @@ Harbor's HarborJobConfig lives in rock.sdk.bench.models.job.config.
 from __future__ import annotations
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from rock.sdk.envhub import EnvironmentConfig
 
@@ -27,13 +27,57 @@ class JobConfig(BaseModel):
 
     @classmethod
     def from_yaml(cls, path: str) -> JobConfig:
+        """Load a job config from YAML.
+
+        When called on the base class (``JobConfig.from_yaml``), the job type is
+        auto-detected by trying each concrete subclass in order:
+
+        1. ``HarborJobConfig`` — tried first (requires ``experiment_id``)
+        2. ``BashJobConfig``   — tried second (all fields optional)
+
+        Both models use ``extra="forbid"``, so any field that belongs to the
+        other type causes a ``ValidationError`` and the attempt is skipped.
+        If both fail the combined ``ValidationError`` details are surfaced.
+
+        When called directly on a subclass (e.g. ``BashJobConfig.from_yaml``),
+        no auto-detection is performed.
+        """
         with open(path) as f:
             data = yaml.safe_load(f)
-        return cls(**data)
+
+        if cls is not JobConfig:
+            # Called as BashJobConfig.from_yaml() or HarborJobConfig.from_yaml() —
+            # respect the explicit class, skip auto-detection.
+            return cls(**data)
+
+        # Lazy import to avoid circular dependency:
+        # rock.sdk.bench.models.job.config → rock.sdk.job.config
+        from rock.sdk.bench.models.job.config import HarborJobConfig
+
+        harbor_error: ValidationError | None = None
+        bash_error: ValidationError | None = None
+
+        try:
+            return HarborJobConfig.model_validate(data)
+        except (ValidationError, ValueError) as exc:
+            harbor_error = exc
+
+        try:
+            return BashJobConfig.model_validate(data)
+        except (ValidationError, ValueError) as exc:
+            bash_error = exc
+
+        raise ValueError(
+            "YAML does not match any known job type.\n"
+            f"  As HarborJobConfig: {harbor_error}\n"
+            f"  As BashJobConfig:   {bash_error}"
+        )
 
 
 class BashJobConfig(JobConfig):
     """Config for a simple bash script job."""
+
+    model_config = ConfigDict(extra="forbid")
 
     script: str | None = None
     script_path: str | None = None

--- a/tests/unit/sdk/agent/test_jobconfig_experiment_id.py
+++ b/tests/unit/sdk/agent/test_jobconfig_experiment_id.py
@@ -18,7 +18,7 @@ class TestExperimentIdNotEmpty:
 
     def test_empty_string_experiment_id_raises(self):
         """experiment_id='' must raise ValidationError."""
-        with pytest.raises(ValidationError, match="experiment_id must not be empty"):
+        with pytest.raises(ValidationError, match="experiment_id"):
             HarborJobConfig(job_name="test", experiment_id="")
 
 

--- a/tests/unit/sdk/job/test_config.py
+++ b/tests/unit/sdk/job/test_config.py
@@ -525,3 +525,99 @@ class TestHarborJobConfigEffectiveTimeout:
         from rock.sdk.bench.constants import DEFAULT_WAIT_TIMEOUT
 
         assert cfg.timeout == int(DEFAULT_WAIT_TIMEOUT * 2.0)
+
+
+# ---------------------------------------------------------------------------
+# JobConfig.from_yaml — auto-detection
+# ---------------------------------------------------------------------------
+
+
+class TestJobConfigFromYamlAutoDetect:
+    """JobConfig.from_yaml dispatches to the correct subclass based on YAML content."""
+
+    def test_auto_detect_bash_by_script(self, tmp_path):
+        yaml_content = "script: echo hello\ntimeout: 60\n"
+        p = tmp_path / "cfg.yaml"
+        p.write_text(yaml_content)
+        cfg = JobConfig.from_yaml(str(p))
+        assert isinstance(cfg, BashJobConfig)
+        assert cfg.script == "echo hello"
+
+    def test_auto_detect_bash_by_script_path(self, tmp_path):
+        yaml_content = "script_path: run.sh\n"
+        p = tmp_path / "cfg.yaml"
+        p.write_text(yaml_content)
+        cfg = JobConfig.from_yaml(str(p))
+        assert isinstance(cfg, BashJobConfig)
+        assert cfg.script_path == "run.sh"
+
+    def test_auto_detect_harbor_by_agents(self, tmp_path):
+        yaml_content = "experiment_id: exp-1\nagents:\n  - name: my-agent\n"
+        p = tmp_path / "cfg.yaml"
+        p.write_text(yaml_content)
+        cfg = JobConfig.from_yaml(str(p))
+        assert isinstance(cfg, HarborJobConfig)
+        assert cfg.experiment_id == "exp-1"
+
+    def test_auto_detect_harbor_by_datasets(self, tmp_path):
+        yaml_content = "experiment_id: exp-2\n" "datasets:\n" "  - name: my-ds\n" "    path: /tmp/ds\n"
+        p = tmp_path / "cfg.yaml"
+        p.write_text(yaml_content)
+        cfg = JobConfig.from_yaml(str(p))
+        assert isinstance(cfg, HarborJobConfig)
+
+    def test_auto_detect_harbor_by_n_attempts(self, tmp_path):
+        yaml_content = "experiment_id: exp-3\nn_attempts: 5\n"
+        p = tmp_path / "cfg.yaml"
+        p.write_text(yaml_content)
+        cfg = JobConfig.from_yaml(str(p))
+        assert isinstance(cfg, HarborJobConfig)
+        assert cfg.n_attempts == 5
+
+    def test_auto_detect_harbor_by_debug_flag(self, tmp_path):
+        yaml_content = "experiment_id: exp-4\ndebug: true\n"
+        p = tmp_path / "cfg.yaml"
+        p.write_text(yaml_content)
+        cfg = JobConfig.from_yaml(str(p))
+        assert isinstance(cfg, HarborJobConfig)
+        assert cfg.debug is True
+
+    def test_raises_on_mixed_fields(self, tmp_path):
+        """YAML with fields from both job types fails validation against either model."""
+        yaml_content = "script: echo hi\nagents:\n  - name: a\nexperiment_id: exp\n"
+        p = tmp_path / "mixed.yaml"
+        p.write_text(yaml_content)
+        with pytest.raises(ValueError, match="does not match any known job type"):
+            JobConfig.from_yaml(str(p))
+
+    def test_base_only_yaml_falls_through_to_bash(self, tmp_path):
+        """YAML with only base fields (no harbor exclusive) falls through to BashJobConfig.
+
+        HarborJobConfig requires experiment_id, so it fails; BashJobConfig has all
+        optional fields and succeeds.
+        """
+        yaml_content = "job_name: my-job\ntimeout: 300\n"
+        p = tmp_path / "base_only.yaml"
+        p.write_text(yaml_content)
+        cfg = JobConfig.from_yaml(str(p))
+        assert isinstance(cfg, BashJobConfig)
+        assert cfg.job_name == "my-job"
+        assert cfg.timeout == 300
+
+    def test_bash_from_yaml_direct_still_works(self, tmp_path):
+        """BashJobConfig.from_yaml() continues to work regardless of auto-detect."""
+        yaml_content = "script: ls -la\ntimeout: 120\n"
+        p = tmp_path / "bash.yaml"
+        p.write_text(yaml_content)
+        cfg = BashJobConfig.from_yaml(str(p))
+        assert isinstance(cfg, BashJobConfig)
+        assert cfg.script == "ls -la"
+
+    def test_harbor_from_yaml_direct_still_works(self, tmp_path):
+        """HarborJobConfig.from_yaml() continues to work regardless of auto-detect."""
+        yaml_content = "experiment_id: exp-5\nn_attempts: 2\n"
+        p = tmp_path / "harbor.yaml"
+        p.write_text(yaml_content)
+        cfg = HarborJobConfig.from_yaml(str(p))
+        assert isinstance(cfg, HarborJobConfig)
+        assert cfg.n_attempts == 2


### PR DESCRIPTION
## Summary

- `JobConfig.from_yaml()` now acts as a universal entry point: tries `HarborJobConfig` first, then `BashJobConfig`; raises `ValueError` with combined details if both fail
- Both models gain `model_config = ConfigDict(extra="forbid")`, so each naturally rejects the other type's fields — no hand-rolled field-name heuristics needed
- `HarborJobConfig.experiment_id` is now a proper required field (`str`, `min_length=1`), replacing the manual `model_validator` empty-check that previously produced the "experiment_id must not be empty" error

## Usage after this change

```python
# Before — must know the type upfront
config = BashJobConfig.from_yaml("job.yaml")
config = HarborJobConfig.from_yaml("job.yaml")

# After — auto-detected
config = JobConfig.from_yaml("job.yaml")   # returns BashJobConfig or HarborJobConfig
```

Explicit subclass calls (`BashJobConfig.from_yaml`, `HarborJobConfig.from_yaml`) continue to work unchanged.

## Test plan

- [x] `test_auto_detect_bash_by_script` / `test_auto_detect_bash_by_script_path`
- [x] `test_auto_detect_harbor_by_agents` / `datasets` / `n_attempts` / `debug`
- [x] `test_raises_on_mixed_fields` — both validations fail → `ValueError`
- [x] `test_base_only_yaml_falls_through_to_bash` — Harbor fails (missing `experiment_id`), Bash succeeds
- [x] Direct subclass calls still work
- [x] `TestExperimentIdNotEmpty` — `None` and `""` both raise `ValidationError`

fixes #813

🤖 Generated with [Claude Code](https://claude.com/claude-code)