### PR TITLE
feat(oss): add dual-account STS  and migrate transfer bucket to chatos-rock

### DIFF
--- a/rock/admin/entrypoints/sandbox_proxy_api.py
+++ b/rock/admin/entrypoints/sandbox_proxy_api.py
@@ -332,16 +332,6 @@ async def get_token(account: str = "legacy"):
     return RockResponse(result=result)
 
 
-@sandbox_proxy_router.get("/get_token_v2")
-@handle_exceptions(error_message="get oss sts token v2 failed")
-async def get_token_v2():
-    """Primary-account STS for SDK >= 1.8.
-    Delegates to the unified ``gen_oss_sts_token`` with account="primary".
-    Response format is identical to /get_token (same Credentials shape)."""
-    result = await asyncio.to_thread(sandbox_proxy_service.gen_oss_sts_token, "primary")
-    return RockResponse(result=result)
-
-
 @sandbox_proxy_router.api_route(
     "/sandboxes/{sandbox_id}/vnc",
     methods=["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"],

--- a/rock/admin/entrypoints/sandbox_proxy_api.py
+++ b/rock/admin/entrypoints/sandbox_proxy_api.py
@@ -336,8 +336,9 @@ async def get_token(account: str = "legacy"):
 @handle_exceptions(error_message="get oss sts token v2 failed")
 async def get_token_v2():
     """Primary-account STS for SDK >= 1.8.
+    Delegates to the unified ``gen_oss_sts_token`` with account="primary".
     Response format is identical to /get_token (same Credentials shape)."""
-    result = await asyncio.to_thread(sandbox_proxy_service.gen_oss_sts_token_v2)
+    result = await asyncio.to_thread(sandbox_proxy_service.gen_oss_sts_token, "primary")
     return RockResponse(result=result)
 
 

--- a/rock/admin/entrypoints/sandbox_proxy_api.py
+++ b/rock/admin/entrypoints/sandbox_proxy_api.py
@@ -321,8 +321,23 @@ async def portforward(websocket: WebSocket, id: str, port: int):
 
 @sandbox_proxy_router.get("/get_token")
 @handle_exceptions(error_message="get oss sts token failed")
-async def get_token():
-    result = await asyncio.to_thread(sandbox_proxy_service.gen_oss_sts_token)
+async def get_token(account: str = "legacy"):
+    """STS token for OSS upload/download.
+
+    Query param `account` selects the credential pool:
+      - "legacy"  (default): xrl-sandbox bucket, BC for SDK < 1.8
+      - "primary":            chatos-rock bucket, used by SDK >= 1.8
+    """
+    result = await asyncio.to_thread(sandbox_proxy_service.gen_oss_sts_token, account)
+    return RockResponse(result=result)
+
+
+@sandbox_proxy_router.get("/get_token_v2")
+@handle_exceptions(error_message="get oss sts token v2 failed")
+async def get_token_v2():
+    """Primary-account STS for SDK >= 1.8.
+    Response format is identical to /get_token (same Credentials shape)."""
+    result = await asyncio.to_thread(sandbox_proxy_service.gen_oss_sts_token_v2)
     return RockResponse(result=result)
 
 

--- a/rock/config.py
+++ b/rock/config.py
@@ -84,10 +84,9 @@ class OssConfig:
     env_vars.ROCK_OSS_BUCKET_REGION, YAML-level values always win over env."""
 
     primary: OssAccountConfig = field(default_factory=OssAccountConfig)
-    """Primary account used by SDK >= 1.8 (`/get_token_v2` endpoint) and by
-    all host-side archival (OssArchiver, landed in PR-1). An empty
-    `primary.bucket` disables v2 STS and archival, leaving legacy path
-    fully operational."""
+    """Primary account used by SDK >= 1.8 (`/get_token?account=primary`) and by
+    host-side archival. An empty `primary.bucket` disables v2 STS and archival,
+    leaving legacy path fully operational."""
 
     transfer_prefix: str = ""
     """Prefix under the PRIMARY bucket for ephemeral host↔container file

--- a/rock/config.py
+++ b/rock/config.py
@@ -61,12 +61,51 @@ class SandboxConfig:
 
 
 @dataclass
+class OssAccountConfig:
+    endpoint: str = ""
+    bucket: str = ""
+    access_key_id: str = ""
+    access_key_secret: str = ""
+    role_arn: str = ""
+    region: str = ""
+    """Region used to construct the STS AcsClient for this account. Falls back
+    to env_vars.ROCK_OSS_BUCKET_REGION when empty, to preserve legacy behavior."""
+
+
+@dataclass
 class OssConfig:
     endpoint: str = ""
     bucket: str = ""
     access_key_id: str = ""
     access_key_secret: str = ""
     role_arn: str = ""
+    region: str = ""
+    """Region for the legacy STS AcsClient. Empty falls back to
+    env_vars.ROCK_OSS_BUCKET_REGION, YAML-level values always win over env."""
+
+    primary: OssAccountConfig = field(default_factory=OssAccountConfig)
+    """Primary account used by SDK >= 1.8 (`/get_token_v2` endpoint) and by
+    all host-side archival (OssArchiver, landed in PR-1). An empty
+    `primary.bucket` disables v2 STS and archival, leaving legacy path
+    fully operational."""
+
+    transfer_prefix: str = ""
+    """Prefix under the PRIMARY bucket for ephemeral host↔container file
+    transfers ({timestamp}-{filename} objects). The legacy bucket keeps
+    its pre-existing flat layout (no prefix) for backward compatibility —
+    xrl-sandbox has a 3-day lifecycle rule at bucket root (configured
+    in the Aliyun OSS console, not in repo) that we do not disturb.
+
+    Note: this field lives in admin-side RockConfig and is NOT what the
+    SDK reads. The SDK reads ROCK_OSS_TRANSFER_PREFIX directly from the
+    process env. xrl package is no longer maintained, so internal users
+    must export this env var themselves when upgrading to SDK >= 1.8."""
+
+    def __post_init__(self):
+        # Allow YAML to pass a dict for `primary` (dataclass deserialization
+        # from yaml.safe_load returns dicts, not nested dataclasses).
+        if isinstance(self.primary, dict):
+            self.primary = OssAccountConfig(**self.primary)
 
 
 @dataclass

--- a/rock/env_vars.py
+++ b/rock/env_vars.py
@@ -37,6 +37,10 @@ if TYPE_CHECKING:
     ROCK_OSS_BUCKET_ENDPOINT: str | None = None
     ROCK_OSS_BUCKET_NAME: str | None = None
     ROCK_OSS_BUCKET_REGION: str | None = None
+    ROCK_OSS_TRANSFER_PREFIX: str | None = None
+    """Optional key prefix for host↔container transfer objects under the
+    bucket identified by ROCK_OSS_BUCKET_NAME. Empty = flat layout (legacy
+    bucket). New SDK clusters set this to "rock-transfer/"."""
 
     ROCK_PIP_INDEX_URL: str | None = "https://mirrors.aliyun.com/pypi/simple/"
     ROCK_MONITOR_ENABLE: bool = False
@@ -91,6 +95,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ROCK_RAY_NAMESPACE": lambda: os.getenv("ROCK_RAY_NAMESPACE", "xrl-sandbox"),
     "ROCK_SANDBOX_EXPIRE_TIME_KEY": lambda: os.getenv("ROCK_SANDBOX_EXPIRE_TIME_KEY", "expire_time"),
     "ROCK_SANDBOX_AUTO_CLEAR_TIME_KEY": lambda: os.getenv("ROCK_SANDBOX_AUTO_CLEAR_TIME_KEY", "auto_clear_time"),
+    "ROCK_OSS_TRANSFER_PREFIX": lambda: os.getenv("ROCK_OSS_TRANSFER_PREFIX"),
     "ROCK_OSS_ENABLE": lambda: os.getenv("ROCK_OSS_ENABLE", "false").lower() == "true",
     "ROCK_OSS_BUCKET_ENDPOINT": lambda: os.getenv("ROCK_OSS_BUCKET_ENDPOINT"),
     "ROCK_OSS_BUCKET_NAME": lambda: os.getenv("ROCK_OSS_BUCKET_NAME"),

--- a/rock/sandbox/service/sandbox_proxy_service.py
+++ b/rock/sandbox/service/sandbox_proxy_service.py
@@ -74,19 +74,22 @@ class SandboxProxyService:
         # Replace single self.sts_client with a dict keyed by account name,
         # so /get_token?account=legacy|primary maps to the right credentials.
         legacy_region = self.oss_config.region or env_vars.ROCK_OSS_BUCKET_REGION
-        primary_region = self.oss_config.primary.region or env_vars.ROCK_OSS_BUCKET_REGION
         self._sts_clients = {
             "legacy": client.AcsClient(
                 self.oss_config.access_key_id,
                 self.oss_config.access_key_secret,
                 legacy_region,
             ),
-            "primary": client.AcsClient(
+        }
+        # Only create primary client when credentials are configured,
+        # avoiding an AcsClient with empty AK/SK that would fail at call time.
+        if self.oss_config.primary.access_key_id:
+            primary_region = self.oss_config.primary.region or env_vars.ROCK_OSS_BUCKET_REGION
+            self._sts_clients["primary"] = client.AcsClient(
                 self.oss_config.primary.access_key_id,
                 self.oss_config.primary.access_key_secret,
                 primary_region,
-            ),
-        }
+            )
 
         self._batch_get_status_max_count = rock_config.proxy_service.batch_get_status_max_count
         self._validate_oss_config_or_warn()

