### PR TITLE
feat(datasets): add tasks subcommand with file task support and improved output

### DIFF
--- a/rock/cli/command/datasets.py
+++ b/rock/cli/command/datasets.py
@@ -13,12 +13,28 @@ from rock.sdk.envhub.datasets.client import DatasetClient
 logger = init_logger(__name__)
 
 
+def _non_negative_int(value: str) -> int:
+    ivalue = int(value)
+    if ivalue < 0:
+        raise argparse.ArgumentTypeError("must be >= 0")
+    return ivalue
+
+
+def _positive_int(value: str) -> int:
+    ivalue = int(value)
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError("must be >= 1")
+    return ivalue
+
+
 class DatasetsCommand(Command):
     name = "datasets"
 
     async def arun(self, args: argparse.Namespace) -> None:
         if args.datasets_command == "list":
             await self._list(args)
+        elif args.datasets_command == "tasks":
+            await self._tasks(args)
         elif args.datasets_command == "upload":
             await self._upload(args)
         else:
@@ -57,6 +73,31 @@ class DatasetsCommand(Command):
         print("-" * len(header))
         for ds in sorted(datasets, key=lambda d: (d.id, d.split)):
             print(f"{ds.id:<{col_id}}  {ds.split:<{col_split}}  {len(ds.task_ids):>6}")
+
+    async def _tasks(self, args: argparse.Namespace) -> None:
+        registry_info = self._build_oss_registry_info(args)
+        client = DatasetClient(registry_info)
+        spec = client.list_dataset_tasks(args.org, args.dataset, args.split)
+
+        if spec is None or not spec.task_ids:
+            print(f"No tasks found for dataset '{args.org}/{args.dataset}' split '{args.split}'.")
+            return
+
+        total = len(spec.task_ids)
+        start = args.offset
+        end = start + args.limit if args.limit is not None else None
+        shown_task_ids = spec.task_ids[start:end]
+
+        if not shown_task_ids:
+            print("No tasks found after applying offset/limit.")
+            return
+
+        limit_text = str(args.limit) if args.limit is not None else "all"
+        print(f"Dataset: {spec.id}")
+        print(f"Split: {spec.split}")
+        print(f"Total: {total}  Offset: {start}  Limit: {limit_text}  Shown: {len(shown_task_ids)}")
+        for task_id in shown_task_ids:
+            print(task_id)
 
     async def _upload(self, args: argparse.Namespace) -> None:
         local_dir = Path(args.dir)
@@ -99,6 +140,13 @@ class DatasetsCommand(Command):
         list_parser = datasets_subparsers.add_parser("list", help="List datasets in OSS registry")
         list_parser.add_argument("--org", help="Filter by organization")
         add_oss_args(list_parser)
+        tasks_parser = datasets_subparsers.add_parser("tasks", help="List task IDs under one dataset split")
+        tasks_parser.add_argument("--org", required=True, help="Organization name")
+        tasks_parser.add_argument("--dataset", required=True, help="Dataset name")
+        tasks_parser.add_argument("--split", default="test", help="Split name (default: test)")
+        tasks_parser.add_argument("--offset", type=_non_negative_int, default=0, help="Skip first N tasks")
+        tasks_parser.add_argument("--limit", type=_positive_int, default=None, help="Maximum number of tasks to show")
+        add_oss_args(tasks_parser)
 
         upload_parser = datasets_subparsers.add_parser("upload", help="Upload local task dirs to OSS")
         upload_parser.add_argument("--org", required=True, help="Organization name")

--- a/rock/cli/command/datasets.py
+++ b/rock/cli/command/datasets.py
@@ -93,9 +93,13 @@ class DatasetsCommand(Command):
             return
 
         limit_text = str(args.limit) if args.limit is not None else "all"
-        print(f"Dataset: {spec.id}")
-        print(f"Split: {spec.split}")
-        print(f"Total: {total}  Offset: {start}  Limit: {limit_text}  Shown: {len(shown_task_ids)}")
+
+        print()
+        print("=" * 80)
+        print(f"Dataset: {spec.id}  Split: {spec.split}  Total: {total}  Shown: {len(shown_task_ids)}")
+        print("=" * 80)
+        print("#Task name")
+        print("-" * 10)
         for task_id in shown_task_ids:
             print(task_id)
 

