### PR TITLE
chore(sdk): make sandbox cluster default configurable via env var

### DIFF
--- a/rock/env_vars.py
+++ b/rock/env_vars.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     ROCK_CONFIG: str | None = None
     ROCK_CONFIG_DIR_NAME: str | None = None
     ROCK_BASE_URL: str | None = "http://localhost:8080"
+    ROCK_DEFAULT_CLUSTER: str = "vpc-nt-a"
     ROCK_WORKER_ROCKLET_PORT: int | None = None
     ROCK_SANDBOX_STARTUP_TIMEOUT_SECONDS: int = 180
     ROCK_CODE_SANDBOX_BASE_URL: str | None = None
@@ -77,6 +78,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ROCK_CONFIG": lambda: os.getenv("ROCK_CONFIG"),
     "ROCK_CONFIG_DIR_NAME": lambda: os.getenv("ROCK_CONFIG_DIR_NAME", "rock-conf"),
     "ROCK_BASE_URL": lambda: os.getenv("ROCK_BASE_URL", "http://localhost:8080"),
+    "ROCK_DEFAULT_CLUSTER": lambda: os.getenv("ROCK_DEFAULT_CLUSTER", "vpc-nt-a"),
     "ROCK_WORKER_ROCKLET_PORT": lambda: int(val) if (val := os.getenv("ROCK_WORKER_ROCKLET_PORT")) else None,
     "ROCK_SANDBOX_STARTUP_TIMEOUT_SECONDS": lambda: int(os.getenv("ROCK_SANDBOX_STARTUP_TIMEOUT_SECONDS", "180")),
     "ROCK_CODE_SANDBOX_BASE_URL": lambda: os.getenv("ROCK_CODE_SANDBOX_BASE_URL", ""),

--- a/rock/sdk/sandbox/config.py
+++ b/rock/sdk/sandbox/config.py
@@ -38,7 +38,7 @@ class SandboxConfig(BaseConfig):
     limit_cpus: float | None = None
     user_id: str | None = None
     experiment_id: str | None = None
-    cluster: str = "zb"
+    cluster: str = env_vars.ROCK_DEFAULT_CLUSTER
     namespace: str | None = None
     registry_username: str | None = None
     registry_password: str | None = None

--- a/tests/unit/sdk/agent/test_job_config_serialization.py
+++ b/tests/unit/sdk/agent/test_job_config_serialization.py
@@ -26,7 +26,7 @@ class TestRockEnvironmentConfigInheritance:
         assert env.image == "python:3.11"
         assert env.memory == "8g"
         assert env.cpus == 2.0
-        assert env.cluster == "zb"
+        assert env.cluster == "vpc-nt-a"
 
     def test_inherits_harbor_env_fields(self):
         env = RockEnvironmentConfig()

--- a/tests/unit/sdk/test_sandbox_config.py
+++ b/tests/unit/sdk/test_sandbox_config.py
@@ -1,6 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
+from rock.sdk.sandbox.client import Sandbox
 from rock.sdk.sandbox.config import SandboxConfig
 
 
@@ -28,3 +29,33 @@ class TestSandboxConfigAutoDeleteSeconds:
     def test_large_negative_value_raises_error(self):
         with pytest.raises(ValidationError, match="auto_delete_seconds must be >= 0"):
             SandboxConfig(auto_delete_seconds=-100)
+
+
+class TestSandboxCluster:
+    def test_sandbox_cluster(self):
+        fake_route_key = "fake_route_key"
+        fake_auth_token = "fake_auth_token"
+        config = SandboxConfig(
+            image="python:3.11",
+            route_key=fake_route_key,
+            xrl_authorization=fake_auth_token,
+            cluster="sg",
+        )
+        sandbox = Sandbox(config)
+        assert sandbox.cluster == "sg"
+        common_headers = sandbox._build_headers()
+        assert common_headers["X-Cluster"] == "sg"
+        assert common_headers["ROUTE-KEY"] == fake_route_key
+        assert common_headers["XRL-Authorization"] == f"Bearer {fake_auth_token}"
+
+        # default cluster is vpc-nt-a
+        config = SandboxConfig(
+            image="python:3.11",
+            route_key=fake_route_key,
+            xrl_authorization=fake_auth_token,
+        )
+
+        sandbox = Sandbox(config)
+        assert sandbox.cluster == "vpc-nt-a"
+        common_headers = sandbox._build_headers()
+        assert common_headers["X-Cluster"] == "vpc-nt-a"


### PR DESCRIPTION
## Summary

- Introduce `ROCK_DEFAULT_CLUSTER` env var in `rock/env_vars.py` (default `vpc-nt-a`).
- Use it as the default for `SandboxConfig.cluster`, replacing the previous hardcoded `"zb"`.
- Update the corresponding unit-test assertion in `test_job_config_serialization.py`.

The server-side `cluster_name` defaults in `rock/admin/proto/request.py` and `rock/admin/core/schema.py` are a separate concept (server-side header / DB-column fallback) and are intentionally left unchanged.

fixes #947

## Test plan

- [x] `uv run pytest tests/unit/sdk/agent/test_job_config_serialization.py` — 23 passed
- [ ] Verify `ROCK_DEFAULT_CLUSTER=foo` env override is respected at SDK init