### PR TITLE
fix(rocklet): use cgroup metrics for container CPU instead of psutil (#945)

### DIFF
--- a/rock/rocklet/linux.py
+++ b/rock/rocklet/linux.py
@@ -34,6 +34,7 @@ from rock.rocklet.exceptions import (
     SessionNotInitializedError,
 )
 from rock.utils import get_executor
+from rock.utils.cgroup_stats import cpu_percent as cgroup_cpu_percent
 
 from .rocklet import Rocklet, Session
 
@@ -347,7 +348,7 @@ class LinuxRocklet(Rocklet):
 
     async def get_statistics(self) -> dict:
         return {
-            "cpu": psutil.cpu_percent(),
+            "cpu": cgroup_cpu_percent(),
             "mem": psutil.virtual_memory().percent,
             "disk": psutil.disk_usage("/").percent,
             "net": psutil.net_io_counters().bytes_recv + psutil.net_io_counters().bytes_sent,

--- a/rock/rocklet/linux.py
+++ b/rock/rocklet/linux.py
@@ -34,7 +34,7 @@ from rock.rocklet.exceptions import (
     SessionNotInitializedError,
 )
 from rock.utils import get_executor
-from rock.utils.cgroup_stats import cpu_percent as cgroup_cpu_percent
+from rock.utils.cgroup_stats import CgroupCpuStats
 
 from .rocklet import Rocklet, Session
 
@@ -343,12 +343,16 @@ class BashSession(Session):
 class LinuxRocklet(Rocklet):
     """Rocklet implementation for sys.platform in {'linux', 'darwin'}."""
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._cgroup_cpu = CgroupCpuStats()
+
     def _build_bash_session(self, request: CreateBashSessionRequest) -> Session:
         return BashSession(request)
 
     async def get_statistics(self) -> dict:
         return {
-            "cpu": cgroup_cpu_percent(),
+            "cpu": self._cgroup_cpu.cpu_percent(),
             "mem": psutil.virtual_memory().percent,
             "disk": psutil.disk_usage("/").percent,
             "net": psutil.net_io_counters().bytes_recv + psutil.net_io_counters().bytes_sent,

--- a/rock/utils/cgroup_stats.py
+++ b/rock/utils/cgroup_stats.py
@@ -5,16 +5,16 @@ outside a container or on non-Linux platforms).
 """
 
 import os
-import threading
 import time
 from pathlib import Path
 
 import psutil
 
-_last_cpu_usage: dict[int, int] = {}
-_last_cpu_time: dict[int, int] = {}
+_last_cpu_usage: int | None = None
+_last_cpu_time: int | None = None
 
 _cgroup_version: int | None = None
+_cpu_quota: float | None = None
 
 
 def _detect_cgroup_version() -> int:
@@ -53,27 +53,37 @@ def _read_cpu_usage_ns() -> int | None:
 
 
 def _read_cpu_quota() -> float:
+    global _cpu_quota
+    if _cpu_quota is not None:
+        return _cpu_quota
+
     try:
         ver = _detect_cgroup_version()
         if ver == 2:
             text = Path("/sys/fs/cgroup/cpu.max").read_text().strip()
             parts = text.split()
             if parts[0] == "max":
-                return float(os.cpu_count() or 1)
+                _cpu_quota = float(os.cpu_count() or 1)
+                return _cpu_quota
             quota = int(parts[0])
             period = int(parts[1])
             if quota <= 0 or period <= 0:
-                return float(os.cpu_count() or 1)
-            return quota / period
+                _cpu_quota = float(os.cpu_count() or 1)
+                return _cpu_quota
+            _cpu_quota = quota / period
+            return _cpu_quota
         elif ver == 1:
             quota = int(Path("/sys/fs/cgroup/cpu/cpu.cfs_quota_us").read_text().strip())
             period = int(Path("/sys/fs/cgroup/cpu/cpu.cfs_period_us").read_text().strip())
             if quota <= 0 or period <= 0:
-                return float(os.cpu_count() or 1)
-            return quota / period
+                _cpu_quota = float(os.cpu_count() or 1)
+                return _cpu_quota
+            _cpu_quota = quota / period
+            return _cpu_quota
     except Exception:
         pass
-    return float(os.cpu_count() or 1)
+    _cpu_quota = float(os.cpu_count() or 1)
+    return _cpu_quota
 
 
 def cpu_percent() -> float:
@@ -82,17 +92,18 @@ def cpu_percent() -> float:
     First call returns 0.0 (no baseline). Falls back to psutil if cgroup
     files are unavailable.
     """
-    tid = threading.current_thread().ident
+    global _last_cpu_usage, _last_cpu_time
+
     usage_ns = _read_cpu_usage_ns()
     now_ns = time.monotonic_ns()
 
     if usage_ns is None:
         return psutil.cpu_percent()
 
-    prev_usage = _last_cpu_usage.get(tid)
-    prev_time = _last_cpu_time.get(tid)
-    _last_cpu_usage[tid] = usage_ns
-    _last_cpu_time[tid] = now_ns
+    prev_usage = _last_cpu_usage
+    prev_time = _last_cpu_time
+    _last_cpu_usage = usage_ns
+    _last_cpu_time = now_ns
 
     if prev_usage is None or prev_time is None:
         return 0.0

--- a/rock/utils/cgroup_stats.py
+++ b/rock/utils/cgroup_stats.py
@@ -1,0 +1,106 @@
+"""Container-aware CPU metrics via cgroup v1/v2.
+
+Falls back to psutil when cgroup files are unavailable (e.g. running
+outside a container or on non-Linux platforms).
+"""
+
+import os
+import threading
+import time
+from pathlib import Path
+
+import psutil
+
+_last_cpu_usage: dict[int, int] = {}
+_last_cpu_time: dict[int, int] = {}
+
+_cgroup_version: int | None = None
+
+
+def _detect_cgroup_version() -> int:
+    global _cgroup_version
+    if _cgroup_version is not None:
+        return _cgroup_version
+
+    if Path("/sys/fs/cgroup/cgroup.controllers").exists():
+        _cgroup_version = 2
+    elif Path("/sys/fs/cgroup/cpu/cpuacct.usage").exists() or Path("/sys/fs/cgroup/cpuacct/cpuacct.usage").exists():
+        _cgroup_version = 1
+    else:
+        _cgroup_version = 0
+
+    return _cgroup_version
+
+
+def _read_cpu_usage_ns() -> int | None:
+    try:
+        ver = _detect_cgroup_version()
+        if ver == 2:
+            text = Path("/sys/fs/cgroup/cpu.stat").read_text()
+            for line in text.splitlines():
+                if line.startswith("usage_usec"):
+                    return int(line.split()[1]) * 1000
+            return None
+        elif ver == 1:
+            for path in ("/sys/fs/cgroup/cpu/cpuacct.usage", "/sys/fs/cgroup/cpuacct/cpuacct.usage"):
+                p = Path(path)
+                if p.exists():
+                    return int(p.read_text().strip())
+            return None
+        return None
+    except Exception:
+        return None
+
+
+def _read_cpu_quota() -> float:
+    try:
+        ver = _detect_cgroup_version()
+        if ver == 2:
+            text = Path("/sys/fs/cgroup/cpu.max").read_text().strip()
+            parts = text.split()
+            if parts[0] == "max":
+                return float(os.cpu_count() or 1)
+            quota = int(parts[0])
+            period = int(parts[1])
+            if quota <= 0 or period <= 0:
+                return float(os.cpu_count() or 1)
+            return quota / period
+        elif ver == 1:
+            quota = int(Path("/sys/fs/cgroup/cpu/cpu.cfs_quota_us").read_text().strip())
+            period = int(Path("/sys/fs/cgroup/cpu/cpu.cfs_period_us").read_text().strip())
+            if quota <= 0 or period <= 0:
+                return float(os.cpu_count() or 1)
+            return quota / period
+    except Exception:
+        pass
+    return float(os.cpu_count() or 1)
+
+
+def cpu_percent() -> float:
+    """Return container CPU utilization % since last call.
+
+    First call returns 0.0 (no baseline). Falls back to psutil if cgroup
+    files are unavailable.
+    """
+    tid = threading.current_thread().ident
+    usage_ns = _read_cpu_usage_ns()
+    now_ns = time.monotonic_ns()
+
+    if usage_ns is None:
+        return psutil.cpu_percent()
+
+    prev_usage = _last_cpu_usage.get(tid)
+    prev_time = _last_cpu_time.get(tid)
+    _last_cpu_usage[tid] = usage_ns
+    _last_cpu_time[tid] = now_ns
+
+    if prev_usage is None or prev_time is None:
+        return 0.0
+
+    delta_usage = usage_ns - prev_usage
+    delta_time = now_ns - prev_time
+    if delta_time <= 0 or delta_usage < 0:
+        return 0.0
+
+    num_cpus = _read_cpu_quota()
+    return min(round((delta_usage / delta_time) / num_cpus * 100, 1), 100.0)

--- a/rock/utils/cgroup_stats.py
+++ b/rock/utils/cgroup_stats.py
@@ -10,108 +10,104 @@ from pathlib import Path
 
 import psutil
 
-_last_cpu_usage: int | None = None
-_last_cpu_time: int | None = None
 
-_cgroup_version: int | None = None
-_cpu_quota: float | None = None
+class CgroupCpuStats:
+    """Reads container CPU utilization from cgroup v1/v2 pseudo-files."""
 
+    def __init__(self):
+        self._last_cpu_usage: int | None = None
+        self._last_cpu_time: int | None = None
+        self._cgroup_version: int | None = None
+        self._cpu_quota: float | None = None
 
-def _detect_cgroup_version() -> int:
-    global _cgroup_version
-    if _cgroup_version is not None:
-        return _cgroup_version
+    def _detect_cgroup_version(self) -> int:
+        if self._cgroup_version is not None:
+            return self._cgroup_version
 
-    if Path("/sys/fs/cgroup/cgroup.controllers").exists():
-        _cgroup_version = 2
-    elif Path("/sys/fs/cgroup/cpu/cpuacct.usage").exists() or Path("/sys/fs/cgroup/cpuacct/cpuacct.usage").exists():
-        _cgroup_version = 1
-    else:
-        _cgroup_version = 0
+        if Path("/sys/fs/cgroup/cgroup.controllers").exists():
+            self._cgroup_version = 2
+        elif Path("/sys/fs/cgroup/cpu/cpuacct.usage").exists() or Path("/sys/fs/cgroup/cpuacct/cpuacct.usage").exists():
+            self._cgroup_version = 1
+        else:
+            self._cgroup_version = 0
 
-    return _cgroup_version
+        return self._cgroup_version
 
-
-def _read_cpu_usage_ns() -> int | None:
-    try:
-        ver = _detect_cgroup_version()
-        if ver == 2:
-            text = Path("/sys/fs/cgroup/cpu.stat").read_text()
-            for line in text.splitlines():
-                if line.startswith("usage_usec"):
-                    return int(line.split()[1]) * 1000
+    def _read_cpu_usage_ns(self) -> int | None:
+        try:
+            ver = self._detect_cgroup_version()
+            if ver == 2:
+                text = Path("/sys/fs/cgroup/cpu.stat").read_text()
+                for line in text.splitlines():
+                    if line.startswith("usage_usec"):
+                        return int(line.split()[1]) * 1000
+                return None
+            elif ver == 1:
+                for path in ("/sys/fs/cgroup/cpu/cpuacct.usage", "/sys/fs/cgroup/cpuacct/cpuacct.usage"):
+                    p = Path(path)
+                    if p.exists():
+                        return int(p.read_text().strip())
+                return None
             return None
-        elif ver == 1:
-            for path in ("/sys/fs/cgroup/cpu/cpuacct.usage", "/sys/fs/cgroup/cpuacct/cpuacct.usage"):
-                p = Path(path)
-                if p.exists():
-                    return int(p.read_text().strip())
+        except Exception:
             return None
-        return None
-    except Exception:
-        return None
 
+    def _read_cpu_quota(self) -> float:
+        if self._cpu_quota is not None:
+            return self._cpu_quota
 
-def _read_cpu_quota() -> float:
-    global _cpu_quota
-    if _cpu_quota is not None:
-        return _cpu_quota
+        try:
+            ver = self._detect_cgroup_version()
+            if ver == 2:
+                text = Path("/sys/fs/cgroup/cpu.max").read_text().strip()
+                parts = text.split()
+                if parts[0] == "max":
+                    self._cpu_quota = float(os.cpu_count() or 1)
+                    return self._cpu_quota
+                quota = int(parts[0])
+                period = int(parts[1])
+                if quota <= 0 or period <= 0:
+                    self._cpu_quota = float(os.cpu_count() or 1)
+                    return self._cpu_quota
+                self._cpu_quota = quota / period
+                return self._cpu_quota
+            elif ver == 1:
+                quota = int(Path("/sys/fs/cgroup/cpu/cpu.cfs_quota_us").read_text().strip())
+                period = int(Path("/sys/fs/cgroup/cpu/cpu.cfs_period_us").read_text().strip())
+                if quota <= 0 or period <= 0:
+                    self._cpu_quota = float(os.cpu_count() or 1)
+                    return self._cpu_quota
+                self._cpu_quota = quota / period
+                return self._cpu_quota
+        except Exception:
+            pass
+        self._cpu_quota = float(os.cpu_count() or 1)
+        return self._cpu_quota
 
-    try:
-        ver = _detect_cgroup_version()
-        if ver == 2:
-            text = Path("/sys/fs/cgroup/cpu.max").read_text().strip()
-            parts = text.split()
-            if parts[0] == "max":
-                _cpu_quota = float(os.cpu_count() or 1)
-                return _cpu_quota
-            quota = int(parts[0])
-            period = int(parts[1])
-            if quota <= 0 or period <= 0:
-                _cpu_quota = float(os.cpu_count() or 1)
-                return _cpu_quota
-            _cpu_quota = quota / period
-            return _cpu_quota
-        elif ver == 1:
-            quota = int(Path("/sys/fs/cgroup/cpu/cpu.cfs_quota_us").read_text().strip())
-            period = int(Path("/sys/fs/cgroup/cpu/cpu.cfs_period_us").read_text().strip())
-            if quota <= 0 or period <= 0:
-                _cpu_quota = float(os.cpu_count() or 1)
-                return _cpu_quota
-            _cpu_quota = quota / period
-            return _cpu_quota
-    except Exception:
-        pass
-    _cpu_quota = float(os.cpu_count() or 1)
-    return _cpu_quota
+    def cpu_percent(self) -> float:
+        """Return container CPU utilization % since last call.
 
+        First call returns 0.0 (no baseline). Falls back to psutil if cgroup
+        files are unavailable.
+        """
+        usage_ns = self._read_cpu_usage_ns()
+        now_ns = time.monotonic_ns()
 
-def cpu_percent() -> float:
-    """Return container CPU utilization % since last call.
+        if usage_ns is None:
+            return psutil.cpu_percent()
 
-    First call returns 0.0 (no baseline). Falls back to psutil if cgroup
-    files are unavailable.
-    """
-    global _last_cpu_usage, _last_cpu_time
+        prev_usage = self._last_cpu_usage
+        prev_time = self._last_cpu_time
+        self._last_cpu_usage = usage_ns
+        self._last_cpu_time = now_ns
 
-    usage_ns = _read_cpu_usage_ns()
-    now_ns = time.monotonic_ns()
+        if prev_usage is None or prev_time is None:
+            return 0.0
 
-    if usage_ns is None:
-        return psutil.cpu_percent()
+        delta_usage = usage_ns - prev_usage
+        delta_time = now_ns - prev_time
+        if delta_time <= 0 or delta_usage < 0:
+            return 0.0
 
-    prev_usage = _last_cpu_usage
-    prev_time = _last_cpu_time
-    _last_cpu_usage = usage_ns
-    _last_cpu_time = now_ns
-
-    if prev_usage is None or prev_time is None:
-        return 0.0
-
-    delta_usage = usage_ns - prev_usage
-    delta_time = now_ns - prev_time
-    if delta_time <= 0 or delta_usage < 0:
-        return 0.0
-
-    num_cpus = _read_cpu_quota()
-    return min(round((delta_usage / delta_time) / num_cpus * 100, 1), 100.0)
+        num_cpus = self._read_cpu_quota()
+        return min(round((delta_usage / delta_time) / num_cpus * 100, 1), 100.0)

--- a/tests/unit/utils/test_cgroup_stats.py
+++ b/tests/unit/utils/test_cgroup_stats.py
@@ -4,26 +4,12 @@ from unittest.mock import patch
 
 import pytest
 
-import rock.utils.cgroup_stats as cgroup_stats
-
-
-@pytest.fixture(autouse=True)
-def _reset_global_state():
-    """Reset module-level caches between tests."""
-    cgroup_stats._cgroup_version = None
-    cgroup_stats._cpu_quota = None
-    cgroup_stats._last_cpu_usage = None
-    cgroup_stats._last_cpu_time = None
-    yield
-    cgroup_stats._cgroup_version = None
-    cgroup_stats._cpu_quota = None
-    cgroup_stats._last_cpu_usage = None
-    cgroup_stats._last_cpu_time = None
+from rock.utils.cgroup_stats import CgroupCpuStats, Path
 
 
 def _mock_path_exists(mapping: dict[str, bool]):
     """Return a side_effect for Path.exists() based on a path-string mapping."""
-    original_exists = cgroup_stats.Path.exists
+    original_exists = Path.exists
 
     def _exists(self):
         s = str(self)
@@ -51,39 +37,44 @@ def _mock_path_read_text(mapping: dict[str, str]):
 
 class TestDetectCgroupVersion:
     def test_detects_v2(self):
+        stats = CgroupCpuStats()
         exists_map = {"/sys/fs/cgroup/cgroup.controllers": True}
-        with patch.object(cgroup_stats.Path, "exists", _mock_path_exists(exists_map)):
-            assert cgroup_stats._detect_cgroup_version() == 2
+        with patch.object(Path, "exists", _mock_path_exists(exists_map)):
+            assert stats._detect_cgroup_version() == 2
 
     def test_detects_v1(self):
+        stats = CgroupCpuStats()
         exists_map = {
             "/sys/fs/cgroup/cgroup.controllers": False,
             "/sys/fs/cgroup/cpu/cpuacct.usage": True,
         }
-        with patch.object(cgroup_stats.Path, "exists", _mock_path_exists(exists_map)):
-            assert cgroup_stats._detect_cgroup_version() == 1
+        with patch.object(Path, "exists", _mock_path_exists(exists_map)):
+            assert stats._detect_cgroup_version() == 1
 
     def test_detects_v1_alternate_path(self):
+        stats = CgroupCpuStats()
         exists_map = {
             "/sys/fs/cgroup/cgroup.controllers": False,
             "/sys/fs/cgroup/cpu/cpuacct.usage": False,
             "/sys/fs/cgroup/cpuacct/cpuacct.usage": True,
         }
-        with patch.object(cgroup_stats.Path, "exists", _mock_path_exists(exists_map)):
-            assert cgroup_stats._detect_cgroup_version() == 1
+        with patch.object(Path, "exists", _mock_path_exists(exists_map)):
+            assert stats._detect_cgroup_version() == 1
 
     def test_detects_no_cgroup(self):
+        stats = CgroupCpuStats()
         exists_map = {
             "/sys/fs/cgroup/cgroup.controllers": False,
             "/sys/fs/cgroup/cpu/cpuacct.usage": False,
             "/sys/fs/cgroup/cpuacct/cpuacct.usage": False,
         }
-        with patch.object(cgroup_stats.Path, "exists", _mock_path_exists(exists_map)):
-            assert cgroup_stats._detect_cgroup_version() == 0
+        with patch.object(Path, "exists", _mock_path_exists(exists_map)):
+            assert stats._detect_cgroup_version() == 0
 
     def test_caches_result(self):
-        cgroup_stats._cgroup_version = 2
-        assert cgroup_stats._detect_cgroup_version() == 2
+        stats = CgroupCpuStats()
+        stats._cgroup_version = 2
+        assert stats._detect_cgroup_version() == 2
 
 
 # ---------- CPU percent ----------
@@ -91,13 +82,15 @@ class TestDetectCgroupVersion:
 
 class TestCpuPercent:
     def test_first_call_returns_zero(self):
-        cgroup_stats._cgroup_version = 2
+        stats = CgroupCpuStats()
+        stats._cgroup_version = 2
         read_map = {"/sys/fs/cgroup/cpu.stat": "usage_usec 1000000\n"}
-        with patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map)):
-            assert cgroup_stats.cpu_percent() == 0.0
+        with patch.object(Path, "read_text", _mock_path_read_text(read_map)):
+            assert stats.cpu_percent() == 0.0
 
     def test_v2_cpu_calculation(self):
