### PR TITLE
chore: bump version to 1.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 authors = [{ name = "chatos@alibaba" }]
 requires-python = "<4.0,>=3.10"
 name = "rl-rock"
-version = "1.5.1"
+version = "1.6.0"
 description = "ROCK-Reinforcement Open Construction Kit"
 readme = "README.md"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -4035,7 +4035,7 @@ wheels = [
 
 [[package]]
 name = "rl-rock"
-version = "1.5.1"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
closes #826

## Summary
- Bump `rl-rock` version from `1.5.1` to `1.6.0` in `pyproject.toml`
- Update `uv.lock` accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)