### PR TITLE
fix(sdk): mkdir target parent dir before wget in OSS upload path

### DIFF
--- a/rock/sdk/sandbox/client.py
+++ b/rock/sdk/sandbox/client.py
@@ -3,6 +3,7 @@ import logging
 import math
 import mimetypes
 import os
+import shlex
 import time
 import uuid
 import warnings
@@ -842,6 +843,15 @@ class Sandbox(AbstractSandbox):
         oss2.resumable_upload(self._oss_bucket, tmp_obj_name, file_path)
         url = self._oss_bucket.sign_url("GET", tmp_obj_name, 600, slash_safe=True)
         try:
+            # wget -O does not create missing parent dirs; mkdir -p first to
+            # match the multipart upload path (rocklet /upload mkdirs server-side).
+            parent_dir = str(Path(target_path).parent)
+            await self.arun(
+                cmd=f"mkdir -p {shlex.quote(parent_dir)}",
+                wait_timeout=10,
+                mode=RunMode.NORMAL,
+            )
+
             download_cmd = f"wget -c -O {target_path} '{url}'"
             await self.arun(cmd=download_cmd, wait_timeout=600, mode=RunMode.NOHUP)
             check_file_session = f"bash-{timestamp}"


### PR DESCRIPTION
## Summary

- `Sandbox._upload_via_oss` 现在会在 `wget` 之前 `mkdir -p` 目标文件的父目录
- 与 multipart 上传路径（rocklet `/upload`）的 server-side mkdir 行为对齐

## 背景

`Sandbox.upload_by_path` 当文件 ≥1 MB 且 `ROCK_OSS_ENABLE=true` 时走 OSS 路径：先把文件 PUT 到 OSS bucket，然后在沙箱里 `wget -O <target_path> <sign_url>` 拉下来。

`wget -O` **不会**自动创建缺失的父目录。如果 `target_path` 父目录不存在，wget 立刻 `No such file or directory` 失败。又因为这条路径用 `RunMode.NOHUP`，wget 的 exit code 不会传播回来，错误被吞，最终只能靠后面的 `test -f <target>` 兜底返回 `success=False`，错误信息模糊。

multipart 上传路径（POST 到 rocklet `/upload`）的服务端 handler 会自己 mkdir，所以这个 bug **只影响 OSS 路径**。

## 修法

`wget` 之前先 `mkdir -p $(dirname target_path)`，使用 `shlex.quote` 防止路径含空格/特殊字符时出问题。

## Test plan

- [x] `uv run ruff check rock/sdk/sandbox/client.py` 通过
- [x] `uv run ruff format --check rock/sdk/sandbox/client.py` 通过
- [ ] 手动验证：在 `ROCK_OSS_ENABLE=true` 下上传 ≥1 MB 文件到不存在的父目录，`resp.success == True`，沙箱里 `command.log` 显示 mkdir 在 wget 之前

## 已知关联问题（不一起修）

`_upload_via_oss` 用 `RunMode.NOHUP` 起 wget，nohup 不传播被 fork 命令的 exit code。任何 wget 失败原因（网络、签名过期、磁盘满等）都被吞掉，错误信息模糊。功能正确（最终还是 `success=False`），但诊断慢。这个独立 issue 后续单独修，避免 review focus 跑偏。

fixes #939

🤖 Generated with [Claude Code](https://claude.com/claude-code)