-        cgroup_stats._cgroup_version = 2
+        stats = CgroupCpuStats()
+        stats._cgroup_version = 2
         read_map_1 = {
             "/sys/fs/cgroup/cpu.stat": "usage_usec 1000000\n",
             "/sys/fs/cgroup/cpu.max": "100000 100000\n",
@@ -115,16 +108,16 @@ class TestCpuPercent:
             return val
 
         with (
-            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map_1)),
+            patch.object(Path, "read_text", _mock_path_read_text(read_map_1)),
             patch("rock.utils.cgroup_stats.time.monotonic_ns", mock_monotonic_ns),
         ):
-            cgroup_stats.cpu_percent()
+            stats.cpu_percent()
 
         with (
-            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map_2)),
+            patch.object(Path, "read_text", _mock_path_read_text(read_map_2)),
             patch("rock.utils.cgroup_stats.time.monotonic_ns", mock_monotonic_ns),
         ):
-            result = cgroup_stats.cpu_percent()
+            result = stats.cpu_percent()
 
         # delta_usage = (1500000 - 1000000) * 1000 = 500_000_000 ns
         # delta_time = 100_000_000_000 ns
@@ -133,7 +126,8 @@ class TestCpuPercent:
         assert result == 0.5
 
     def test_v1_cpu_calculation(self):