--- a/rock/sdk/envhub/datasets/client.py
+++ b/rock/sdk/envhub/datasets/client.py
@@ -11,6 +11,9 @@ class DatasetClient:
     def list_datasets(self, org: str | None = None) -> list[DatasetSpec]:
         return self._registry.list_datasets(org)
 
+    def list_dataset_tasks(self, organization: str, dataset: str, split: str = "test") -> DatasetSpec | None:
+        return self._registry.list_dataset_tasks(organization, dataset, split)
+
     def upload_dataset(
         self,
         source: LocalDatasetConfig,

--- a/rock/sdk/envhub/datasets/registry/base.py
+++ b/rock/sdk/envhub/datasets/registry/base.py
@@ -12,6 +12,11 @@ class BaseDatasetRegistry(ABC):
         ...
 
     @abstractmethod
+    def list_dataset_tasks(self, organization: str, dataset: str, split: str = "test") -> DatasetSpec | None:
+        """List task ids for one dataset split. Returns None if dataset/split has no tasks."""
+        ...
+
+    @abstractmethod
     def upload_dataset(
         self,
         source: LocalDatasetConfig,

--- a/rock/sdk/envhub/datasets/registry/oss.py
+++ b/rock/sdk/envhub/datasets/registry/oss.py
@@ -36,6 +36,40 @@ class OssDatasetRegistry(BaseDatasetRegistry):
     def _last_segment(prefix: str) -> str:
         return prefix.rstrip("/").rsplit("/", 1)[-1]
 
+    def _extract_tasks_from_split(self, bucket: oss2.Bucket, split_prefix: str) -> list[str]:
+        """Extract tasks from a split prefix, combining directory and file tasks.
+
+        Directory tasks: from prefix_list (e.g., "datasets/org/name/split/task-001/")
+        File tasks: from object_list (e.g., "datasets/org/name/split/task-001.json")
+
+        File tasks are stripped of their suffix (e.g., "task-001.json" -> "task-001").
+        Placeholder objects (key ending with "/") and nested objects are ignored.
+        """
+        result = bucket.list_objects_v2(prefix=split_prefix, delimiter="/", max_keys=1000)
+
+        # Directory tasks from prefix_list
+        dir_tasks = [self._last_segment(p) for p in result.prefix_list]
+
+        # File tasks from object_list: direct files under split, strip suffix
+        file_tasks = []
+        for obj in result.object_list:
+            key = obj.key
+            # Ignore directory placeholder objects (key ending with "/")
+            if key.endswith("/"):
+                continue
+            # Get the relative path from split_prefix
+            relative = key[len(split_prefix):]
+            # Only direct files (no nested paths with "/")
+            if "/" in relative:
+                continue
+            # Strip suffix (e.g., "task-001.json" -> "task-001")
+            name = relative.rsplit(".", 1)[0] if "." in relative else relative
+            file_tasks.append(name)
+
+        # Merge and dedupe with stable sort
+        all_tasks = sorted(set(dir_tasks + file_tasks))
+        return all_tasks
+
     def list_datasets(self, organization: str | None = None) -> list[DatasetSpec]:
         bucket = self._build_bucket()
         base = self._registry.oss_dataset_path or "datasets"
@@ -58,8 +92,7 @@ class OssDatasetRegistry(BaseDatasetRegistry):
                 for split_prefix in result2.prefix_list:
                     split = self._last_segment(split_prefix)
 
-                    result3 = bucket.list_objects_v2(prefix=split_prefix, delimiter="/", max_keys=1000)
-                    task_ids = [self._last_segment(p) for p in result3.prefix_list]
+                    task_ids = self._extract_tasks_from_split(bucket, split_prefix)
                     datasets.append(DatasetSpec(
                         id=f"{org}/{name}",
                         split=split,
@@ -71,8 +104,7 @@ class OssDatasetRegistry(BaseDatasetRegistry):
     def list_dataset_tasks(self, organization: str, dataset: str, split: str = "test") -> DatasetSpec | None:
         bucket = self._build_bucket()
         split_prefix = f"{self._build_prefix(organization, dataset, split)}/"
-        result = bucket.list_objects_v2(prefix=split_prefix, delimiter="/", max_keys=1000)
-        task_ids = sorted(self._last_segment(prefix) for prefix in result.prefix_list)
+        task_ids = self._extract_tasks_from_split(bucket, split_prefix)
 
         if not task_ids:
             return None

--- a/rock/sdk/envhub/datasets/registry/oss.py
+++ b/rock/sdk/envhub/datasets/registry/oss.py
@@ -68,6 +68,21 @@ class OssDatasetRegistry(BaseDatasetRegistry):
 
         return datasets
 
+    def list_dataset_tasks(self, organization: str, dataset: str, split: str = "test") -> DatasetSpec | None:
+        bucket = self._build_bucket()
+        split_prefix = f"{self._build_prefix(organization, dataset, split)}/"
+        result = bucket.list_objects_v2(prefix=split_prefix, delimiter="/", max_keys=1000)
+        task_ids = sorted(self._last_segment(prefix) for prefix in result.prefix_list)
+
+        if not task_ids:
+            return None
+
+        return DatasetSpec(
+            id=f"{organization}/{dataset}",
+            split=split,
+            task_ids=task_ids,
+        )
+
     def _task_exists(self, bucket: oss2.Bucket, task_prefix: str) -> bool:
         result = bucket.list_objects_v2(prefix=task_prefix, max_keys=1)
         return len(result.object_list) > 0

--- a/tests/unit/datasets/test_client.py
+++ b/tests/unit/datasets/test_client.py
@@ -31,3 +31,14 @@ def test_dataset_client_upload_delegates_to_registry(tmp_path):
 
     mock_up.assert_called_once_with(source, target, 2)
     assert result == expected
+
+
+def test_dataset_client_list_tasks_delegates_to_registry_with_default_split():
+    client = DatasetClient(make_registry_info())
+    expected = DatasetSpec(id="qwen/bench", split="test", task_ids=["task-001"])
+
+    with patch.object(client._registry, "list_dataset_tasks", return_value=expected) as mock_list_tasks:
+        result = client.list_dataset_tasks("qwen", "bench")
+
+    mock_list_tasks.assert_called_once_with("qwen", "bench", "test")
+    assert result == expected

--- a/tests/unit/datasets/test_datasets_command.py
+++ b/tests/unit/datasets/test_datasets_command.py
@@ -1,9 +1,12 @@
 import argparse
-from unittest.mock import patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from rock.cli.command.datasets import DatasetsCommand
+from rock.sdk.bench.models.job.config import OssRegistryInfo
+from rock.sdk.envhub.datasets.models import DatasetSpec
 
 
 def make_base_args(**kwargs):
@@ -16,10 +19,24 @@ def make_base_args(**kwargs):
         access_key_secret=None,
         region=None,
         org=None,
+        dataset=None,
+        split=None,
+        offset=0,
+        limit=None,
     )
     for k, v in kwargs.items():
         setattr(args, k, v)
     return args
+
+def make_registry_info():
+    return OssRegistryInfo(oss_bucket="b", oss_access_key_id="k", oss_access_key_secret="s")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="rock")
+    subparsers = parser.add_subparsers(dest="command")
+    asyncio.run(DatasetsCommand.add_parser_to(subparsers))
+    return parser
 
 
 def test_command_name():
@@ -76,3 +93,115 @@ def test_build_oss_registry_info_raises_when_bucket_missing():
 
         with pytest.raises(ValueError, match="bucket"):
             cmd._build_oss_registry_info(args)
+
+
+def test_tasks_parser_defaults_split_offset_limit():
+    parser = _build_parser()
+    ns = parser.parse_args(["datasets", "tasks", "--org", "qwen", "--dataset", "my-bench"])
+
+    assert ns.command == "datasets"
+    assert ns.datasets_command == "tasks"
+    assert ns.org == "qwen"
+    assert ns.dataset == "my-bench"
+    assert ns.split == "test"
+    assert ns.offset == 0
+    assert ns.limit is None
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["datasets", "tasks", "--dataset", "my-bench"],
+        ["datasets", "tasks", "--org", "qwen"],
+    ],
+)
+def test_tasks_parser_requires_org_and_dataset(argv):
+    parser = _build_parser()
+
+    with pytest.raises(SystemExit) as excinfo:
+        parser.parse_args(argv)
+
+    assert excinfo.value.code == 2
+
+
+def test_tasks_parser_rejects_negative_offset():
+    parser = _build_parser()
+
+    with pytest.raises(SystemExit) as excinfo:
+        parser.parse_args(["datasets", "tasks", "--org", "qwen", "--dataset", "my-bench", "--offset", "-1"])
+
+    assert excinfo.value.code == 2
+
+
+def test_tasks_parser_rejects_non_positive_limit():
+    parser = _build_parser()
+
+    with pytest.raises(SystemExit) as excinfo:
+        parser.parse_args(["datasets", "tasks", "--org", "qwen", "--dataset", "my-bench", "--limit", "0"])
+
+    assert excinfo.value.code == 2
+
+
+def test_arun_dispatches_tasks():
+    cmd = DatasetsCommand()
+    args = make_base_args(datasets_command="tasks", org="qwen", dataset="my-bench", split="test")
+
+    with patch.object(DatasetsCommand, "_tasks", new_callable=AsyncMock, create=True) as mock_tasks:
+        asyncio.run(cmd.arun(args))
+
+    mock_tasks.assert_awaited_once_with(args)
+
+
+def test_tasks_outputs_paginated_results(capsys):
+    cmd = DatasetsCommand()
+    args = make_base_args(
+        datasets_command="tasks",
+        org="qwen",
+        dataset="my-bench",
+        split="test",
+        offset=1,
+        limit=2,
+    )
+    mock_client = MagicMock()
+    mock_client.list_dataset_tasks.return_value = DatasetSpec(
+        id="qwen/my-bench",
+        split="test",
+        task_ids=["task-001", "task-002", "task-003"],
+    )
+
+    with patch.object(cmd, "_build_oss_registry_info", return_value=make_registry_info()):
+        with patch("rock.cli.command.datasets.DatasetClient", return_value=mock_client):
+            asyncio.run(cmd._tasks(args))
+
+    mock_client.list_dataset_tasks.assert_called_once_with("qwen", "my-bench", "test")
+    out = capsys.readouterr().out
+    assert "Dataset: qwen/my-bench" in out
+    assert "Split: test" in out
+    assert "task-002" in out
+    assert "task-003" in out
+    assert "task-001" not in out
+    assert "Total: 3" in out
+    assert "Offset: 1" in out
+    assert "Limit: 2" in out
+    assert "Shown: 2" in out
+
+
+def test_tasks_prints_no_tasks_message_when_not_found(capsys):
+    cmd = DatasetsCommand()
+    args = make_base_args(
+        datasets_command="tasks",
+        org="qwen",
+        dataset="my-bench",
+        split="test",
+        offset=0,
+        limit=None,
+    )
+    mock_client = MagicMock()
+    mock_client.list_dataset_tasks.return_value = None
+
+    with patch.object(cmd, "_build_oss_registry_info", return_value=make_registry_info()):
+        with patch("rock.cli.command.datasets.DatasetClient", return_value=mock_client):
+            asyncio.run(cmd._tasks(args))
+
+    out = capsys.readouterr().out
+    assert "No tasks found" in out

