### PR TITLE
fix(rocklet): mount loop disk to docker data-root instead of hardcode…

### DIFF
--- a/rock/rocklet/local_files/docker_run.sh
+++ b/rock/rocklet/local_files/docker_run.sh
@@ -30,11 +30,19 @@ is_nix() {
 
 # Kata DinD: set up loop device and mount disk image for Docker storage
 setup_kata_dind() {
-    mkdir -p /var/lib/docker
+    local docker_root="/var/lib/docker"
+    if [ -f /etc/docker/daemon.json ]; then
+        local custom_root
+        custom_root=$(grep -o '"data-root"[[:space:]]*:[[:space:]]*"[^"]*"' /etc/docker/daemon.json | sed 's/.*"data-root"[[:space:]]*:[[:space:]]*"\([^"]*\)"/\1/')
+        if [ -n "$custom_root" ]; then
+            docker_root="$custom_root"
+        fi
+    fi
+    mkdir -p "$docker_root"
     for i in $(seq 0 7); do
         mknod -m 660 /dev/loop$i b 7 $i 2>/dev/null || true
     done
-    mount -o loop /docker-disk.img /var/lib/docker
+    mount -o loop /docker-disk.img "$docker_root"
     mount -o remount,rw /sys/fs/cgroup
     mount -o remount,rw /proc/sys
 }


### PR DESCRIPTION
  ## Summary      

  - `setup_kata_dind` previously hardcoded the loop disk mount target to `/var/lib/docker`. When Docker is configured with a custom `data-root`, the mount directory and Docker's actual storage
   path diverge, causing the disk image to have no effect inside DinD containers.
  - Now reads `data-root` from `/etc/docker/daemon.json` if present and mounts the loop disk to that path; falls back to the default `/var/lib/docker` otherwise.                               
   
  Fixes #932                                                                                                                                                                                             
  ## Test plan
                                                                                                                                                                                                
  - [x] Verify default behavior is unchanged when no `data-root` is configured (mounts to `/var/lib/docker`)                                                                                    
  - [x] Verify loop disk is correctly mounted to the custom path (e.g. `/data/docker`) when `data-root` is set in `daemon.json`
  - [x] Verify graceful fallback when `/etc/docker/daemon.json` does not exist
 
   🤖 Generated with [Claude Code](https://claude.com/claude-code)