-        cgroup_stats._cgroup_version = 1
+        stats = CgroupCpuStats()
+        stats._cgroup_version = 1
         exists_map = {"/sys/fs/cgroup/cpu/cpuacct.usage": True}
         read_map_1 = {
             "/sys/fs/cgroup/cpu/cpuacct.usage": "1000000000\n",
@@ -154,18 +148,18 @@ class TestCpuPercent:
             return val
 
         with (
-            patch.object(cgroup_stats.Path, "exists", _mock_path_exists(exists_map)),
-            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map_1)),
+            patch.object(Path, "exists", _mock_path_exists(exists_map)),
+            patch.object(Path, "read_text", _mock_path_read_text(read_map_1)),
             patch("rock.utils.cgroup_stats.time.monotonic_ns", mock_monotonic_ns),
         ):
-            cgroup_stats.cpu_percent()
+            stats.cpu_percent()
 
         with (
-            patch.object(cgroup_stats.Path, "exists", _mock_path_exists(exists_map)),
-            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map_2)),
+            patch.object(Path, "exists", _mock_path_exists(exists_map)),
+            patch.object(Path, "read_text", _mock_path_read_text(read_map_2)),
             patch("rock.utils.cgroup_stats.time.monotonic_ns", mock_monotonic_ns),
         ):