--- a/tests/unit/datasets/test_datasets_command.py
+++ b/tests/unit/datasets/test_datasets_command.py
@@ -181,9 +181,8 @@ def test_tasks_outputs_paginated_results(capsys):
     assert "task-003" in out
     assert "task-001" not in out
     assert "Total: 3" in out
-    assert "Offset: 1" in out
-    assert "Limit: 2" in out
     assert "Shown: 2" in out
+    assert "#Task name" in out
 
 
 def test_tasks_prints_no_tasks_message_when_not_found(capsys):

--- a/tests/unit/datasets/test_oss_registry.py
+++ b/tests/unit/datasets/test_oss_registry.py
@@ -79,6 +79,59 @@ def test_build_prefix_with_split():
     registry = OssDatasetRegistry(make_registry_info())
     assert registry._build_prefix("qwen", "my-bench", "train") == "datasets/qwen/my-bench/train"
 
+# ---------------------------------------------------------------------------
+# list_dataset_tasks tests
+# ---------------------------------------------------------------------------
+
+
+def test_list_dataset_tasks_uses_default_test_split_and_sorts_task_ids():
+    registry = OssDatasetRegistry(make_registry_info())
+    mock_bucket = MagicMock()
+    mock_bucket.list_objects_v2.return_value = make_list_result(prefixes=[
+        "datasets/qwen/my-bench/test/task-002/",
+        "datasets/qwen/my-bench/test/task-001/",
+    ])
+
+    with patch.object(registry, "_build_bucket", return_value=mock_bucket):
+        spec = registry.list_dataset_tasks("qwen", "my-bench")
+
+    assert spec is not None
+    assert spec.id == "qwen/my-bench"
+    assert spec.split == "test"
+    assert spec.task_ids == ["task-001", "task-002"]
+
+    first_call_kwargs = mock_bucket.list_objects_v2.call_args_list[0][1]
+    assert first_call_kwargs["prefix"] == "datasets/qwen/my-bench/test/"
+
+
+def test_list_dataset_tasks_supports_custom_split():
+    registry = OssDatasetRegistry(make_registry_info())
+    mock_bucket = MagicMock()
+    mock_bucket.list_objects_v2.return_value = make_list_result(prefixes=[
+        "datasets/qwen/my-bench/train/task-001/",
+    ])
+
+    with patch.object(registry, "_build_bucket", return_value=mock_bucket):
+        spec = registry.list_dataset_tasks("qwen", "my-bench", "train")
+
+    assert spec is not None
+    assert spec.split == "train"
+    assert spec.task_ids == ["task-001"]
+
+    first_call_kwargs = mock_bucket.list_objects_v2.call_args_list[0][1]
+    assert first_call_kwargs["prefix"] == "datasets/qwen/my-bench/train/"
+
+
+def test_list_dataset_tasks_returns_none_when_no_tasks_found():
+    registry = OssDatasetRegistry(make_registry_info())
+    mock_bucket = MagicMock()
+    mock_bucket.list_objects_v2.return_value = make_list_result(prefixes=[])
+
+    with patch.object(registry, "_build_bucket", return_value=mock_bucket):
+        spec = registry.list_dataset_tasks("qwen", "my-bench", "test")
+
+    assert spec is None
+
 
 # ---------------------------------------------------------------------------
 # upload_dataset tests

