### PR TITLE
fix(metrics): read sandbox image from meta_store instead of in-memory dict

### DIFF
--- a/rock/sandbox/base_manager.py
+++ b/rock/sandbox/base_manager.py
@@ -36,7 +36,6 @@ class BaseManager:
         )
         self._report_interval = 10
         self._check_job_interval = 180
-        self._sandbox_meta = {}
         self._setup_scheduler()
         self.deployment_manager = DeploymentManager(rock_config, enable_runtime_auto_clear)
 
@@ -128,10 +127,10 @@ class BaseManager:
     async def _collect_sandbox_meta(self) -> tuple[int, dict[str, dict[str, str]]]:
         meta: dict = {}
         cnt = 0
-        async for sandbox_id in self._meta_store.iter_alive_sandbox_ids():
+        async for sandbox_info in self._meta_store.iter_alive_sandbox_info():
             cnt += 1
-            image = self._sandbox_meta.get(sandbox_id, {}).get("image", "default")
-            meta[sandbox_id] = {"image": image}
+            image = sandbox_info.get("image", "default")
+            meta[sandbox_info.get("sandbox_id")] = {"image": image}
         return cnt, meta
 
     def stop_monitoring(self):

--- a/rock/sandbox/sandbox_manager.py
+++ b/rock/sandbox/sandbox_manager.py
@@ -157,8 +157,6 @@ class SandboxManager(BaseManager):
             await asyncio.sleep(1)
         await self.get_status(sandbox_id)
 
-        self._sandbox_meta[sandbox_id] = {"image": docker_deployment_config.image}
-
         return SandboxStartResponse(
             sandbox_id=sandbox_id,
             host_name=await self._ray_service.async_ray_get(sandbox_actor.host_name.remote()),
@@ -181,10 +179,6 @@ class SandboxManager(BaseManager):
             logger.error(f"ray get actor, actor {sandbox_id} not exist", exc_info=e)
             await self._meta_store.archive(sandbox_id, sandbox_info)
             return
-        try:
-            self._sandbox_meta.pop(sandbox_id)
-        except KeyError:
-            logger.debug(f"{sandbox_id} key not found")
         logger.info(f"sandbox {sandbox_id} stopped")
         await self._meta_store.archive(sandbox_id, sandbox_info)
 

--- a/rock/sandbox/sandbox_meta_store.py
+++ b/rock/sandbox/sandbox_meta_store.py
@@ -139,6 +139,11 @@ class SandboxMetaStore:
             if sandbox_id:
                 yield sandbox_id
 
+    async def iter_alive_sandbox_info(self) -> AsyncIterator[SandboxInfo]:
+        """Yield active sandbox info from the DB."""
+        for sandbox_info in await self._db.list_by_in("state", _ACTIVE_STATES):
+            yield sandbox_info
+
     @monitor_metastore_operation
     async def batch_get(self, sandbox_ids: list[str]) -> list[SandboxInfo]:
         """Fetch sandbox info for multiple IDs from the DB. Missing IDs are omitted."""

--- a/tests/unit/sandbox/test_collect_sandbox_meta.py
+++ b/tests/unit/sandbox/test_collect_sandbox_meta.py
@@ -1,0 +1,77 @@
+"""RED-GREEN test: _collect_sandbox_meta must read image from meta_store.
+
+Before the fix, BaseManager._collect_sandbox_meta read image from the
+in-memory dict ``_sandbox_meta`` which was never populated by ``start_async``,
+so image was always "default".  After the fix it reads from meta_store.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from rock.actions.sandbox.response import State
+from rock.admin.core.sandbox_table import SandboxTable
+from rock.sandbox.sandbox_meta_store import SandboxMetaStore
+from rock.utils.providers.redis_provider import RedisProvider
+
+SANDBOX_ID = "sbx-image-001"
+EXPECTED_IMAGE = "python:3.11-slim"
+
+SANDBOX_INFO = {
+    "sandbox_id": SANDBOX_ID,
+    "image": EXPECTED_IMAGE,
+    "user_id": "u1",
+    "state": State.RUNNING,
+    "host_ip": "10.0.0.1",
+}
+
+
+@pytest.fixture
+def meta_store(redis_provider: RedisProvider, _memory_sandbox_table: SandboxTable):
+    return SandboxMetaStore(redis_provider=redis_provider, sandbox_table=_memory_sandbox_table)
+
+
+@pytest.fixture
+def base_manager(meta_store):
+    """Minimal BaseManager with real meta_store, everything else mocked."""
+    from rock.sandbox.base_manager import BaseManager
+
+    with patch.object(BaseManager, "__init__", lambda self, *a, **kw: None):
+        mgr = BaseManager.__new__(BaseManager)
+        mgr._meta_store = meta_store
+        mgr._sandbox_meta = {}  # old code needs this; proves empty dict → "default"
+        return mgr
+
+
+class TestCollectSandboxMeta:
+    async def test_image_read_from_meta_store(self, base_manager, meta_store):
+        """_collect_sandbox_meta should return the actual image stored in meta_store,
+        not 'default'.  This test fails on the old code (empty _sandbox_meta dict)."""
+        await meta_store.create(SANDBOX_ID, SANDBOX_INFO)
+
+        cnt, meta = await base_manager._collect_sandbox_meta()
+
+        assert cnt == 1
+        assert SANDBOX_ID in meta
+        assert meta[SANDBOX_ID]["image"] == EXPECTED_IMAGE
+
+    async def test_missing_image_falls_back_to_default(self, base_manager, meta_store):
+        """When sandbox_info has no image field, should fall back to 'default'."""
+        info_no_image = {
+            "sandbox_id": SANDBOX_ID,
+            "state": State.RUNNING,
+            "host_ip": "10.0.0.1",
+        }
+        await meta_store.create(SANDBOX_ID, info_no_image)
+
+        cnt, meta = await base_manager._collect_sandbox_meta()
+
+        assert cnt == 1
+        assert meta[SANDBOX_ID]["image"] == "default"
+
+    async def test_no_sandboxes_returns_empty(self, base_manager):
+        """No alive sandboxes should return zero count and empty dict."""
+        cnt, meta = await base_manager._collect_sandbox_meta()
+
+        assert cnt == 0
+        assert meta == {}


### PR DESCRIPTION
close #912 

- Replace `self._sandbox_meta` lookups in `_collect_sandbox_meta` with `self._meta_store.get()` calls to read the `image` field from Redis
- Remove the unused `_sandbox_meta` in-memory dict and all write/pop sites in `SandboxManager`