-            result = cgroup_stats.cpu_percent()
+            result = stats.cpu_percent()
 
         # delta_usage = 1_000_000_000 ns, delta_time = 100_000_000_000 ns
         # quota = 200000/100000 = 2.0 CPUs
@@ -173,17 +167,18 @@ class TestCpuPercent:
         assert result == 0.5
 
     def test_fallback_to_psutil_when_no_cgroup(self):
-        cgroup_stats._cgroup_version = 0
+        stats = CgroupCpuStats()
+        stats._cgroup_version = 0
         with patch("rock.utils.cgroup_stats.psutil.cpu_percent", return_value=42.0):
-            assert cgroup_stats.cpu_percent() == 42.0
+            assert stats.cpu_percent() == 42.0
 
     def test_capped_at_100(self):
-        cgroup_stats._cgroup_version = 2
+        stats = CgroupCpuStats()
+        stats._cgroup_version = 2
         read_map_1 = {
             "/sys/fs/cgroup/cpu.stat": "usage_usec 0\n",
             "/sys/fs/cgroup/cpu.max": "100000 100000\n",
         }
-        # Huge jump to exceed 100%
         read_map_2 = {
             "/sys/fs/cgroup/cpu.stat": "usage_usec 200000000\n",
             "/sys/fs/cgroup/cpu.max": "100000 100000\n",
@@ -197,35 +192,37 @@ class TestCpuPercent:
             return val
 
         with (
-            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map_1)),
+            patch.object(Path, "read_text", _mock_path_read_text(read_map_1)),
             patch("rock.utils.cgroup_stats.time.monotonic_ns", mock_monotonic_ns),
         ):
