### PR TITLE
fix(job): remove redundant shebang and set -e from BashTrial.build()

### DIFF
--- a/rock/sdk/job/trial/bash.py
+++ b/rock/sdk/job/trial/bash.py
@@ -22,10 +22,7 @@ class BashTrial(AbstractTrial):
             self._config.script = Path(self._config.script_path).read_text()
 
     def build(self) -> str:
-        lines = ["#!/bin/bash", "set -e", ""]
-        if self._config.script:
-            lines.append(self._config.script)
-        return "\n".join(lines)
+        return self._config.script or ""
 
     async def collect(self, sandbox, output: str, exit_code: int) -> TrialResult:
         exception_info = None

--- a/tests/unit/sdk/job/test_trial_bash.py
+++ b/tests/unit/sdk/job/test_trial_bash.py
@@ -27,10 +27,12 @@ class TestBashTrialBuild:
     def test_build_basic_script(self):
         cfg = BashJobConfig(script="echo hello")
         trial = BashTrial(cfg)
-        out = trial.build()
-        assert "#!/bin/bash" in out
-        assert "set -e" in out
-        assert "echo hello" in out
+        assert trial.build() == "echo hello"
+
+    def test_build_empty_script(self):
+        cfg = BashJobConfig(script=None)
+        trial = BashTrial(cfg)
+        assert trial.build() == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `#!/bin/bash` in `BashTrial.build()` is dead code — the executor runs `bash {script_path}` directly, so the shebang is never interpreted
- `set -e` was silently injected without user control, causing unexpected script exits
- Simplify `build()` to `return self._config.script or ""`

## Test plan

- [x] Updated `TestBashTrialBuild` to assert script returned as-is
- [x] Added `test_build_empty_script` for `script=None` → `""`
- [x] All 10 unit tests pass

Closes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)