### PR TITLE
fix(cli): lazy import psutil in admin stop command

### DIFF
--- a/rock/cli/command/admin.py
+++ b/rock/cli/command/admin.py
@@ -2,8 +2,6 @@ import argparse
 import asyncio
 import subprocess
 
-import psutil
-
 from rock.cli.command.command import Command as CliCommand
 from rock.logger import init_logger
 
@@ -37,6 +35,11 @@ class AdminCommand(CliCommand):
 
     async def _admin_stop(self, args: argparse.Namespace):
         """Stop admin service"""
+        try:
+            import psutil
+        except ImportError:
+            raise ImportError("psutil is required for 'rock admin stop'. Install it with: pip install psutil")
+
         try:
             # Find admin processes
             admin_processes = []


### PR DESCRIPTION
fixes #830

## Summary
- Remove top-level `import psutil` from `rock/cli/command/admin.py`
- Move import inside `_admin_stop()` so it's only loaded when actually needed
- Add clear `ImportError` message guiding users to install psutil if missing

## Why
`psutil` is an admin-only dependency. SDK-only users don't install it, causing an `ImportError` on CLI import even when they never use `rock admin stop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)