### PR TITLE
fix(sdk): fix auto_clear_time conversion and wait_interval boundary #882

### DIFF
--- a/rock/sdk/sandbox/client.py
+++ b/rock/sdk/sandbox/client.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import math
 import mimetypes
 import os
 import time
@@ -169,8 +170,8 @@ class Sandbox(AbstractSandbox):
         data = {
             "image": self.config.image,
             "image_os": self.config.image_os,
-            "auto_clear_time": self.config.auto_clear_seconds / 60,
-            "auto_clear_time_minutes": self.config.auto_clear_seconds / 60,
+            "auto_clear_time": int(math.ceil(self.config.auto_clear_seconds / 60)),
+            "auto_clear_time_minutes": int(math.ceil(self.config.auto_clear_seconds / 60)),
             "startup_timeout": self.config.startup_timeout,
             "memory": self.config.memory,
             "cpus": self.config.cpus,
@@ -637,6 +638,7 @@ class Sandbox(AbstractSandbox):
                 tuple[bool, str]: (success status, message)
         """
         wait_interval = max(5, wait_interval)  # Minimum interval 5 seconds
+        wait_interval = min(self.config.auto_clear_seconds - 2, wait_interval)  # wait_interval < auto_clear_seconds
         check_alive_cmd = f"kill -0 {pid}"
         check_alive_timeout = min(wait_interval * 2, wait_timeout)  # Not greater than wait_timeout
 


### PR DESCRIPTION
## 改动功能点

- 修复 `auto_clear_time` 从秒转分钟时产生浮点数的问题，改为向上取整为整数
- 修复 `wait_for_process()` 中 `wait_interval` 可能大于 `auto_clear_seconds` 导致沙箱在轮询前被清除的问题

## 代码改动点

- `rock/sdk/sandbox/client.py`: 新增 `import math`
- `rock/sdk/sandbox/client.py:171-172`: `auto_clear_time` 和 `auto_clear_time_minutes` 从 `auto_clear_seconds / 60` 改为 `int(math.ceil(auto_clear_seconds / 60))`，确保传给服务端的值为整数分钟且向上取整
- `rock/sdk/sandbox/client.py:641`: 在 `wait_for_process()` 中增加 `wait_interval = min(self.config.auto_clear_seconds - 2, wait_interval)`，确保轮询间隔小于自动清理时间

## 关联 Issue

refs #882