-            cgroup_stats.cpu_percent()
+            stats.cpu_percent()
 
         with (
-            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map_2)),
+            patch.object(Path, "read_text", _mock_path_read_text(read_map_2)),
             patch("rock.utils.cgroup_stats.time.monotonic_ns", mock_monotonic_ns),
         ):
-            result = cgroup_stats.cpu_percent()
+            result = stats.cpu_percent()
 
         assert result == 100.0
 
     def test_zero_delta_time_returns_zero(self):
-        cgroup_stats._cgroup_version = 2
+        stats = CgroupCpuStats()
+        stats._cgroup_version = 2
         read_map = {"/sys/fs/cgroup/cpu.stat": "usage_usec 1000000\n"}
         same_time = 100_000_000_000
 
         with (
-            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map)),
+            patch.object(Path, "read_text", _mock_path_read_text(read_map)),
             patch("rock.utils.cgroup_stats.time.monotonic_ns", return_value=same_time),
         ):
-            cgroup_stats.cpu_percent()
-            result = cgroup_stats.cpu_percent()
+            stats.cpu_percent()
+            result = stats.cpu_percent()
 
         assert result == 0.0
 
     def test_negative_delta_usage_returns_zero(self):
-        cgroup_stats._cgroup_version = 2
+        stats = CgroupCpuStats()
+        stats._cgroup_version = 2
         read_map_1 = {"/sys/fs/cgroup/cpu.stat": "usage_usec 2000000\n"}
         read_map_2 = {
             "/sys/fs/cgroup/cpu.stat": "usage_usec 1000000\n",
@@ -240,16 +237,16 @@ class TestCpuPercent:
             return val
 
         with (
-            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map_1)),
+            patch.object(Path, "read_text", _mock_path_read_text(read_map_1)),
             patch("rock.utils.cgroup_stats.time.monotonic_ns", mock_monotonic_ns),
         ):
