### PR TITLE
feat(cli): add --async flag to `job run` for non-blocking submit

### DIFF
--- a/rock/cli/command/job.py
+++ b/rock/cli/command/job.py
@@ -92,8 +92,15 @@ class JobCommand(Command):
         self._apply_overrides(config, args)
 
         # ── 4. Run ────────────────────────────────────────────────────
+        job = Job(config)
+        if getattr(args, "async_mode", False):
+            await job.submit()
+            print(f"experiment_id: {config.experiment_id or ''}")
+            print(f"job_name: {config.job_name or ''}")
+            print(f"sandbox_ids: {','.join(job.sandbox_ids)}")
+            return
         try:
-            result = await Job(config).run()
+            result = await job.run()
             if result.trial_results:
                 for tr in result.trial_results:
                     output = getattr(tr, "raw_output", None) or ""
@@ -266,6 +273,12 @@ class JobCommand(Command):
             "--xrl-authorization",
             default=None,
             help="XRL authorization token",
+        )
+        run_parser.add_argument(
+            "--async",
+            dest="async_mode",
+            action="store_true",
+            help="Submit job and return immediately with job info (non-blocking).",
         )
 
         # Stash on the class so _job_run can call parser.error() with the right parser.

--- a/rock/sdk/job/api.py
+++ b/rock/sdk/job/api.py
@@ -51,6 +51,13 @@ class Job:
         """Non-blocking submit: operator generates trials, executor starts them."""
         self._job_client = await self._executor.submit(self._operator, self._config)
 
+    @property
+    def sandbox_ids(self) -> list[str]:
+        """Sandbox IDs of all submitted trials; empty before submit()."""
+        if not self._job_client:
+            return []
+        return [tc.sandbox.sandbox_id for tc in self._job_client.trials]
+
     async def wait(self) -> JobResult:
         """Wait for completion, build JobResult."""
         if not self._job_client:

--- a/tests/unit/cli/command/test_job.py
+++ b/tests/unit/cli/command/test_job.py
@@ -669,3 +669,120 @@ class TestHelpOutput:
         assert "flags mode" in out
         assert "--job_config" in out
         assert "--script" in out
