### PR TITLE
feat: add startup timing instrumentation for sandbox launch stages

### DIFF
--- a/rock/deployments/docker.py
+++ b/rock/deployments/docker.py
@@ -32,7 +32,7 @@ from rock.utils import (
     ENV_POOL,
     DockerUtil,
     ImageUtil,
-    Timer,
+    StageTimer,
     find_free_port,
     get_executor,
     release_port,
@@ -259,7 +259,7 @@ class DockerDeployment(AbstractDeployment):
         logger.info(f"Pulling image {self._config.image!r}")
 
         try:
-            with Timer(description=f"[{self._config.image}] Image pull"):
+            with StageTimer("startup_timing", f"[{self._container_name}] [{self._config.image}] Image pull", logger):
                 # Parse registry from image name
                 registry, _ = ImageUtil.parse_registry_and_others(self._config.image)
 
@@ -429,8 +429,9 @@ class DockerDeployment(AbstractDeployment):
 
     async def start(self):
         """Starts the runtime."""
-        if not self.sandbox_validator.check_availability():
-            raise Exception("Docker is not available")
+        with StageTimer("startup_timing", f"[{self._container_name}] Check availability", logger):
+            if not self.sandbox_validator.check_availability():
+                raise Exception("Docker is not available")
 
         storage_opt_supported = DockerUtil.detect_storage_opt_support()
         # Resolve effective rootfs quota: downgrade to None if storage-opt is not supported.
@@ -490,12 +491,14 @@ class DockerDeployment(AbstractDeployment):
 
         # Kata DinD: prepare disk image and add volume mount + env var
         if self._config.use_kata_runtime:
-            self._prepare_kata_disk()
+            with StageTimer("startup_timing", f"[{self._container_name}] Kata disk prepare", logger):
+                self._prepare_kata_disk()
             disk_path = self._get_kata_disk_image_path()
             volume_args.extend(["-v", f"{disk_path}:/docker-disk.img"])
             env_arg.extend(["-e", "ROCK_KATA_RUNTIME=true"])
 
-        time.sleep(random.randint(0, 5))
+        with StageTimer("startup_timing", f"[{self._container_name}] Random sleep", logger):
+            time.sleep(random.randint(0, 5))
         runtime_args = self._build_runtime_args()
         cmds = [
             "docker",
@@ -528,14 +531,15 @@ class DockerDeployment(AbstractDeployment):
         )
         logger.info(f"Command: {cmd_str!r}")
         # shell=True required for && etc.
-        with Timer(description=f"[{self._config.image}] Container start"):
+        with StageTimer("startup_timing", f"[{self._container_name}] Docker run", logger):
             self._container_process = await loop.run_in_executor(executor, self._docker_run, cmds)
-            await loop.run_in_executor(executor, self._hooks.on_custom_step, DeploymentHookStep.STARTING_RUNTIME)
-            logger.info(f"Starting runtime at {self._config.port}")
-            self._runtime = RemoteSandboxRuntime.from_config(
-                RemoteSandboxRuntimeConfig(port=self._config.port, timeout=self._runtime_timeout)
-            )
-            self._runtime.set_executor(executor)
+        await loop.run_in_executor(executor, self._hooks.on_custom_step, DeploymentHookStep.STARTING_RUNTIME)
+        logger.info(f"Starting runtime at {self._config.port}")
+        self._runtime = RemoteSandboxRuntime.from_config(
+            RemoteSandboxRuntimeConfig(port=self._config.port, timeout=self._runtime_timeout)
+        )
+        self._runtime.set_executor(executor)
+        with StageTimer("startup_timing", f"[{self._container_name}] Wait until alive", logger):
             await self._wait_until_alive(timeout=self._config.startup_timeout)
         if self._config.enable_auto_clear:
             self._check_stop_task = asyncio.create_task(self._check_stop())

--- a/rock/sandbox/sandbox_manager.py
+++ b/rock/sandbox/sandbox_manager.py
@@ -37,6 +37,7 @@ from rock.sandbox.sandbox_meta_store import SandboxMetaStore
 from rock.sandbox.service.sandbox_proxy_service import SandboxProxyService
 from rock.sandbox.utils.timeout import SandboxTimeoutHelper
 from rock.sdk.common.exceptions import BadRequestRockError, InternalServerRockError
+from rock.utils import StageTimer
 from rock.utils.crypto_utils import AESEncryption
 from rock.utils.format import convert_to_gb, parse_size_to_bytes
 from rock.utils.system import get_iso8601_timestamp
@@ -112,7 +113,8 @@ class SandboxManager(BaseManager):
     ) -> SandboxStartResponse:
         await self._check_sandbox_exists_in_redis(config)
         self.validate_sandbox_spec(self.rock_config.runtime, config)
