### PR TITLE
feat(cli): add -v verbosity control and unify log level management

### DIFF
--- a/rock/cli/main.py
+++ b/rock/cli/main.py
@@ -19,6 +19,16 @@ from rock.logger import init_logger
 logger = init_logger("rock.cli")
 
 
+# ── Verbose level mapping ────────────────────────────────────────────
+_VERBOSE_LEVELS = [
+    logging.ERROR,    # 0: default
+    logging.WARNING,  # 1: -v
+    logging.INFO,     # 2: -vv
+    logging.DEBUG,    # 3: -vvv
+]
+_THIRD_PARTY_LOGGERS = ("httpx", "httpcore", "urllib3")
+
+
 def load_config_from_file(args):
     """Load valid configuration, command line arguments take precedence over configuration file"""
     # Load configuration file
@@ -81,16 +91,21 @@ Examples:
     )
 
     # Global parameters
-    parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose logging")
+    parser.add_argument(
+        "-v", "--verbose",
+        action="count",
+        default=0,
+        help="Increase verbosity (-v=WARNING, -vv=INFO, -vvv=DEBUG; default=ERROR)",
+    )
     parser.add_argument("--config", help="Path to config file (default: ./.rock/config.ini)")
     parser.add_argument("--base-url", help="ROCK server base URL (overrides config file)")
     parser.add_argument("--auth-token", help="ROCK authorization token (overrides config file)")
     parser.add_argument("--cluster", help="ROCK cluster (overrides config file)")
     parser.add_argument(
         "--httpx-log-level",
-        help="httpx log level (default: INFO, options: DEBUG, INFO, WARNING, ERROR)",
+        help="Override httpx/httpcore log level (overrides -v; options: DEBUG, INFO, WARNING, ERROR)",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
-        default="INFO",
+        default=None,
     )
 
     # extra-header parameter
@@ -119,9 +134,26 @@ def find_command(command: str, subclasses: list[type[Command]]) -> type | None:
 
 
 def config_log(args: argparse.Namespace):
-    """Configure logging"""
-    logging.getLogger("httpx").setLevel(getattr(logging, args.httpx_log_level))
-    logging.getLogger("httpcore").setLevel(getattr(logging, args.httpx_log_level))
+    """Configure logging based on -v verbosity and --httpx-log-level."""
+    idx = min(args.verbose, len(_VERBOSE_LEVELS) - 1)
+    level = _VERBOSE_LEVELS[idx]
+
+    # --httpx-log-level overrides the inferred level for third-party loggers
+    third_party_level = level
+    if args.httpx_log_level is not None:
+        third_party_level = getattr(logging, args.httpx_log_level)
+
+    # Apply to all rock.* loggers (each has its own handler + propagate=False)
+    for name, logger_obj in logging.Logger.manager.loggerDict.items():
+        if name == "rock" or name.startswith("rock."):
+            if isinstance(logger_obj, logging.Logger):
+                logger_obj.setLevel(level)
+                for handler in logger_obj.handlers:
+                    handler.setLevel(level)
+
+    # Apply to third-party loggers
+    for name in _THIRD_PARTY_LOGGERS:
+        logging.getLogger(name).setLevel(third_party_level)
 
 
 def main():
@@ -137,10 +169,11 @@ def main():
         parser.print_help()
         sys.exit(1)
 
+    # Configure logging before any business logic produces log output
+    config_log(args)
+
     # Load valid configuration (configuration file + command line arguments)
     load_config_from_file(args)
-
-    config_log(args)
 
     try:
         command = find_command(args.command, subclasses)