-            cgroup_stats.cpu_percent()
+            stats.cpu_percent()
 
         with (
-            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map_2)),
+            patch.object(Path, "read_text", _mock_path_read_text(read_map_2)),
             patch("rock.utils.cgroup_stats.time.monotonic_ns", mock_monotonic_ns),
         ):
-            result = cgroup_stats.cpu_percent()
+            result = stats.cpu_percent()
 
         assert result == 0.0
 
@@ -259,30 +256,33 @@ class TestCpuPercent:
 
 class TestCpuQuota:
     def test_v2_unlimited(self):
-        cgroup_stats._cgroup_version = 2
+        stats = CgroupCpuStats()
+        stats._cgroup_version = 2
         read_map = {"/sys/fs/cgroup/cpu.max": "max 100000\n"}
         with (
-            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map)),
+            patch.object(Path, "read_text", _mock_path_read_text(read_map)),
             patch("rock.utils.cgroup_stats.os.cpu_count", return_value=4),
         ):
-            assert cgroup_stats._read_cpu_quota() == 4.0
+            assert stats._read_cpu_quota() == 4.0
 
     def test_v1_unlimited(self):
-        cgroup_stats._cgroup_version = 1
+        stats = CgroupCpuStats()
+        stats._cgroup_version = 1
         read_map = {
             "/sys/fs/cgroup/cpu/cpu.cfs_quota_us": "-1\n",
             "/sys/fs/cgroup/cpu/cpu.cfs_period_us": "100000\n",
         }
         with (
-            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map)),
+            patch.object(Path, "read_text", _mock_path_read_text(read_map)),
             patch("rock.utils.cgroup_stats.os.cpu_count", return_value=8),
         ):
-            assert cgroup_stats._read_cpu_quota() == 8.0
+            assert stats._read_cpu_quota() == 8.0
 
     def test_fallback_on_error(self):
-        cgroup_stats._cgroup_version = 2
+        stats = CgroupCpuStats()
+        stats._cgroup_version = 2
         with (
-            patch.object(cgroup_stats.Path, "read_text", side_effect=PermissionError),
+            patch.object(Path, "read_text", side_effect=PermissionError),
             patch("rock.utils.cgroup_stats.os.cpu_count", return_value=2),
         ):
-            assert cgroup_stats._read_cpu_quota() == 2.0
+            assert stats._read_cpu_quota() == 2.0