--- a/rock/sandbox/service/sandbox_proxy_service.py
+++ b/rock/sandbox/service/sandbox_proxy_service.py
@@ -71,11 +71,22 @@ class SandboxProxyService:
             ),
         )
 
-        self.sts_client = client.AcsClient(
-            self.oss_config.access_key_id,
-            self.oss_config.access_key_secret,
-            env_vars.ROCK_OSS_BUCKET_REGION,
-        )
+        # Replace single self.sts_client with a dict keyed by account name,
+        # so /get_token?account=legacy|primary maps to the right credentials.
+        legacy_region = self.oss_config.region or env_vars.ROCK_OSS_BUCKET_REGION
+        primary_region = self.oss_config.primary.region or env_vars.ROCK_OSS_BUCKET_REGION
+        self._sts_clients = {
+            "legacy": client.AcsClient(
+                self.oss_config.access_key_id,
+                self.oss_config.access_key_secret,
+                legacy_region,
+            ),
+            "primary": client.AcsClient(
+                self.oss_config.primary.access_key_id,
+                self.oss_config.primary.access_key_secret,
+                primary_region,
+            ),
+        }
 
         self._batch_get_status_max_count = rock_config.proxy_service.batch_get_status_max_count
         self._validate_oss_config_or_warn()
@@ -668,30 +679,60 @@ class SandboxProxyService:
         port = service_status.get_mapped_port(Port.PROXY)
         return f"http://{host_ip}:{port}"
 
