### PR TITLE
fix(job): sync experiment_id to environment when environment.experiment_id is None

### DIFF
--- a/rock/sdk/job/config.py
+++ b/rock/sdk/job/config.py
@@ -32,18 +32,20 @@ class JobConfig(BaseModel):
 
     @model_validator(mode="after")
     def _sync_experiment_id(self) -> JobConfig:
-        """When both experiment_id fields are set and differ, JobConfig.experiment_id takes priority."""
-        if (
-            self.experiment_id is not None
-            and self.environment.experiment_id is not None
-            and self.experiment_id != self.environment.experiment_id
-        ):
-            logger.warning(
-                "experiment_id conflict: JobConfig has '%s', environment has '%s'. "
-                "Using JobConfig.experiment_id and overriding environment.experiment_id.",
-                self.experiment_id,
-                self.environment.experiment_id,
-            )
+        """Sync JobConfig.experiment_id down to environment.experiment_id.
+
+        - If only JobConfig.experiment_id is set, propagate it to environment silently.
+        - If both are set and differ, JobConfig.experiment_id wins and a warning is logged.
+        - If both are set and equal, or JobConfig.experiment_id is None, do nothing.
+        """
+        if self.experiment_id is not None:
+            if self.environment.experiment_id is not None and self.experiment_id != self.environment.experiment_id:
+                logger.warning(
+                    "experiment_id conflict: JobConfig has '%s', environment has '%s'. "
+                    "Using JobConfig.experiment_id and overriding environment.experiment_id.",
+                    self.experiment_id,
+                    self.environment.experiment_id,
+                )
             self.environment.experiment_id = self.experiment_id
         return self
 

--- a/tests/unit/sdk/job/test_config.py
+++ b/tests/unit/sdk/job/test_config.py
@@ -105,6 +105,19 @@ class TestJobConfig:
         assert cfg.environment.experiment_id == "same-exp"
         mock_warn.assert_not_called()
 
+    def test_experiment_id_synced_to_environment_when_env_is_none(self):
+        """When JobConfig.experiment_id is set and environment.experiment_id is None,
+        it should be synced down to environment without a warning."""
+        from unittest.mock import patch
+
+        import rock.sdk.job.config as job_config_module
+
+        with patch.object(job_config_module.logger, "warning") as mock_warn:
+            cfg = JobConfig(experiment_id="exp-sync")
+
+        assert cfg.environment.experiment_id == "exp-sync"
+        mock_warn.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # BashJobConfig


### PR DESCRIPTION
## Summary

- `JobConfig._sync_experiment_id` failed to propagate `experiment_id` to `environment` when `environment.experiment_id` was `None` — only conflicting (both-set-and-different) cases were handled
- Fix: restructure condition to always sync when `self.experiment_id is not None`, warning only on actual conflict
- Add regression test `test_experiment_id_synced_to_environment_when_env_is_none` in `TestJobConfig`

## Test plan

- [x] New test `TestJobConfig::test_experiment_id_synced_to_environment_when_env_is_none` covers the missing case (RED → GREEN confirmed)
- [x] All 70 existing tests in `test_config.py` + `test_jobconfig_experiment_id.py` pass

closes #834

🤖 Generated with [Claude Code](https://claude.com/claude-code)