--- a/tests/unit/datasets/test_oss_registry.py
+++ b/tests/unit/datasets/test_oss_registry.py
@@ -58,6 +58,31 @@ def test_list_datasets_filter_by_org():
     assert first_call_kwargs["prefix"] == "datasets/qwen/"
     assert len(datasets) == 1
 
+def test_list_datasets_counts_directory_and_file_tasks():
+    registry = OssDatasetRegistry(make_registry_info())
+    mock_bucket = MagicMock()
+    mock_bucket.list_objects_v2.side_effect = [
+        make_list_result(prefixes=["datasets/qwen/"]),
+        make_list_result(prefixes=["datasets/qwen/my-bench/"]),
+        make_list_result(prefixes=["datasets/qwen/my-bench/train/"]),
+        make_list_result(
+            prefixes=["datasets/qwen/my-bench/train/task-dir/"],
+            objects=[
+                MagicMock(key="datasets/qwen/my-bench/train/task-file.json"),
+                MagicMock(key="datasets/qwen/my-bench/train/"),
+                MagicMock(key="datasets/qwen/my-bench/train/nested/task-ignored.json"),
+            ],
+        ),
+    ]
+
+    with patch.object(registry, "_build_bucket", return_value=mock_bucket):
+        datasets = registry.list_datasets()
+
+    assert len(datasets) == 1
+    assert datasets[0].id == "qwen/my-bench"
+    assert datasets[0].split == "train"
+    assert datasets[0].task_ids == ["task-dir", "task-file"]
+
 
 def test_list_datasets_empty_registry():
     registry = OssDatasetRegistry(make_registry_info())