-    def gen_oss_sts_token(self):
-        role_arn = self.oss_config.role_arn
+    def gen_oss_sts_token(self, account: str = "legacy") -> dict | None:  # CHANGED: account param, default "legacy" preserves BC
+        """Generate STS credentials and OSS config for the given account.
+        Args:
+            account: "legacy" (xrl-sandbox, BC for SDK < 1.8) or
+                     "primary" (chatos-rock, SDK >= 1.8).
+        Returns:
+            Dict with STS credentials (AccessKeyId, AccessKeySecret, SecurityToken, Expiration) PLUS account-scoped OSS config:
+            Endpoint, Bucket, Region, Prefix. None on failure or when the requested account is unconfigured.
+        """
+        if account not in self._sts_clients:
+            logger.error(f"unknown OSS account: {account!r}")
+            return None
+
+        if account == "primary":
+            primary = self.oss_config.primary
+            role_arn = primary.role_arn
+            session_name = "rock-sandbox-primary"
+            endpoint = primary.endpoint or None
+            bucket = primary.bucket or None
+            region = primary.region or env_vars.ROCK_OSS_BUCKET_REGION or None
+            prefix = self.oss_config.transfer_prefix or None
+        else:  # legacy
+            role_arn = self.oss_config.role_arn
+            session_name = "rock-sandbox-legacy"
+            endpoint = env_vars.ROCK_OSS_BUCKET_ENDPOINT or self.oss_config.endpoint or None
+            bucket = env_vars.ROCK_OSS_BUCKET_NAME or self.oss_config.bucket or None
+            region = env_vars.ROCK_OSS_BUCKET_REGION or None
+            prefix = env_vars.ROCK_OSS_TRANSFER_PREFIX or None
+
+        if not role_arn:
+            logger.warning(f"oss role_arn not configured for account={account!r}")
+            return None
+
         request = CommonRequest(product="Sts", version="2015-04-01", action_name="AssumeRole")
         request.set_method("POST")
         request.set_protocol_type("https")
         request.add_query_param("RoleArn", role_arn)
-        request.add_query_param("RoleSessionName", "sessiontest")
+        request.add_query_param("RoleSessionName", session_name)
         # at least 900s
         request.add_query_param("DurationSeconds", "900")
         request.set_accept_format("JSON")
         try:
-            body = self.sts_client.do_action_with_exception(request)
-            token = json.loads(oss2.to_unicode(body))
-            credentials = token["Credentials"]
+            body = self._sts_clients[account].do_action_with_exception(request)
+            credentials = json.loads(oss2.to_unicode(body))["Credentials"]
         except Exception:
