### PR TITLE
 fix(uv-env): copy project to writable dir before install in container 

### DIFF
--- a/.rayignore
+++ b/.rayignore
@@ -1,0 +1,7 @@
+*.egg-info/
+.venv/
+.git/
+__pycache__/
+*.pyc
+.pytest_cache/
+.ruff_cache/

--- a/rock/rocklet/local_files/docker_run_with_uv.sh
+++ b/rock/rocklet/local_files/docker_run_with_uv.sh
@@ -32,13 +32,23 @@ if [ ! -f /etc/alpine-release ]; then
         UV_CMD=$HOME/.local/bin/uv
     fi
 
-    cd $PROJECT_ROOT
+    # Copy project to a writable directory (source mount is read-only)
+    # Use tar to exclude large unnecessary directories for faster copy
+    WRITABLE_PROJECT=/tmp/rock-build
+    mkdir -p $WRITABLE_PROJECT
+    tar -cf - --exclude='.venv' --exclude='.git' --exclude='__pycache__' \
+        --exclude='*.egg-info' --exclude='.pytest_cache' --exclude='.ruff_cache' \
+        -C $PROJECT_ROOT . | tar -xf - -C $WRITABLE_PROJECT
+    cd $WRITABLE_PROJECT
 
     # Create virtual environment
     $UV_CMD venv --python 3.11 /tmp/rocklet-venv
 
     # Install dependencies
-    $UV_CMD pip install --python /tmp/rocklet-venv/bin/python -e ".[rocklet]"
+    $UV_CMD pip install --python /tmp/rocklet-venv/bin/python ".[rocklet]"
+
+    # Clean up build directory to free disk space
+    rm -rf $WRITABLE_PROJECT
 
 
     mkdir -p /data/logs


### PR DESCRIPTION
The UvRuntimeEnv mounts the host project directory as read-only (:ro)
into the container. However, setuptools requires writing egg-info
metadata to the source directory during uv pip install, which fails
on a read-only filesystem. Fix by copying the project to a writable
temporary directory (/tmp/rock-build) before running the install.
Also add .rayignore to exclude .venv, .git, pycache and other
non-essential files from Ray working_dir uploads. Fixes #856