@@ -120,6 +145,41 @@ def test_list_dataset_tasks_supports_custom_split():
 
     first_call_kwargs = mock_bucket.list_objects_v2.call_args_list[0][1]
     assert first_call_kwargs["prefix"] == "datasets/qwen/my-bench/train/"
+
+def test_list_dataset_tasks_includes_directory_and_file_tasks_with_suffix_stripped():
+    registry = OssDatasetRegistry(make_registry_info())
+    mock_bucket = MagicMock()
+    mock_bucket.list_objects_v2.return_value = make_list_result(
+        prefixes=["datasets/qwen/my-bench/test/task-002/"],
+        objects=[MagicMock(key="datasets/qwen/my-bench/test/task-001.json")],
+    )
+
+    with patch.object(registry, "_build_bucket", return_value=mock_bucket):
+        spec = registry.list_dataset_tasks("qwen", "my-bench", "test")
+
+    assert spec is not None
+    assert spec.id == "qwen/my-bench"
+    assert spec.split == "test"
+    assert spec.task_ids == ["task-001", "task-002"]
+
+
+def test_list_dataset_tasks_ignores_placeholder_and_nested_objects():
+    registry = OssDatasetRegistry(make_registry_info())
+    mock_bucket = MagicMock()
+    mock_bucket.list_objects_v2.return_value = make_list_result(
+        prefixes=[],
+        objects=[
+            MagicMock(key="datasets/qwen/my-bench/test/"),
+            MagicMock(key="datasets/qwen/my-bench/test/nested/task-002.json"),
+            MagicMock(key="datasets/qwen/my-bench/test/task-001.json"),
+        ],
+    )
+
+    with patch.object(registry, "_build_bucket", return_value=mock_bucket):
+        spec = registry.list_dataset_tasks("qwen", "my-bench", "test")
+
+    assert spec is not None
+    assert spec.task_ids == ["task-001"]
 
 
 def test_list_dataset_tasks_returns_none_when_no_tasks_found():