--- a/tests/unit/cli/test_config_log.py
+++ b/tests/unit/cli/test_config_log.py
@@ -1,0 +1,142 @@
+import argparse
+import logging
+
+import pytest
+
+from rock.cli.main import config_log
+
+
+def _make_args(verbose=0, httpx_log_level=None):
+    """Helper to create argparse.Namespace for config_log tests."""
+    return argparse.Namespace(verbose=verbose, httpx_log_level=httpx_log_level)
+
+
+@pytest.fixture(autouse=True)
+def _reset_log_levels():
+    """Reset logger levels before each test to avoid cross-test pollution."""
+    # Save original levels
+    loggers = ["rock", "rock.cli", "rock.sdk.job.executor", "httpx", "httpcore", "urllib3"]
+    saved = {name: logging.getLogger(name).level for name in loggers}
+    saved_handlers = {}
+    for name in loggers:
+        logger = logging.getLogger(name)
+        saved_handlers[name] = [(h, h.level) for h in logger.handlers]
+
+    yield
+
+    # Restore original levels
+    for name in loggers:
+        logger = logging.getLogger(name)
+        logger.setLevel(saved[name])
+        for handler, orig_level in saved_handlers[name]:
+            handler.setLevel(orig_level)
+
+
+class TestConfigLogVerbosity:
+    """Test -v count → unified log level mapping."""
+
+    def test_default_error(self):
+        config_log(_make_args(verbose=0))
+        assert logging.getLogger("rock").level == logging.ERROR
+
+    def test_v1_warning(self):
+        config_log(_make_args(verbose=1))
+        assert logging.getLogger("rock").level == logging.WARNING
+
+    def test_v2_info(self):
+        config_log(_make_args(verbose=2))
+        assert logging.getLogger("rock").level == logging.INFO
+
+    def test_v3_debug(self):
+        config_log(_make_args(verbose=3))
+        assert logging.getLogger("rock").level == logging.DEBUG
+
+    def test_overflow_clamped_to_debug(self):
+        config_log(_make_args(verbose=99))
+        assert logging.getLogger("rock").level == logging.DEBUG
+
+
+class TestConfigLogThirdParty:
+    """Test third-party logger levels follow -v by default."""
+
+    def test_third_party_follows_verbosity(self):
+        config_log(_make_args(verbose=2))
+        for name in ("httpx", "httpcore", "urllib3"):
+            assert logging.getLogger(name).level == logging.INFO
+
+    def test_third_party_default_error(self):
+        config_log(_make_args(verbose=0))
+        for name in ("httpx", "httpcore", "urllib3"):
+            assert logging.getLogger(name).level == logging.ERROR
+
+
+class TestConfigLogHttpxOverride:
+    """Test --httpx-log-level overrides -v inference for third-party only."""
+
+    def test_httpx_override_does_not_affect_rock(self):
+        config_log(_make_args(verbose=0, httpx_log_level="WARNING"))
+        assert logging.getLogger("rock").level == logging.ERROR
+        assert logging.getLogger("httpx").level == logging.WARNING
+
+    def test_httpx_override_with_v(self):
+        config_log(_make_args(verbose=2, httpx_log_level="WARNING"))
+        assert logging.getLogger("rock").level == logging.INFO
+        assert logging.getLogger("httpx").level == logging.WARNING
+
+    def test_httpx_log_level_none_uses_verbosity(self):
+        config_log(_make_args(verbose=2, httpx_log_level=None))
+        assert logging.getLogger("httpx").level == logging.INFO
+
+
+class TestConfigLogRockHandler:
+    """Test rock logger handler levels are also updated."""
+
+    def test_rock_handler_level_updated(self):
+        config_log(_make_args(verbose=3))
+        for handler in logging.getLogger("rock").handlers:
+            assert handler.level == logging.DEBUG
+
+
+class TestConfigLogChildLogger:
+    """Test rock.* child loggers with propagate=False are also updated."""
+
+    def test_child_logger_level_updated(self):
+        """Simulate init_logger behavior: child logger with own handler + propagate=False."""
+        child = logging.getLogger("rock.cli")
+        child.addHandler(logging.StreamHandler())
+        child.setLevel(logging.INFO)
+        child.propagate = False
+
+        config_log(_make_args(verbose=0))
+        assert child.level == logging.ERROR
+
+    def test_child_handler_level_updated(self):
+        """Child logger handler level should also be updated by config_log."""
+        child = logging.getLogger("rock.cli")
+        child.addHandler(logging.StreamHandler())
+        child.setLevel(logging.INFO)
+        child.propagate = False
+
+        config_log(_make_args(verbose=3))
+        for handler in child.handlers:
+            assert handler.level == logging.DEBUG
+
+    def test_deep_child_logger_updated(self):
+        """Deeply nested rock.* logger (e.g. rock.sdk.job.executor) is also updated."""
+        child = logging.getLogger("rock.sdk.job.executor")
+        child.addHandler(logging.StreamHandler())
+        child.setLevel(logging.INFO)
+        child.propagate = False
+
+        config_log(_make_args(verbose=2))
+        assert child.level == logging.INFO
+
+    def test_non_rock_logger_not_affected(self):
+        """Non-rock child loggers should NOT be changed by config_log."""
+        other = logging.getLogger("myapp.worker")
+        other.addHandler(logging.StreamHandler())
+        other.setLevel(logging.DEBUG)
+        other.propagate = False
+
+        config_log(_make_args(verbose=0))
+        assert other.level == logging.DEBUG  # unchanged


### PR DESCRIPTION
## Summary

Add `-v` count-based verbosity control to the rock CLI for unified log level management, and fix two bugs in `config_log()`.

## Changes

- **`-v` from dead code to functional**: Changed from `store_true` to `count` action with 4-level mapping (0=ERROR, -v=WARNING, -vv=INFO, -vvv=DEBUG)
- **`--httpx-log-level` as override**: Changed default from `"INFO"` to `None`; now acts as a high-priority override for third-party loggers only, without affecting rock loggers
- **Fix child logger propagation bug**: `config_log()` now iterates all `rock.*` loggers via `logging.Logger.manager.loggerDict` instead of only the `rock` parent logger — necessary because `init_logger()` sets `propagate=False` per child
- **Fix log timing issue**: Moved `config_log()` before `load_config_from_file()` to suppress premature WARNING output at default level

## Test Plan

- [x] 15 unit tests added in `tests/unit/cli/test_config_log.py`
  - 5 verbosity mapping tests (default/ERROR, -v/WARNING, -vv/INFO, -vvv/DEBUG, overflow clamp)
  - 2 third-party logger tests (follows verbosity, default ERROR)
  - 3 httpx override tests (doesn't affect rock, overrides with -v, None uses verbosity)
  - 1 rock handler level test
  - 4 child logger tests (level updated, handler updated, deep child, non-rock unaffected)
- [x] All existing CLI tests pass (48/49, 1 pre-existing pytest-asyncio failure)

## Known Limitation

Loggers created dynamically during `command().arun(args)` (e.g., `rock.sdk.job.executor`) still get the default INFO level from `init_logger()` since they don't exist when `config_log()` runs. This is a pre-existing issue that requires modifying `init_logger()` to respect the CLI-configured level, which is out of scope for this PR.

Closes #906