+
+
+class TestAsyncFlag:
+    """--async submits the job and returns immediately without waiting."""
+
+    def _setup(self):
+        JobCommand._run_parser = None
+        top = argparse.ArgumentParser(prog="rock")
+        subparsers = top.add_subparsers(dest="command")
+        asyncio.run(JobCommand.add_parser_to(subparsers))
+        return top
+
+    def test_async_flag_parses_to_async_mode_true(self):
+        top = self._setup()
+        ns = top.parse_args(["job", "run", "--script", "run.sh", "--async"])
+        assert ns.async_mode is True
+
+    def test_async_mode_defaults_to_false(self):
+        top = self._setup()
+        ns = top.parse_args(["job", "run", "--script", "run.sh"])
+        assert ns.async_mode is False
+
+    def test_async_mode_calls_submit_not_run(self, monkeypatch):
+        """With --async, _job_run should call job.submit() and skip run()/wait()."""
+        calls = {"submit": 0, "run": 0, "wait": 0}
+
+        class FakeJob:
+            def __init__(self, cfg):
+                self._cfg = cfg
+
+            async def submit(self):
+                calls["submit"] += 1
+
+            async def run(self):
+                calls["run"] += 1
+
+            async def wait(self):
+                calls["wait"] += 1
+
+            @property
+            def sandbox_ids(self):
+                return ["sb-x"]
+
+        monkeypatch.setattr("rock.sdk.job.Job", FakeJob)
+
+        top = self._setup()
+        ns = top.parse_args(["job", "run", "--script", "run.sh", "--async"])
+        asyncio.run(JobCommand().arun(ns))
+
+        assert calls == {"submit": 1, "run": 0, "wait": 0}
+
+    def test_async_mode_prints_experiment_job_and_sandbox_ids(self, monkeypatch, capsys):
+        """Output must expose experiment_id, job_name and sandbox_ids after submit."""
+
+        class FakeJob:
+            def __init__(self, cfg):
+                self._cfg = cfg
+
+            async def submit(self):
+                pass
+
+            async def run(self):
+                raise AssertionError("run() should not be called in async mode")
+
+            @property
+            def sandbox_ids(self):
+                return ["sb-a", "sb-b"]
+
+        monkeypatch.setattr("rock.sdk.job.Job", FakeJob)
+
+        top = self._setup()
+        ns = top.parse_args(
+            [
+                "job",
+                "run",
+                "--script",
+                "run.sh",
+                "--async",
+            ]
+        )
+        # Set experiment_id and job_name via the parsed config path by mocking config after build
+        # Simpler: assert the three labels exist in stdout with actual values from config.
+        asyncio.run(JobCommand().arun(ns))
+
+        out = capsys.readouterr().out
+        assert "experiment_id:" in out
+        assert "job_name:" in out
+        assert "sandbox_ids: sb-a,sb-b" in out
+
+    def test_sync_mode_still_uses_run(self, monkeypatch):
+        """Regression: without --async, existing run() path stays intact."""
+        from unittest.mock import MagicMock
+
+        calls = {"submit": 0, "run": 0}
+
+        class FakeJob:
+            def __init__(self, cfg):
+                pass
+
+            async def submit(self):
+                calls["submit"] += 1
+
+            async def run(self):
+                calls["run"] += 1
+                r = MagicMock()
+                r.status = "COMPLETED"
+                r.trial_results = []
+                return r
+
+        monkeypatch.setattr("rock.sdk.job.Job", FakeJob)
+
+        top = self._setup()
+        ns = top.parse_args(["job", "run", "--script", "run.sh"])
+        asyncio.run(JobCommand().arun(ns))
+
+        assert calls["run"] == 1
+        assert calls["submit"] == 0

--- a/tests/unit/sdk/job/test_job.py
+++ b/tests/unit/sdk/job/test_job.py
@@ -90,6 +90,39 @@ class TestJobSubmitWait:
 
 
 # ---------------------------------------------------------------------------
+# sandbox_ids property
+# ---------------------------------------------------------------------------
+
+
+class TestJobSandboxIds:
+    async def test_sandbox_ids_empty_before_submit(self):
+        job = Job(BashJobConfig(script="echo hi", job_name="test"))
+        assert job.sandbox_ids == []
+
+    async def test_sandbox_ids_after_submit(self):
+        mock_sandbox = _make_mock_sandbox()
+        mock_sandbox.sandbox_id = "sb-one"
+        with patch("rock.sdk.job.executor.Sandbox", return_value=mock_sandbox):
+            job = Job(BashJobConfig(script="echo hi", job_name="test"))
+            await job.submit()
+
+        assert job.sandbox_ids == ["sb-one"]
+
+    async def test_sandbox_ids_multi_trials(self):
+        mocks = [_make_mock_sandbox() for _ in range(2)]
+        mocks[0].sandbox_id = "sb-a"
+        mocks[1].sandbox_id = "sb-b"
+        with patch("rock.sdk.job.executor.Sandbox", side_effect=mocks):
+            job = Job(
+                BashJobConfig(script="echo hi", job_name="test"),
+                operator=ScatterOperator(size=2),
+            )
+            await job.submit()
+
+        assert sorted(job.sandbox_ids) == ["sb-a", "sb-b"]
+
+
+# ---------------------------------------------------------------------------
 # cancel()
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Adds `--async` to `rock job run`. When set, the command calls
`Job.submit()` instead of `Job.run()` and prints `experiment_id`,
`job_name`, and `sandbox_ids` before returning. Sync mode is unchanged.

Also adds a read-only `Job.sandbox_ids` property (empty before submit).

closes #929 