### PR DESCRIPTION
## Summary      
                                                                                                                                                    
  - Add `rock datasets tasks` CLI command to list task IDs under a dataset split                                                                    
  - Fix task listing to recognize both directory and file tasks                                                                                     
  - Improve output formatting with visual separation from logs                                                                                      
                                                                                                                                                    
  closes #874                                                                                                                                     
                                                                                                                                                    
  ## Changes                                                                                                                                        
                                                                                                                                                    
  ### CLI         
  - Add `rock datasets tasks` with `--org`, `--dataset`, `--split`, `--offset`, `--limit` args                                                      
  - Add separator lines and `#Task name` header for readable output                           
                                                                                                                                                    
  ### SDK                                                                                                                                           
  - Add `list_dataset_tasks` to `DatasetClient` and registry layers                                                                                 
  - Add `_extract_tasks_from_split` method to merge directory + file tasks                                                                          
  - Strip file suffix (e.g., `task-001.json` → `task-001`)                                                                                          
  - Ignore placeholder objects and nested paths                                                                                                     
                                                                                                                                                    
  ### Tests                                                                                                                                         
  - Unit tests for CLI command, client, and OSS registry                                                                                            
  - Tests for directory + file task merging scenarios                                                                                               
                                                                                                                                                    
  ## Test Plan                                                                                                                                      
                                                                                                                                                    
  - [x] `uv run pytest tests/unit/datasets/ -v` passes (15 tests)                                                                                   
                                                                                                                                                    
  ## Usage Example
                                                                                                                                                    
  ```bash         
  rock datasets tasks \                                                                                                                             
    --bucket my-bucket \
    --org my-org --dataset my-dataset --split train                                                                                                 
                                                                                                                                                    
  Output:                                                                                                                                           
                                                                                                                                                    
  ================================================================================                                                                  
  Dataset: my-org/my-dataset  Split: train  Total: 5  Shown: 5                                                                                      
  ================================================================================                                                                  
  #Task name                                                                                                                                        
  ----------                                                                                                                                        
  environment                                                                                                                                       
  instruction                                                                                                                                       
  solution                                                                                                                                          
  task                                                                                                                                              
  tests