--- a/tests/unit/utils/test_cgroup_stats.py
+++ b/tests/unit/utils/test_cgroup_stats.py
@@ -1,0 +1,286 @@
+"""Tests for rock.utils.cgroup_stats — container-aware CPU metrics."""
+
+from unittest.mock import patch
+
+import pytest
+
+import rock.utils.cgroup_stats as cgroup_stats
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_state():
+    """Reset module-level caches between tests."""
+    cgroup_stats._cgroup_version = None
+    cgroup_stats._last_cpu_usage.clear()
+    cgroup_stats._last_cpu_time.clear()
+    yield
+    cgroup_stats._cgroup_version = None
+    cgroup_stats._last_cpu_usage.clear()
+    cgroup_stats._last_cpu_time.clear()
+
+
+def _mock_path_exists(mapping: dict[str, bool]):
+    """Return a side_effect for Path.exists() based on a path-string mapping."""
+    original_exists = cgroup_stats.Path.exists
+
+    def _exists(self):
+        s = str(self)
+        if s in mapping:
+            return mapping[s]
+        return original_exists(self)
+
+    return _exists
+
+
+def _mock_path_read_text(mapping: dict[str, str]):
+    """Return a side_effect for Path.read_text() based on a path-string mapping."""
+
+    def _read_text(self, *args, **kwargs):
+        s = str(self)
+        if s in mapping:
+            return mapping[s]
+        raise FileNotFoundError(s)
+
+    return _read_text
+
+
+# ---------- cgroup version detection ----------
+
+
+class TestDetectCgroupVersion:
+    def test_detects_v2(self):
+        exists_map = {"/sys/fs/cgroup/cgroup.controllers": True}
+        with patch.object(cgroup_stats.Path, "exists", _mock_path_exists(exists_map)):
+            assert cgroup_stats._detect_cgroup_version() == 2
+
+    def test_detects_v1(self):
+        exists_map = {
+            "/sys/fs/cgroup/cgroup.controllers": False,
+            "/sys/fs/cgroup/cpu/cpuacct.usage": True,
+        }
+        with patch.object(cgroup_stats.Path, "exists", _mock_path_exists(exists_map)):
+            assert cgroup_stats._detect_cgroup_version() == 1
+
+    def test_detects_v1_alternate_path(self):
+        exists_map = {
+            "/sys/fs/cgroup/cgroup.controllers": False,
+            "/sys/fs/cgroup/cpu/cpuacct.usage": False,
+            "/sys/fs/cgroup/cpuacct/cpuacct.usage": True,
+        }
+        with patch.object(cgroup_stats.Path, "exists", _mock_path_exists(exists_map)):
+            assert cgroup_stats._detect_cgroup_version() == 1
+
+    def test_detects_no_cgroup(self):
+        exists_map = {
+            "/sys/fs/cgroup/cgroup.controllers": False,
+            "/sys/fs/cgroup/cpu/cpuacct.usage": False,
+            "/sys/fs/cgroup/cpuacct/cpuacct.usage": False,
+        }
+        with patch.object(cgroup_stats.Path, "exists", _mock_path_exists(exists_map)):
+            assert cgroup_stats._detect_cgroup_version() == 0
+
+    def test_caches_result(self):
+        cgroup_stats._cgroup_version = 2
+        assert cgroup_stats._detect_cgroup_version() == 2
+
+
+# ---------- CPU percent ----------
+
+
+class TestCpuPercent:
+    def test_first_call_returns_zero(self):
+        cgroup_stats._cgroup_version = 2
+        read_map = {"/sys/fs/cgroup/cpu.stat": "usage_usec 1000000\n"}
+        with patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map)):
+            assert cgroup_stats.cpu_percent() == 0.0
+
+    def test_v2_cpu_calculation(self):
+        cgroup_stats._cgroup_version = 2
+        read_map_1 = {
+            "/sys/fs/cgroup/cpu.stat": "usage_usec 1000000\n",
+            "/sys/fs/cgroup/cpu.max": "100000 100000\n",
+        }
+        read_map_2 = {
+            "/sys/fs/cgroup/cpu.stat": "usage_usec 1500000\n",
+            "/sys/fs/cgroup/cpu.max": "100000 100000\n",
+        }
+        time_values = [100_000_000_000, 200_000_000_000]
+        time_idx = {"i": 0}
+
+        def mock_monotonic_ns():
+            val = time_values[time_idx["i"]]
+            time_idx["i"] += 1
+            return val
+
+        with (
+            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map_1)),
+            patch("rock.utils.cgroup_stats.time.monotonic_ns", mock_monotonic_ns),
+        ):
+            cgroup_stats.cpu_percent()
+
+        with (
+            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map_2)),
+            patch("rock.utils.cgroup_stats.time.monotonic_ns", mock_monotonic_ns),
+        ):
+            result = cgroup_stats.cpu_percent()
+
+        # delta_usage = (1500000 - 1000000) * 1000 = 500_000_000 ns
+        # delta_time = 100_000_000_000 ns
+        # quota = 100000/100000 = 1.0 CPU
+        # pct = (500_000_000 / 100_000_000_000) / 1.0 * 100 = 0.5%
+        assert result == 0.5
+
+    def test_v1_cpu_calculation(self):
+        cgroup_stats._cgroup_version = 1
+        exists_map = {"/sys/fs/cgroup/cpu/cpuacct.usage": True}
+        read_map_1 = {
+            "/sys/fs/cgroup/cpu/cpuacct.usage": "1000000000\n",
+            "/sys/fs/cgroup/cpu/cpu.cfs_quota_us": "200000\n",
+            "/sys/fs/cgroup/cpu/cpu.cfs_period_us": "100000\n",
+        }
+        read_map_2 = {
+            "/sys/fs/cgroup/cpu/cpuacct.usage": "2000000000\n",
+            "/sys/fs/cgroup/cpu/cpu.cfs_quota_us": "200000\n",
+            "/sys/fs/cgroup/cpu/cpu.cfs_period_us": "100000\n",
+        }
+        time_values = [100_000_000_000, 200_000_000_000]
+        time_idx = {"i": 0}
+
+        def mock_monotonic_ns():
+            val = time_values[time_idx["i"]]
+            time_idx["i"] += 1
+            return val
+
+        with (
+            patch.object(cgroup_stats.Path, "exists", _mock_path_exists(exists_map)),
+            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map_1)),
+            patch("rock.utils.cgroup_stats.time.monotonic_ns", mock_monotonic_ns),
+        ):
+            cgroup_stats.cpu_percent()
+
+        with (
+            patch.object(cgroup_stats.Path, "exists", _mock_path_exists(exists_map)),
+            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map_2)),
+            patch("rock.utils.cgroup_stats.time.monotonic_ns", mock_monotonic_ns),
+        ):
+            result = cgroup_stats.cpu_percent()
+
+        # delta_usage = 1_000_000_000 ns, delta_time = 100_000_000_000 ns
+        # quota = 200000/100000 = 2.0 CPUs
+        # pct = (1_000_000_000 / 100_000_000_000) / 2.0 * 100 = 0.5%
+        assert result == 0.5
+
+    def test_fallback_to_psutil_when_no_cgroup(self):
+        cgroup_stats._cgroup_version = 0
+        with patch("rock.utils.cgroup_stats.psutil.cpu_percent", return_value=42.0):
+            assert cgroup_stats.cpu_percent() == 42.0
+
+    def test_capped_at_100(self):
+        cgroup_stats._cgroup_version = 2
+        read_map_1 = {
+            "/sys/fs/cgroup/cpu.stat": "usage_usec 0\n",
+            "/sys/fs/cgroup/cpu.max": "100000 100000\n",
+        }
+        # Huge jump to exceed 100%
+        read_map_2 = {
+            "/sys/fs/cgroup/cpu.stat": "usage_usec 200000000\n",
+            "/sys/fs/cgroup/cpu.max": "100000 100000\n",
+        }
+        time_values = [100_000_000_000, 200_000_000_000]
+        time_idx = {"i": 0}
+
+        def mock_monotonic_ns():
+            val = time_values[time_idx["i"]]
+            time_idx["i"] += 1
+            return val
+
+        with (
+            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map_1)),
+            patch("rock.utils.cgroup_stats.time.monotonic_ns", mock_monotonic_ns),
+        ):
+            cgroup_stats.cpu_percent()
+
+        with (
+            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map_2)),
+            patch("rock.utils.cgroup_stats.time.monotonic_ns", mock_monotonic_ns),
+        ):
+            result = cgroup_stats.cpu_percent()
+
+        assert result == 100.0
+
+    def test_zero_delta_time_returns_zero(self):
+        cgroup_stats._cgroup_version = 2
+        read_map = {"/sys/fs/cgroup/cpu.stat": "usage_usec 1000000\n"}
+        same_time = 100_000_000_000
+
+        with (
+            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map)),
+            patch("rock.utils.cgroup_stats.time.monotonic_ns", return_value=same_time),
+        ):
+            cgroup_stats.cpu_percent()
+            result = cgroup_stats.cpu_percent()
+
+        assert result == 0.0
+
+    def test_negative_delta_usage_returns_zero(self):
+        cgroup_stats._cgroup_version = 2
+        read_map_1 = {"/sys/fs/cgroup/cpu.stat": "usage_usec 2000000\n"}
+        read_map_2 = {
+            "/sys/fs/cgroup/cpu.stat": "usage_usec 1000000\n",
+            "/sys/fs/cgroup/cpu.max": "100000 100000\n",
+        }
+        time_values = [100_000_000_000, 200_000_000_000]
+        time_idx = {"i": 0}
+
+        def mock_monotonic_ns():
+            val = time_values[time_idx["i"]]
+            time_idx["i"] += 1
+            return val
+
+        with (
+            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map_1)),
+            patch("rock.utils.cgroup_stats.time.monotonic_ns", mock_monotonic_ns),
+        ):
+            cgroup_stats.cpu_percent()
+
+        with (
+            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map_2)),
+            patch("rock.utils.cgroup_stats.time.monotonic_ns", mock_monotonic_ns),
+        ):
+            result = cgroup_stats.cpu_percent()
+
+        assert result == 0.0
+
+
+# ---------- CPU quota ----------
+
+
+class TestCpuQuota:
+    def test_v2_unlimited(self):
+        cgroup_stats._cgroup_version = 2
+        read_map = {"/sys/fs/cgroup/cpu.max": "max 100000\n"}
+        with (
+            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map)),
+            patch("rock.utils.cgroup_stats.os.cpu_count", return_value=4),
+        ):
+            assert cgroup_stats._read_cpu_quota() == 4.0
+
+    def test_v1_unlimited(self):
+        cgroup_stats._cgroup_version = 1
+        read_map = {
+            "/sys/fs/cgroup/cpu/cpu.cfs_quota_us": "-1\n",
+            "/sys/fs/cgroup/cpu/cpu.cfs_period_us": "100000\n",
+        }
+        with (
+            patch.object(cgroup_stats.Path, "read_text", _mock_path_read_text(read_map)),
+            patch("rock.utils.cgroup_stats.os.cpu_count", return_value=8),
+        ):
+            assert cgroup_stats._read_cpu_quota() == 8.0
+
+    def test_fallback_on_error(self):
+        cgroup_stats._cgroup_version = 2
+        with (
+            patch.object(cgroup_stats.Path, "read_text", side_effect=PermissionError),
+            patch("rock.utils.cgroup_stats.os.cpu_count", return_value=2),
+        ):
+            assert cgroup_stats._read_cpu_quota() == 2.0

