### PR TITLE
fix(job): JobConfig.experiment_id takes priority over environment.experiment_id (#821)

### DIFF
--- a/rock/sdk/job/config.py
+++ b/rock/sdk/job/config.py
@@ -10,9 +10,12 @@ Harbor's HarborJobConfig lives in rock.sdk.bench.models.job.config.
 from __future__ import annotations
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
+from rock.logger import init_logger
 from rock.sdk.envhub import EnvironmentConfig
+
+logger = init_logger(__name__)
 
 
 class JobConfig(BaseModel):
@@ -24,6 +27,23 @@ class JobConfig(BaseModel):
     experiment_id: str | None = None
     labels: dict[str, str] = Field(default_factory=dict)
     timeout: int = 7200
+
+    @model_validator(mode="after")
+    def _sync_experiment_id(self) -> JobConfig:
+        """When both experiment_id fields are set and differ, JobConfig.experiment_id takes priority."""
+        if (
+            self.experiment_id is not None
+            and self.environment.experiment_id is not None
+            and self.experiment_id != self.environment.experiment_id
+        ):
+            logger.warning(
+                "experiment_id conflict: JobConfig has '%s', environment has '%s'. "
+                "Using JobConfig.experiment_id and overriding environment.experiment_id.",
+                self.experiment_id,
+                self.environment.experiment_id,
+            )
+            self.environment.experiment_id = self.experiment_id
+        return self
 
     @classmethod
     def from_yaml(cls, path: str) -> JobConfig:

--- a/rock/sdk/job/trial/abstract.py
+++ b/rock/sdk/job/trial/abstract.py
@@ -44,12 +44,9 @@ class AbstractTrial(ABC):
 
         sb_exp = getattr(sandbox, "_experiment_id", None)
         if sb_exp is not None:
-            if self._config.experiment_id is not None and self._config.experiment_id != sb_exp:
-                raise ValueError(
-                    f"experiment_id mismatch: {type(self._config).__name__} has "
-                    f"'{self._config.experiment_id}', but sandbox returned '{sb_exp}'"
-                )
-            self._config.experiment_id = sb_exp
+            if self._config.experiment_id is None:
+                self._config.experiment_id = sb_exp
+            # If config already has experiment_id, it takes priority over sandbox's value.
 
     @abstractmethod
     async def setup(self, sandbox: Sandbox) -> None:

--- a/tests/unit/sdk/job/test_config.py
+++ b/tests/unit/sdk/job/test_config.py
@@ -71,6 +71,43 @@ class TestJobConfig:
 
         assert issubclass(JobConfig, BaseModel)
 
+    def test_experiment_id_overrides_environment_experiment_id(self):
+        """When both experiment_ids differ, JobConfig.experiment_id wins and a warning is logged."""
+        from unittest.mock import patch
+
+        import rock.sdk.job.config as job_config_module
+
+        env = EnvironmentConfig(experiment_id="default")
+        with patch.object(job_config_module.logger, "warning") as mock_warn:
+            cfg = JobConfig(experiment_id="claw-eval", environment=env)
+
+        assert cfg.environment.experiment_id == "claw-eval"
+        mock_warn.assert_called_once()
+        warn_msg = mock_warn.call_args[0][0]
+        assert "experiment_id" in warn_msg
+        assert "claw-eval" in str(mock_warn.call_args)
+
+    def test_environment_experiment_id_preserved_when_job_unset(self):
+        """When only environment.experiment_id is set, it is preserved unchanged."""
+        env = EnvironmentConfig(experiment_id="from-env")
+        cfg = JobConfig(environment=env)
+
+        assert cfg.environment.experiment_id == "from-env"
+        assert cfg.experiment_id is None
+
+    def test_no_warning_when_experiment_ids_match(self):
+        """When both experiment_ids are the same, no warning is emitted."""
+        from unittest.mock import patch
+
+        import rock.sdk.job.config as job_config_module
+
+        env = EnvironmentConfig(experiment_id="same-exp")
+        with patch.object(job_config_module.logger, "warning") as mock_warn:
+            cfg = JobConfig(experiment_id="same-exp", environment=env)
+
+        assert cfg.environment.experiment_id == "same-exp"
+        mock_warn.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # BashJobConfig

--- a/tests/unit/sdk/job/test_trial_bash.py
+++ b/tests/unit/sdk/job/test_trial_bash.py
@@ -138,17 +138,17 @@ class TestBashTrialOnSandboxReady:
         assert cfg.namespace == "sb-ns"
         assert cfg.experiment_id == "exp-1"
 
-    async def test_experiment_id_mismatch_raises(self):
-        import pytest
-
-        cfg = BashJobConfig(script="echo hi", experiment_id="exp-1")
+    async def test_experiment_id_config_takes_priority_over_sandbox(self):
+        """Config experiment_id overrides sandbox's different value — no error raised."""
+        cfg = BashJobConfig(script="echo hi", experiment_id="claw-eval")
         trial = BashTrial(cfg)
         sandbox = MagicMock()
         sandbox._namespace = None
-        sandbox._experiment_id = "exp-DIFFERENT"
+        sandbox._experiment_id = "default"
 
-        with pytest.raises(ValueError, match="experiment_id mismatch"):
-            await trial.on_sandbox_ready(sandbox)
+        await trial.on_sandbox_ready(sandbox)
+
+        assert cfg.experiment_id == "claw-eval"
 
     async def test_namespace_mismatch_raises(self):
         import pytest

--- a/tests/unit/sdk/job/test_trial_harbor.py
+++ b/tests/unit/sdk/job/test_trial_harbor.py
@@ -155,17 +155,17 @@ class TestHarborTrialOnSandboxReady:
 
         assert cfg.namespace == "sb-ns"
 
-    async def test_experiment_id_mismatch_raises(self):
-        import pytest
-
-        cfg = HarborJobConfig(experiment_id="exp-1")
+    async def test_experiment_id_config_takes_priority_over_sandbox(self):
+        """Config experiment_id overrides sandbox's different value — no error raised."""
+        cfg = HarborJobConfig(experiment_id="claw-eval")
         trial = HarborTrial(cfg)
         sandbox = MagicMock()
         sandbox._namespace = None
-        sandbox._experiment_id = "exp-DIFFERENT"
+        sandbox._experiment_id = "default"
 
-        with pytest.raises(ValueError, match="experiment_id mismatch"):
-            await trial.on_sandbox_ready(sandbox)
+        await trial.on_sandbox_ready(sandbox)
+
+        assert cfg.experiment_id == "claw-eval"
 
     async def test_namespace_mismatch_raises(self):
         import pytest


### PR DESCRIPTION
## Summary

- **`AbstractTrial.on_sandbox_ready`**: config `experiment_id` now wins over sandbox-returned value — no more `ValueError` on mismatch. Sandbox value is only used as a fallback when config has `None`.
- **`JobConfig`**: added `model_validator(mode='after')` that overwrites `environment.experiment_id` when `JobConfig.experiment_id` differs, logging a `WARNING` to make the override visible.
- Tests updated/added for both behaviors following TDD (red → green).

## Test Plan

- [x] `TestBashTrialOnSandboxReady::test_experiment_id_config_takes_priority_over_sandbox`
- [x] `TestHarborTrialOnSandboxReady::test_experiment_id_config_takes_priority_over_sandbox`
- [x] `TestJobConfig::test_experiment_id_overrides_environment_experiment_id`
- [x] `TestJobConfig::test_environment_experiment_id_preserved_when_job_unset`
- [x] `TestJobConfig::test_no_warning_when_experiment_ids_match`
- [x] Full fast test suite: 767 passed

fixes #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)