### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/rock/admin/scheduler/tasks/container_cleanup_task.py
+++ b/rock/admin/scheduler/tasks/container_cleanup_task.py
@@ -29,6 +29,14 @@ class ContainerCleanupTask(BaseTask):
             interval_seconds=interval_seconds,
             idempotency=IdempotencyType.IDEMPOTENT,
         )
+        try:
+            max_age_hours = int(max_age_hours)
+        except (TypeError, ValueError):
+            raise ValueError("max_age_hours must be an integer")
+
+        if max_age_hours <= 0 or max_age_hours > 8760:
+            raise ValueError("max_age_hours must be between 1 and 8760")
+
         self.max_age_hours = max_age_hours
 
     @classmethod

--- a/rock/sdk/builder/provider/dockerfile_builder.py
+++ b/rock/sdk/builder/provider/dockerfile_builder.py
@@ -35,8 +35,13 @@ class DockerfileBuilder:
     @staticmethod
     async def build_terminal_bench(instance_record: dict[str, str], build_dir: str) -> str:
         os.makedirs(build_dir, exist_ok=True)
+        build_dir_resolved = os.path.abspath(build_dir)
         for file_name, content in instance_record["files"].items():
-            file_path = f"{build_dir}/{file_name}"
+            if os.path.isabs(file_name):
+                raise ValueError(f"Invalid file path: {file_name}")
+            file_path = os.path.abspath(os.path.join(build_dir_resolved, file_name))
+            if os.path.commonpath([build_dir_resolved, file_path]) != build_dir_resolved:
+                raise ValueError(f"Invalid file path: {file_name}")
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             with open(file_path, "w") as f:
                 f.write(content)


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `rock/sdk/builder/provider/dockerfile_builder.py:L36`

The `build_terminal_bench` method writes files using untrusted keys from `instance_record["files"]` directly into `f"{build_dir}/{file_name}"` without path normalization or boundary checks. An attacker can provide filenames like `../../../../etc/cron.d/pwn` to write outside `build_dir`, potentially overwriting arbitrary files on the host.

## Solution

Normalize and validate each target path before writing. Use `Path(build_dir) / file_name`, resolve it, and enforce that it remains within `build_dir` (e.g., `resolved_path.is_relative_to(build_dir_resolved)` in Python 3.9+ equivalent logic). Reject absolute paths and parent traversal (`..`) segments.

## Changes

- `rock/sdk/builder/provider/dockerfile_builder.py` (modified)
- `rock/admin/scheduler/tasks/container_cleanup_task.py` (modified)