-        docker_deployment_config: DockerDeploymentConfig = await self.deployment_manager.init_config(config)
+        with StageTimer("startup_timing", f"[{config.image}] Init config", logger):
+            docker_deployment_config: DockerDeploymentConfig = await self.deployment_manager.init_config(config)
 
         sandbox_id = docker_deployment_config.container_name
         if self.rock_config.runtime.use_standard_spec_only:
@@ -123,15 +125,17 @@ class SandboxManager(BaseManager):
             )
             docker_deployment_config.cpus = self.rock_config.runtime.standard_spec.cpus
             docker_deployment_config.memory = self.rock_config.runtime.standard_spec.memory
-        sandbox_info: SandboxInfo = await self._operator.submit(docker_deployment_config, user_info)
+        with StageTimer("startup_timing", f"[{sandbox_id}] Operator submit", logger):
+            sandbox_info: SandboxInfo = await self._operator.submit(docker_deployment_config, user_info)
         await self._build_sandbox_info_metadata(sandbox_info, user_info, cluster_info)
         timeout_info = SandboxTimeoutHelper.make_timeout_info(docker_deployment_config.auto_clear_time)
-        await self._meta_store.create(
-            sandbox_id,
-            sandbox_info,
-            timeout_info=timeout_info,
-            deployment_config=docker_deployment_config,
-        )
+        with StageTimer("startup_timing", f"[{sandbox_id}] Meta store create", logger):
+            await self._meta_store.create(
+                sandbox_id,
+                sandbox_info,
+                timeout_info=timeout_info,
+                deployment_config=docker_deployment_config,
+            )
         return SandboxStartResponse(
             sandbox_id=sandbox_id,
             host_name=sandbox_info.get("host_name"),
@@ -148,13 +152,15 @@ class SandboxManager(BaseManager):
 
         sandbox_actor: SandboxActor = await deployment.creator_actor(actor_name)
 
-        await self._ray_service.async_ray_get(sandbox_actor.start.remote())
+        with StageTimer("startup_timing", f"[{sandbox_id}] Actor start", logger):
+            await self._ray_service.async_ray_get(sandbox_actor.start.remote())
         logger.info(f"sandbox {sandbox_id} is started")
 
-        while not await self._is_actor_alive(sandbox_id):
-            logger.debug(f"wait actor for sandbox alive, sandbox_id: {sandbox_id}")
-            # TODO: timeout check
-            await asyncio.sleep(1)
+        with StageTimer("startup_timing", f"[{sandbox_id}] Wait actor alive", logger):
+            while not await self._is_actor_alive(sandbox_id):
+                logger.debug(f"wait actor for sandbox alive, sandbox_id: {sandbox_id}")
+                # TODO: timeout check
+                await asyncio.sleep(1)
         await self.get_status(sandbox_id)
 
         return SandboxStartResponse(

--- a/rock/utils/__init__.py
+++ b/rock/utils/__init__.py
@@ -1,6 +1,15 @@
 from contextvars import ContextVar
 
-from .concurrent_helper import AsyncAtomicInt, AsyncSafeDict, RayUtil, Timer, get_executor, run_until_complete, timeout
+from .concurrent_helper import (
+    AsyncAtomicInt,
+    AsyncSafeDict,
+    RayUtil,
+    StageTimer,
+    Timer,
+    get_executor,
+    run_until_complete,
+    timeout,
+)
 from .data import (
     FileUtil,
     ListUtil,
@@ -54,6 +63,7 @@ __all__ = [
     "get_uniagent_endpoint",
     # Concurrent utilities
     "get_executor",
+    "StageTimer",
     "Timer",
     "RayUtil",
     "AsyncSafeDict",

--- a/rock/utils/concurrent_helper.py
+++ b/rock/utils/concurrent_helper.py
@@ -97,6 +97,25 @@ class Timer:
         return False
 
 
+class StageTimer:
+    """Context manager that logs elapsed time for a named stage."""
+
+    def __init__(self, phase: str, description: str, logger):
+        self._phase = phase
+        self._description = description
+        self._logger = logger
+        self._start_time = 0.0
+
+    def __enter__(self):
+        self._start_time = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        duration = time.perf_counter() - self._start_time
+        self._logger.info(f"[{self._phase}] {self._description} took {duration:.3f} s")
+        return False
+
+
 class AsyncSafeDict(Generic[K, V]):
     """Thread-safe async dictionary"""
 

--- a/tests/unit/utils/test_stage_timer.py
+++ b/tests/unit/utils/test_stage_timer.py
@@ -1,0 +1,51 @@
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from rock.utils.concurrent_helper import StageTimer
+
+
+class TestStageTimer:
+    def test_logs_duration_on_exit(self, caplog):
+        with caplog.at_level(logging.INFO):
+            logger = logging.getLogger("test_stage_timer")
+            with StageTimer("startup_timing", "[sandbox-abc] Check availability", logger):
+                pass
+
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert "[startup_timing]" in record.message
+        assert "[sandbox-abc] Check availability" in record.message
+        assert "took" in record.message
+        assert "s" in record.message
+
+    @patch("rock.utils.concurrent_helper.time.perf_counter", side_effect=[100.0, 102.5])
+    def test_duration_calculation(self, mock_perf_counter, caplog):
+        with caplog.at_level(logging.INFO):
+            logger = logging.getLogger("test_stage_timer")
+            with StageTimer("startup_timing", "[sandbox-abc] Image pull", logger):
+                pass
+
+        assert "took 2.500 s" in caplog.records[0].message
+
+    def test_exception_still_logs(self, caplog):
+        with caplog.at_level(logging.INFO):
+            logger = logging.getLogger("test_stage_timer")
+            with pytest.raises(ValueError, match="boom"):
+                with StageTimer("startup_timing", "[sandbox-abc] Docker run", logger):
+                    raise ValueError("boom")
+
+        assert len(caplog.records) == 1
+        assert "[startup_timing]" in caplog.records[0].message
+        assert "[sandbox-abc] Docker run" in caplog.records[0].message
+
+    def test_log_format(self, caplog):
+        with caplog.at_level(logging.INFO):
+            logger = logging.getLogger("test_stage_timer")
+            with StageTimer("my_phase", "my description", logger):
+                pass
+
+        record = caplog.records[0]
+        assert record.message.startswith("[my_phase] my description took ")
+        assert record.message.endswith(" s")


### PR DESCRIPTION
## Summary                                                                                                                                                                   
  - Add `StageTimer` context manager utility for logging elapsed time per startup stage                                                                                        
  - Instrument `DockerDeployment.start()` with timing for: check availability, image pull, kata disk prepare, docker run, wait until alive                                     
  - Instrument `SandboxManager` with timing for: operator submit, meta store create                                                                                            
  - All stages emit `[startup_timing]` prefixed log lines for performance analysis                                                                                             
                                                                                                                                                                               
  fixes #923                                                                                                                                                                   
                                                                                                                                                                               
  ## Test plan                                                                                                                                                                 
  - [x] Unit tests for `StageTimer` added (`tests/unit/utils/test_stage_timer.py`)                                                                                                                                                
  - [x] Verify log output contains `[startup_timing]` markers during sandbox startup