--- a/tests/unit/utils/test_cgroup_stats.py
+++ b/tests/unit/utils/test_cgroup_stats.py
@@ -11,12 +11,14 @@ import rock.utils.cgroup_stats as cgroup_stats
 def _reset_global_state():
     """Reset module-level caches between tests."""
     cgroup_stats._cgroup_version = None
-    cgroup_stats._last_cpu_usage.clear()
-    cgroup_stats._last_cpu_time.clear()
+    cgroup_stats._cpu_quota = None
+    cgroup_stats._last_cpu_usage = None
+    cgroup_stats._last_cpu_time = None
     yield
     cgroup_stats._cgroup_version = None
-    cgroup_stats._last_cpu_usage.clear()
-    cgroup_stats._last_cpu_time.clear()
+    cgroup_stats._cpu_quota = None
+    cgroup_stats._last_cpu_usage = None
+    cgroup_stats._last_cpu_time = None
 
 
 def _mock_path_exists(mapping: dict[str, bool]):


### PR DESCRIPTION
## Summary                                                                                                                                                          
                                                                                                                                                                       
   - Replace `psutil.cpu_percent()` with cgroup-aware CPU measurement in `LinuxRocklet.get_statistics()` to report accurate container-level utilization instead of     
   host-level metrics                                                                                                                                                  
   - Add `rock/utils/cgroup_stats.py` supporting both cgroup v1 and v2 with automatic fallback to psutil in non-container environments
   - Add comprehensive unit tests covering v1/v2 detection, CPU calculation, quota parsing, and edge cases

   Fixes #945

   ## Test Plan

   - [x] `uv run pytest tests/unit/utils/test_cgroup_stats.py` — all unit tests pass
   - [x] `uv run pytest -m "not need_ray and not need_admin and not need_admin_and_network" --reruns 1` — no regressions in fast tests
   - [ ] Deploy rocklet in a cgroup v2 container and verify `GET /statistics` returns CPU % relative to container quota
   - [x] Deploy rocklet in a cgroup v1 container and verify correct CPU readings
   - [x] Run rocklet outside a container (bare metal / macOS) and verify fallback to psutil works

   🤖 Generated with [Claude Code](https://claude.com/claude-code)