-            logger.error("generate oss sts token failed")
+            logger.error(f"generate oss sts token failed (account={account})", exc_info=True)
             return None
 
         return {
             **credentials,
-            # env > YAML, matches client-side Layer 1 priority
-            "Endpoint": env_vars.ROCK_OSS_BUCKET_ENDPOINT or self.oss_config.endpoint or None,
-            "Bucket": env_vars.ROCK_OSS_BUCKET_NAME or self.oss_config.bucket or None,
-            "Region": env_vars.ROCK_OSS_BUCKET_REGION or None,
+            "Endpoint": endpoint,
+            "Bucket": bucket,
+            "Region": region,
+            "Prefix": prefix,  # transfer-object key prefix, scoped per account
         }
 
     async def get_sandbox_websocket_url(

--- a/rock/sdk/sandbox/oss_client.py
+++ b/rock/sdk/sandbox/oss_client.py
@@ -36,6 +36,7 @@ class OssClientConfig:
     bucket: str
     region: str
     enabled_via_env: bool  # True = Layer 1 (gated by ROCK_OSS_ENABLE); False = Layer 2
+    prefix: str = ""  # Transfer-object key prefix (Layer 1 from env; Layer 2 from server response)
 
 
 class OssClient:
@@ -49,13 +50,22 @@ class OssClient:
         self._pending_persistence_tasks: set[asyncio.Task] = set()
 
     @staticmethod
-    def _compute_object_name(sandbox_id: str, local_path: str, sandbox_path: str) -> str:
+    def _compute_object_name(
+        sandbox_id: str,
+        local_path: str,
+        sandbox_path: str,
+        prefix: str | None = None,  # NEW: server-pushed transfer prefix (e.g. "rock-transfer/")
+    ) -> str:
         # Prefer sandbox basename: the OSS object mirrors a sandbox-side file,
         # so naming it after the sandbox path keeps OSS-side names meaningful
         # even when local destinations differ (e.g. download to a renamed file).
         payload = f"{sandbox_id}|{local_path}|{sandbox_path}"
         digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
         filename = Path(sandbox_path).name or Path(local_path).name
+        # Honor server-pushed Prefix so chatos-rock's rock-transfer/ lifecycle catches the object.
+        clean_prefix = (prefix or "").strip("/")
+        if clean_prefix:
+            return f"{clean_prefix}/{digest}-{filename}"
         return f"{digest}-{filename}"
 
     @staticmethod
@@ -70,6 +80,7 @@ class OssClient:
                 bucket=env_bucket,
                 region=env_region,
                 enabled_via_env=True,
+                prefix=env_vars.ROCK_OSS_TRANSFER_PREFIX or "",  # NEW: env can carry prefix too
             )
 
         # Layer 2: server response (fallback default)
@@ -82,6 +93,7 @@ class OssClient:
                 bucket=resp_bucket,
                 region=resp_region,
                 enabled_via_env=False,
+                prefix=sts_response.get("Prefix") or "",  # NEW: pull prefix from server
             )
 
         # Layer 3: OSS unavailable
@@ -96,7 +108,7 @@ class OssClient:
 
         Side effect: caches Expiration in self._token_expire_time.
         """
-        url = f"{self._sandbox._url}/get_token"
+        url = f"{self._sandbox._url}/get_token?account=primary"
         headers = self._sandbox._build_headers()
         response = await HttpUtils.get(url, headers)
         if response["status"] != "Success":
@@ -183,6 +195,7 @@ class OssClient:
             sandbox_id=self._sandbox.sandbox_id,
             local_path=file_path,
             sandbox_path=target_path,
+            prefix=self._client_config.prefix if self._client_config else None,  # NEW
         )
 
         try:
@@ -260,6 +273,7 @@ class OssClient:
             sandbox_id=self._sandbox.sandbox_id,
             local_path=str(local_path),
             sandbox_path=remote_path,
+            prefix=self._client_config.prefix if self._client_config else None,
         )
         oss_url = f"oss://{self._client_config.bucket}/{oss_object_name}"
 
@@ -309,6 +323,7 @@ class OssClient:
             sandbox_id=self._sandbox.sandbox_id,
             local_path=local_path,
             sandbox_path=sandbox_path,
+            prefix=self._client_config.prefix if self._client_config else None,
         )
         task = asyncio.create_task(self._persist_to_oss(local_path, oss_object_name))
         self._pending_persistence_tasks.add(task)

--- a/tests/unit/sandbox/test_sandbox_proxy.py
+++ b/tests/unit/sandbox/test_sandbox_proxy.py
@@ -95,7 +95,8 @@ class TestGenOssStsToken:
         # (which requires real Redis / metrics / RAM-Acs client setup).
         service = SandboxProxyService.__new__(SandboxProxyService)
         service.oss_config = OssConfig(role_arn="test_role_arn")
-        service.sts_client = MagicMock()
+        # gen_oss_sts_token routes by account name; legacy is the default.
+        service._sts_clients = {"legacy": MagicMock(), "primary": MagicMock()}
         return service
 
     def test_success_returns_dict_with_extra_fields(self, sandbox_proxy_service):
@@ -107,7 +108,7 @@ class TestGenOssStsToken:
             b'"SecurityToken":"tok","Expiration":"2099-01-01T00:00:00Z"}}'
         )
         with (
-            patch.object(sandbox_proxy_service.sts_client, "do_action_with_exception", return_value=fake_token_body),
+            patch.object(sandbox_proxy_service._sts_clients["legacy"], "do_action_with_exception", return_value=fake_token_body),
             patch("rock.sandbox.service.sandbox_proxy_service.env_vars") as mock_env,
         ):
             mock_env.ROCK_OSS_BUCKET_ENDPOINT = ""
@@ -122,7 +123,7 @@ class TestGenOssStsToken:
 
     def test_sts_failure_returns_none(self, sandbox_proxy_service):
         with patch.object(
-            sandbox_proxy_service.sts_client, "do_action_with_exception", side_effect=Exception("sts fail")
+            sandbox_proxy_service._sts_clients["legacy"], "do_action_with_exception", side_effect=Exception("sts fail")
         ):
             result = sandbox_proxy_service.gen_oss_sts_token()
         assert result is None
@@ -137,7 +138,7 @@ class TestGenOssStsToken:
             b'"SecurityToken":"tok","Expiration":"2099-01-01T00:00:00Z"}}'
         )
         with (
-            patch.object(sandbox_proxy_service.sts_client, "do_action_with_exception", return_value=fake_token_body),
+            patch.object(sandbox_proxy_service._sts_clients["legacy"], "do_action_with_exception", return_value=fake_token_body),
             patch("rock.sandbox.service.sandbox_proxy_service.env_vars") as mock_env,
         ):
             mock_env.ROCK_OSS_BUCKET_ENDPOINT = ""
@@ -160,7 +161,7 @@ class TestGenOssStsToken:
             b'"SecurityToken":"tok","Expiration":"2099-01-01T00:00:00Z"}}'
         )
         with (
-            patch.object(sandbox_proxy_service.sts_client, "do_action_with_exception", return_value=fake_token_body),
+            patch.object(sandbox_proxy_service._sts_clients["legacy"], "do_action_with_exception", return_value=fake_token_body),
             patch("rock.sandbox.service.sandbox_proxy_service.env_vars") as mock_env,
         ):
             mock_env.ROCK_OSS_BUCKET_ENDPOINT = "env.endpoint"
@@ -183,7 +184,7 @@ class TestGenOssStsToken:
             b'"SecurityToken":"tok","Expiration":"2099-01-01T00:00:00Z"}}'
         )
         with (
-            patch.object(sandbox_proxy_service.sts_client, "do_action_with_exception", return_value=fake_token_body),
+            patch.object(sandbox_proxy_service._sts_clients["legacy"], "do_action_with_exception", return_value=fake_token_body),
             patch("rock.sandbox.service.sandbox_proxy_service.env_vars") as mock_env,
         ):
             mock_env.ROCK_OSS_BUCKET_ENDPOINT = ""

--- a/tests/unit/sandbox/test_sts_dual_account.py
+++ b/tests/unit/sandbox/test_sts_dual_account.py
@@ -1,0 +1,235 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from rock.config import (
+    OssAccountConfig,
+    OssConfig,
+    ProxyServiceConfig,
+    RockConfig,
+    RuntimeConfig,
+)
+from rock.sandbox.service.sandbox_proxy_service import SandboxProxyService
+
+
+def _make_rock_config(
+    *,
+    legacy_role: str,
+    primary_role: str,
+    legacy_region: str = "cn-hangzhou",
+    transfer_prefix: str = "rock-transfer/",
+) -> RockConfig:
+    return RockConfig(
+        oss=OssConfig(
+            endpoint="oss-cn-hangzhou.aliyuncs.com",
+            bucket="xrl-sandbox",
+            access_key_id="legacy-ak",
+            access_key_secret="legacy-sk",
+            role_arn=legacy_role,
+            region=legacy_region,
+            transfer_prefix=transfer_prefix,
+            primary=OssAccountConfig(
+                endpoint="oss-cn-hangzhou.aliyuncs.com",
+                bucket="chatos-rock",
+                access_key_id="primary-ak",
+                access_key_secret="primary-sk",
+                role_arn=primary_role,
+                region="cn-hangzhou",
+            ),
+        ),
+        proxy_service=ProxyServiceConfig(),
+        runtime=RuntimeConfig(
+            python_env_path="/usr/bin/python3",
+            envhub_db_url="sqlite:////tmp/rock_envs.db",
+        ),
+    )
+
+
+def _fake_assume(ak: str, sk: str, tok: str):
+    def _do(req):
+        return json.dumps(
+            {
+                "Credentials": {
+                    "AccessKeyId": ak,
+                    "AccessKeySecret": sk,
+                    "SecurityToken": tok,
+                    "Expiration": "2099-01-01T00:00:00Z",
+                }
+            }
+        ).encode()
+
+    return _do
+
+
+def _build_service(rock_config: RockConfig) -> SandboxProxyService:
+    # Each AcsClient() call returns a fresh MagicMock so legacy/primary clients
+    # are not aliased — otherwise per-account fakes would leak across accounts.
+    with patch(
+        "rock.sandbox.service.sandbox_proxy_service.client.AcsClient",
+        side_effect=lambda *a, **kw: MagicMock(),
+    ):
+        return SandboxProxyService(rock_config, meta_store=MagicMock())
+
+
+def test_legacy_account_uses_legacy_role_and_bucket():
+    svc = _build_service(
+        _make_rock_config(
+            legacy_role="acs:ram::1933967579503727:role/legacy-role",
+            primary_role="acs:ram::1771269394322852:role/chatos-rock-sts-role",
+        )
+    )
+    svc._sts_clients["legacy"].do_action_with_exception = _fake_assume("L-AK", "L-SK", "L-TOK")
+    svc._sts_clients["primary"].do_action_with_exception = _fake_assume("P-AK", "P-SK", "P-TOK")
+
+    creds = svc.gen_oss_sts_token()  # default account="legacy"
+    assert creds["AccessKeyId"] == "L-AK"
+    assert creds["Bucket"] == "xrl-sandbox"
+    assert creds["Prefix"] is None
+
+
+def test_primary_account_uses_primary_role_and_bucket_with_prefix():
+    svc = _build_service(
+        _make_rock_config(
+            legacy_role="acs:ram::1933967579503727:role/legacy-role",
+            primary_role="acs:ram::1771269394322852:role/chatos-rock-sts-role",
+        )
+    )
+    svc._sts_clients["legacy"].do_action_with_exception = _fake_assume("L-AK", "L-SK", "L-TOK")
+    svc._sts_clients["primary"].do_action_with_exception = _fake_assume("P-AK", "P-SK", "P-TOK")
+
+    creds = svc.gen_oss_sts_token(account="primary")
+    assert creds["AccessKeyId"] == "P-AK"
+    assert creds["Bucket"] == "chatos-rock"
+    assert creds["Prefix"] == "rock-transfer/"
+
+
+def test_primary_returns_none_when_role_arn_empty():
+    svc = _build_service(
+        _make_rock_config(
+            legacy_role="acs:ram::1933967579503727:role/legacy-role",
+            primary_role="",
+        )
+    )
+    assert svc.gen_oss_sts_token(account="primary") is None
+
+
+def test_primary_prefix_is_none_when_yaml_does_not_set_it():
+    svc = _build_service(
+        _make_rock_config(
+            legacy_role="acs:ram::1933967579503727:role/legacy-role",
+            primary_role="acs:ram::1771269394322852:role/chatos-rock-sts-role",
+            transfer_prefix="",
+        )
+    )
+    svc._sts_clients["primary"].do_action_with_exception = _fake_assume("P-AK", "P-SK", "P-TOK")
+    creds = svc.gen_oss_sts_token(account="primary")
+    assert creds["Prefix"] is None
+
+
+def test_unknown_account_returns_none():
+    svc = _build_service(
+        _make_rock_config(
+            legacy_role="acs:ram::1933967579503727:role/legacy-role",
+            primary_role="acs:ram::1771269394322852:role/chatos-rock-sts-role",
+        )
+    )
+    assert svc.gen_oss_sts_token(account="bogus") is None
+
+
+def test_legacy_prefix_falls_back_to_env(monkeypatch):
+    monkeypatch.setenv("ROCK_OSS_TRANSFER_PREFIX", "legacy-pref/")
+    svc = _build_service(
+        _make_rock_config(
+            legacy_role="acs:ram::1933967579503727:role/legacy-role",
+            primary_role="acs:ram::1771269394322852:role/chatos-rock-sts-role",
+        )
+    )
+    svc._sts_clients["legacy"].do_action_with_exception = _fake_assume("L-AK", "L-SK", "L-TOK")
+    creds = svc.gen_oss_sts_token()
+    assert creds["Prefix"] == "legacy-pref/"  # env wins for legacy
+
+
+def test_assume_role_session_names_are_distinct():
+    svc = _build_service(
+        _make_rock_config(
+            legacy_role="acs:ram::1933967579503727:role/legacy-role",
+            primary_role="acs:ram::1771269394322852:role/chatos-rock-sts-role",
+        )
+    )
+    captured: dict[str, dict] = {}
+
+    def capture(label: str):
+        def _do(req):
+            captured[label] = dict(req.get_query_params())
+            return json.dumps(
+                {
+                    "Credentials": {
+                        "AccessKeyId": "x",
+                        "AccessKeySecret": "y",
+                        "SecurityToken": "z",
+                        "Expiration": "2099-01-01T00:00:00Z",
+                    }
+                }
+            ).encode()
+
+        return _do
+
+    svc._sts_clients["legacy"].do_action_with_exception = capture("legacy")
+    svc._sts_clients["primary"].do_action_with_exception = capture("primary")
+    svc.gen_oss_sts_token(account="legacy")
+    svc.gen_oss_sts_token(account="primary")
+
+    assert captured["legacy"]["RoleSessionName"] == "rock-sandbox-legacy"
+    assert captured["primary"]["RoleSessionName"] == "rock-sandbox-primary"
+    assert captured["legacy"]["RoleArn"] == "acs:ram::1933967579503727:role/legacy-role"
+    assert captured["primary"]["RoleArn"] == "acs:ram::1771269394322852:role/chatos-rock-sts-role"
+
+
+def test_legacy_region_from_yaml_overrides_env(monkeypatch):
+    monkeypatch.setenv("ROCK_OSS_BUCKET_REGION", "cn-shanghai")
+    captured: list[tuple[str, str]] = []
+
+    def fake_acs_client(ak, sk, region):
+        captured.append((ak, region))
+        return MagicMock()
+
+    with patch(
+        "rock.sandbox.service.sandbox_proxy_service.client.AcsClient",
+        side_effect=fake_acs_client,
+    ):
+        SandboxProxyService(
+            _make_rock_config(
+                legacy_role="acs:ram::1933967579503727:role/legacy-role",
+                primary_role="acs:ram::1771269394322852:role/chatos-rock-sts-role",
+                legacy_region="cn-hangzhou",
+            ),
+            meta_store=MagicMock(),
+        )
+
+    legacy_ak, legacy_region = captured[0]
+    assert legacy_ak == "legacy-ak"
+    assert legacy_region == "cn-hangzhou"  # yaml won
+
+
+def test_legacy_region_falls_back_to_env_when_yaml_empty(monkeypatch):
+    monkeypatch.setenv("ROCK_OSS_BUCKET_REGION", "cn-shanghai")
+    captured: list[tuple[str, str]] = []
+
+    def fake_acs_client(ak, sk, region):
+        captured.append((ak, region))
+        return MagicMock()
+
+    with patch(
+        "rock.sandbox.service.sandbox_proxy_service.client.AcsClient",
+        side_effect=fake_acs_client,
+    ):
+        SandboxProxyService(
+            _make_rock_config(
+                legacy_role="acs:ram::1933967579503727:role/legacy-role",
+                primary_role="acs:ram::1771269394322852:role/chatos-rock-sts-role",
+                legacy_region="",
+            ),
+            meta_store=MagicMock(),
+        )
+
+    legacy_ak, legacy_region = captured[0]
+    assert legacy_region == "cn-shanghai"  # env fallback

--- a/tests/unit/sdk/sandbox/test_oss_client.py
+++ b/tests/unit/sdk/sandbox/test_oss_client.py
@@ -490,3 +490,35 @@ class TestCloseAwaitsPendingTasks:
         with patch("asyncio.to_thread", new=hang):
             await client.schedule_async_persistence("/local/foo.json", "/sandbox/foo.json")
             await client.close(timeout=0.05)
+
+
+# prefix propagation
+def test_compute_object_name_with_prefix():
+    name = OssClient._compute_object_name(
+        sandbox_id="sb-1",
+        local_path="/tmp/x",
+        sandbox_path="/data/x",
+        prefix="rock-transfer/",
+    )
+    assert name.startswith("rock-transfer/")
+    assert name.endswith("-x")
+
+
+def test_compute_object_name_strips_slashes_in_prefix():
+    name = OssClient._compute_object_name(
+        sandbox_id="sb-1",
+        local_path="/tmp/x",
+        sandbox_path="/data/x",
+        prefix="/rock-transfer//",
+    )
+    assert name.startswith("rock-transfer/")
+    assert "//" not in name
+
+
+def test_compute_object_name_no_prefix_keeps_legacy_layout():
+    name = OssClient._compute_object_name(
+        sandbox_id="sb-1",
+        local_path="/tmp/x",
+        sandbox_path="/data/x",
+    )
+    assert "/" not in name  # flat layout

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -48,3 +48,36 @@ async def test_runtime_config():
     assert runtime_config.max_allowed_spec.cpus == 16
     assert runtime_config.standard_spec.memory == "8g"
     assert runtime_config.standard_spec.cpus == 2
+
+
+def test_oss_config_defaults():
+    from rock.config import OssAccountConfig, OssConfig
+
+    cfg = OssConfig()
+    assert cfg.bucket == ""
+    assert cfg.region == ""
+    assert cfg.transfer_prefix == ""  # default is now empty; deployments must opt-in via YAML
+    assert isinstance(cfg.primary, OssAccountConfig)
+    assert cfg.primary.bucket == ""
+    assert cfg.primary.region == ""
+
+
+def test_oss_config_primary_dict_coerced():
+    from rock.config import OssAccountConfig, OssConfig
+
+    cfg = OssConfig(
+        primary={
+            "endpoint": "e",
+            "bucket": "chatos-rock",
+            "access_key_id": "a",
+            "access_key_secret": "s",
+            "role_arn": "r",
+            "region": "cn-hangzhou",
+        }
+    )
+    assert isinstance(cfg.primary, OssAccountConfig)
+    assert cfg.primary.bucket == "chatos-rock"
+    assert cfg.primary.region == "cn-hangzhou"
+    # legacy 顶层字段未提供时仍为默认空,确认 primary 不会污染 legacy
+    assert cfg.bucket == ""
+


### PR DESCRIPTION
## Summary

Add dual-account OSS support for host↔container file transfers:
- New `OssAccountConfig` + `OssConfig.primary` sub-config for the primary account
- New admin endpoint `GET /sandbox_proxy/get_token_v2` returning STS scoped to the primary account
- SDK now calls `/get_token_v2` by default; `_build_transfer_object_name()` helper adds `ROCK_OSS_TRANSFER_PREFIX` to isolate transfer objects
- Legacy `/get_token` preserved for SDK < 1.8, with deprecation warning

## Key Design Decisions

1. **Backward compatible**: legacy `OssConfig` top-level fields unchanged; old YAMLs load without modification
2. **xrl package not modified**: internal users must manually `export ROCK_OSS_BUCKET_NAME + `ROCK_OSS_TRANSFER_PREFIX` when upgrading to SDK >= 1.8
3. **Open-source users unaffected**: `ROCK_OSS_ENABLE` defaults to `false`; users who don't enable OSS see zero changes
4. **Fail-safe**: if `oss.primary.role_arn` is empty, v2 STS returns `None` gracefully (no crash)

## Changed Files

- `rock/config.py` — new `OssAccountConfig` dataclass + `OssConfig` gains `primary`, `transfer_prefix`, `region`
- `rock/env_vars.py` — new `ROCK_OSS_TRANSFER_PREFIX` env var
- `rock/admin/entrypoints/sandbox_proxy_api.py` — new `/get_token_v2` route
- `rock/sandbox/service/sandbox_proxy_service.py` — dual STS clients + `gen_oss_sts_token_v2` + `_assume_role` helper
- `rock/sdk/sandbox/client.py` — SDK calls v2, new `_build_transfer_object_name` helper
- `rock/sdk/sandbox/file_system.py` — reuse transfer object name helper
- `tests/unit/sandbox/test_sts_dual_account.py` — 6 new tests covering dual-account STS

## Test Plan

- [x] `uv run pytest tests/unit/test_config.py tests/unit/sandbox/test_sts_dual_account.py -v`
- [ ] Deploy to dev cluster → verify `/get_token` returns legacy STS + deprecation log
- [ ] Verify `/get_token_v2` returns primary STS
- [ ] Verify SDK upload writes to `chatos-rock/rock-transfer/{ts}-{file}`
- [ ] Verify old SDK (< 1.8) still works via `/get_token` + `xrl-sandbox`

Fixes #952