### PR TITLE
feature(oss): add archive command builder + OSS config fields for sandbox log archival

### DIFF
--- a/rock/config.py
+++ b/rock/config.py
@@ -100,6 +100,25 @@ class OssConfig:
     process env. xrl package is no longer maintained, so internal users
     must export this env var themselves when upgrading to SDK >= 1.8."""
 
+    archive_prefix: str = ""
+    """OSS object key prefix under the PRIMARY bucket for sandbox-log
+    archives. Empty (default) means each deployment's YAML must opt-in
+    explicitly to a value matching its OSS bucket lifecycle rule (e.g.
+    "rock-archives/")."""
+
+    archive_ttl_days: int = 30
+    """OSS-side lifecycle expiration days for archives. Audit-only:
+    ROCK does not enforce TTL itself; the bucket lifecycle rule on
+    `archive_prefix` is the source of truth."""
+
+    keep_days_before_archive: int = 3
+    """Days to wait after sandbox stop before archiving. Gives
+    operators a short investigation window without bloating disk."""
+
+    archive_max_attempts: int = 3
+    """Max retry attempts before giving up archival and degrading
+    to KEEP (FileCleanupTask is the eventual janitor)."""
+
     def __post_init__(self):
         # Allow YAML to pass a dict for `primary` (dataclass deserialization
         # from yaml.safe_load returns dicts, not nested dataclasses).

--- a/rock/config.py
+++ b/rock/config.py
@@ -53,11 +53,69 @@ class RedisConfig:
 
 
 @dataclass
+class SandboxLogConfig:
+    """Policy for archiving stopped-sandbox log directories to OSS.
+
+    Lives under SandboxConfig.log: the fields are domain knobs of "what to do
+    with stopped sandbox logs" — when to archive, how many retries, what OSS
+    key prefix to use — colocated with other sandbox lifecycle / cleanup
+    policy (image_keep_patterns, remove_container_enabled). OSS endpoint /
+    bucket / credentials still belong to OssConfig.primary.
+    """
+
+    archive_prefix: str = ""
+    """OSS object key prefix under OssConfig.primary.bucket for sandbox-log
+    archives. Empty (default) means each deployment's YAML must opt-in
+    explicitly to a value matching its OSS bucket lifecycle rule (e.g.
+    "rock-archives/")."""
+
+    keep_days_before_archive: int = 3
+    """Days to wait after sandbox stop before archiving. Gives operators
+    a short investigation window without bloating disk."""
+
+    archive_max_attempts: int = 3
+    """Max retry attempts before giving up archival and degrading to KEEP
+    (FileCleanupTask is the eventual janitor)."""
+
+
+@dataclass
+class SandboxFileTransferConfig:
+    """Policy for sandbox <-> host file transfer via OSS as intermediary.
+
+    Lives under SandboxConfig.file_transfer: the prefix governs where the
+    SDK puts ephemeral transfer objects under OssConfig.primary.bucket,
+    a sandbox-side concern not OSS connectivity.
+    """
+
+    prefix: str = ""
+    """Prefix under OssConfig.primary.bucket for ephemeral host↔container
+    file transfers ({timestamp}-{filename} objects). The legacy bucket keeps
+    its pre-existing flat layout (no prefix) for backward compatibility —
+    xrl-sandbox has a 3-day lifecycle rule at bucket root (configured in
+    the Aliyun OSS console, not in repo) that we do not disturb.
+
+    Note: this field lives in admin-side RockConfig and is NOT what the SDK
+    reads. The SDK reads ROCK_OSS_TRANSFER_PREFIX directly from the process
+    env. xrl package is no longer maintained, so internal users must export
+    this env var themselves when upgrading to SDK >= 1.8."""
+
+
+@dataclass
 class SandboxConfig:
     actor_resource: str = ""
     actor_resource_num: float = 0.0
     gateway_num: int = 1
     remove_container_enabled: bool = True
+    log: SandboxLogConfig = field(default_factory=SandboxLogConfig)
+    file_transfer: SandboxFileTransferConfig = field(default_factory=SandboxFileTransferConfig)
+
+    def __post_init__(self):
+        # Allow YAML to pass dicts for nested dataclasses (yaml.safe_load
+        # returns dicts, not nested dataclass instances).
+        if isinstance(self.log, dict):
+            self.log = SandboxLogConfig(**self.log)
+        if isinstance(self.file_transfer, dict):
+            self.file_transfer = SandboxFileTransferConfig(**self.file_transfer)
 
 
 @dataclass
@@ -87,32 +145,6 @@ class OssConfig:
     """Primary account used by SDK >= 1.8 (`/get_token?account=primary`) and by
     host-side archival. An empty `primary.bucket` disables v2 STS and archival,
     leaving legacy path fully operational."""
-
-    transfer_prefix: str = ""
-    """Prefix under the PRIMARY bucket for ephemeral host↔container file
-    transfers ({timestamp}-{filename} objects). The legacy bucket keeps
-    its pre-existing flat layout (no prefix) for backward compatibility —
-    xrl-sandbox has a 3-day lifecycle rule at bucket root (configured
-    in the Aliyun OSS console, not in repo) that we do not disturb.
-
-    Note: this field lives in admin-side RockConfig and is NOT what the
-    SDK reads. The SDK reads ROCK_OSS_TRANSFER_PREFIX directly from the
-    process env. xrl package is no longer maintained, so internal users
-    must export this env var themselves when upgrading to SDK >= 1.8."""
-
-    archive_prefix: str = ""
-    """OSS object key prefix under the PRIMARY bucket for sandbox-log
-    archives. Empty (default) means each deployment's YAML must opt-in
-    explicitly to a value matching its OSS bucket lifecycle rule (e.g.
-    "rock-archives/")."""
-
-    keep_days_before_archive: int = 3
-    """Days to wait after sandbox stop before archiving. Gives
-    operators a short investigation window without bloating disk."""
-
-    archive_max_attempts: int = 3
-    """Max retry attempts before giving up archival and degrading
-    to KEEP (FileCleanupTask is the eventual janitor)."""
 
     def __post_init__(self):
         # Allow YAML to pass a dict for `primary` (dataclass deserialization

--- a/rock/config.py
+++ b/rock/config.py
@@ -106,11 +106,6 @@ class OssConfig:
     explicitly to a value matching its OSS bucket lifecycle rule (e.g.
     "rock-archives/")."""
 
-    archive_ttl_days: int = 30
-    """OSS-side lifecycle expiration days for archives. Audit-only:
-    ROCK does not enforce TTL itself; the bucket lifecycle rule on
-    `archive_prefix` is the source of truth."""
-
     keep_days_before_archive: int = 3
     """Days to wait after sandbox stop before archiving. Gives
     operators a short investigation window without bloating disk."""

--- a/rock/sandbox/service/sandbox_proxy_service.py
+++ b/rock/sandbox/service/sandbox_proxy_service.py
@@ -686,12 +686,17 @@ class SandboxProxyService:
         self, account: str = "legacy"
     ) -> dict | None:  # CHANGED: account param, default "legacy" preserves BC
         """Generate STS credentials and OSS config for the given account.
+
+        Returns ONLY OSS connectivity / account-scoped config. Sandbox-side
+        domain policy (e.g. archive prefix, retry counts) does NOT belong here
+        and must be fetched from a separate endpoint when a client needs it.
+
         Args:
             account: "legacy" (xrl-sandbox, BC for SDK < 1.8) or
                      "primary" (chatos-rock, SDK >= 1.8).
         Returns:
             Dict with STS credentials (AccessKeyId, AccessKeySecret, SecurityToken, Expiration) PLUS account-scoped OSS config:
-            Endpoint, Bucket, Region, Prefix (transfer/upload prefix), ArchivePrefix (recovery prefix used by `rock storage get`).
+            Endpoint, Bucket, Region, Prefix (transfer/upload prefix).
             None on failure or when the requested account is unconfigured.
         """
         if account not in self._sts_clients:
@@ -739,10 +744,6 @@ class SandboxProxyService:
             "Bucket": bucket,
             "Region": region,
             "Prefix": prefix,  # transfer-object key prefix, scoped per account
-            # ArchivePrefix is the same across both accounts (it lives on the dedicated
-            # SandboxLogConfig under SandboxConfig.log, not per-OSS-account). Letting
-            # the client pull it from STS lets `rock storage get` skip --archive-prefix.
-            "ArchivePrefix": self._rock_config.sandbox_config.log.archive_prefix or None,
         }
 
     async def get_sandbox_websocket_url(

--- a/rock/sandbox/service/sandbox_proxy_service.py
+++ b/rock/sandbox/service/sandbox_proxy_service.py
@@ -682,14 +682,17 @@ class SandboxProxyService:
         port = service_status.get_mapped_port(Port.PROXY)
         return f"http://{host_ip}:{port}"
 
-    def gen_oss_sts_token(self, account: str = "legacy") -> dict | None:  # CHANGED: account param, default "legacy" preserves BC
+    def gen_oss_sts_token(
+        self, account: str = "legacy"
+    ) -> dict | None:  # CHANGED: account param, default "legacy" preserves BC
         """Generate STS credentials and OSS config for the given account.
         Args:
             account: "legacy" (xrl-sandbox, BC for SDK < 1.8) or
                      "primary" (chatos-rock, SDK >= 1.8).
         Returns:
             Dict with STS credentials (AccessKeyId, AccessKeySecret, SecurityToken, Expiration) PLUS account-scoped OSS config:
-            Endpoint, Bucket, Region, Prefix. None on failure or when the requested account is unconfigured.
+            Endpoint, Bucket, Region, Prefix (transfer/upload prefix), ArchivePrefix (recovery prefix used by `rock storage get`).
+            None on failure or when the requested account is unconfigured.
         """
         if account not in self._sts_clients:
             logger.error(f"unknown OSS account: {account!r}")
@@ -736,6 +739,9 @@ class SandboxProxyService:
             "Bucket": bucket,
             "Region": region,
             "Prefix": prefix,  # transfer-object key prefix, scoped per account
+            # ArchivePrefix is the same across both accounts (it lives on oss_config root, not per-account).
+            # Letting the client pull it from STS lets `rock storage get` skip --archive-prefix.
+            "ArchivePrefix": self.oss_config.archive_prefix or None,
         }
 
     async def get_sandbox_websocket_url(

--- a/rock/sandbox/service/sandbox_proxy_service.py
+++ b/rock/sandbox/service/sandbox_proxy_service.py
@@ -705,7 +705,7 @@ class SandboxProxyService:
             endpoint = primary.endpoint or None
             bucket = primary.bucket or None
             region = primary.region or env_vars.ROCK_OSS_BUCKET_REGION or None
-            prefix = self.oss_config.transfer_prefix or None
+            prefix = self._rock_config.sandbox_config.file_transfer.prefix or None
         else:  # legacy
             role_arn = self.oss_config.role_arn
             session_name = "rock-sandbox-legacy"
@@ -739,9 +739,10 @@ class SandboxProxyService:
             "Bucket": bucket,
             "Region": region,
             "Prefix": prefix,  # transfer-object key prefix, scoped per account
-            # ArchivePrefix is the same across both accounts (it lives on oss_config root, not per-account).
-            # Letting the client pull it from STS lets `rock storage get` skip --archive-prefix.
-            "ArchivePrefix": self.oss_config.archive_prefix or None,
+            # ArchivePrefix is the same across both accounts (it lives on the dedicated
+            # SandboxLogConfig under SandboxConfig.log, not per-OSS-account). Letting
+            # the client pull it from STS lets `rock storage get` skip --archive-prefix.
+            "ArchivePrefix": self._rock_config.sandbox_config.log.archive_prefix or None,
         }
 
     async def get_sandbox_websocket_url(

--- a/rock/utils/archive_command.py
+++ b/rock/utils/archive_command.py
@@ -8,6 +8,7 @@ string), so they never appear in `ps` argv output.
 """
 
 import shlex
+import textwrap
 from pathlib import Path
 
 
@@ -49,18 +50,23 @@ class ArchiveCommand:
         The scratch dir is removed via ``trap EXIT`` regardless of outcome.
         """
         log_path = Path(log_dir)
-        parent = str(log_path.parent)
-        name = log_path.name
-        oss_url = f"oss://{bucket}/{oss_key}"
-        return (
-            "set -e && "
-            "ARCHIVE_DIR=$(mktemp -d -t sb-archive-XXXXXX) && "
-            "trap 'rm -rf \"$ARCHIVE_DIR\"' EXIT && "
-            "umask 077 && "
-            "printf '[Credentials]\\nlanguage=EN\\nendpoint=%s\\naccessKeyID=%s\\naccessKeySecret=%s\\n' "
-            f'{shlex.quote(endpoint)} "$OSS_ACCESS_KEY_ID" "$OSS_ACCESS_KEY_SECRET" '
-            '> "$ARCHIVE_DIR/ossconfig" && '
-            f'tar -czf "$ARCHIVE_DIR/archive.tar.gz" -C {shlex.quote(parent)} {shlex.quote(name)} && '
-            f'ossutil cp -c "$ARCHIVE_DIR/ossconfig" -f "$ARCHIVE_DIR/archive.tar.gz" {shlex.quote(oss_url)} && '
-            f"rm -rf {shlex.quote(log_dir)}"
+        parent = shlex.quote(str(log_path.parent))
+        name = shlex.quote(log_path.name)
+        endpoint_q = shlex.quote(endpoint)
+        oss_url_q = shlex.quote(f"oss://{bucket}/{oss_key}")
+        log_dir_q = shlex.quote(log_dir)
+        # textwrap.dedent strips the common leading whitespace so the source can be
+        # indented for readability without polluting the emitted shell string.
+        return textwrap.dedent(
+            f"""\
+            set -e \\
+            && ARCHIVE_DIR=$(mktemp -d -t sb-archive-XXXXXX) \\
+            && trap 'rm -rf "$ARCHIVE_DIR"' EXIT \\
+            && umask 077 \\
+            && printf '[Credentials]\\nlanguage=EN\\nendpoint=%s\\naccessKeyID=%s\\naccessKeySecret=%s\\n' \\
+            {endpoint_q} "$OSS_ACCESS_KEY_ID" "$OSS_ACCESS_KEY_SECRET" \\
+            > "$ARCHIVE_DIR/ossconfig" \\
+            && tar -czf "$ARCHIVE_DIR/archive.tar.gz" -C {parent} {name} \\
+            && ossutil cp -c "$ARCHIVE_DIR/ossconfig" -f "$ARCHIVE_DIR/archive.tar.gz" {oss_url_q} \\
+            && rm -rf {log_dir_q}"""
         )

--- a/rock/utils/archive_command.py
+++ b/rock/utils/archive_command.py
@@ -23,19 +23,35 @@ def build_sandbox_log_key(sandbox_id: str, prefix: str = "") -> str:
 
 
 def build_archive_command(log_dir: str, oss_key: str, bucket: str, endpoint: str) -> str:
-    """Build the bash one-liner that tar+gzips ``log_dir`` and streams to OSS.
+    """Build the bash one-liner that tar+gzips ``log_dir`` and uploads to OSS.
 
-    On non-zero exit (tar / ossutil failure), the trailing ``rm -rf`` is
-    skipped — caller relies on the exit code to decide retry vs delete.
-    AK/SK come from ``OSS_ACCESS_KEY_ID`` / ``OSS_ACCESS_KEY_SECRET`` env
-    vars set by the caller via ``SandboxCommand.env``.
+    Why a temp-file pipeline instead of ``tar | ossutil cp -``: ossutil
+    1.7.x neither reads ``OSS_ACCESS_KEY_ID`` env vars nor accepts stdin
+    (``-``) as source, so we materialize the tarball under ``mktemp -d``
+    and write a temporary ossutil config carrying the credentials.
+
+    AK/SK still flow via ``OSS_ACCESS_KEY_ID`` / ``OSS_ACCESS_KEY_SECRET``
+    env vars set by the caller via ``SandboxCommand.env`` — they are
+    referenced by name in the command string, never substituted in, so
+    ``ps`` / shell history never sees the literal values.
+
+    ``set -e`` aborts the chain before the final ``rm -rf <log_dir>`` if
+    any step fails, so the caller can rely on the exit code to retry.
+    The scratch dir is removed via ``trap EXIT`` regardless of outcome.
     """
     log_path = Path(log_dir)
     parent = str(log_path.parent)
     name = log_path.name
     oss_url = f"oss://{bucket}/{oss_key}"
     return (
-        f"tar -czf - -C {shlex.quote(parent)} {shlex.quote(name)} "
-        f"| ossutil cp -f - {shlex.quote(oss_url)} --endpoint {shlex.quote(endpoint)} "
-        f"&& rm -rf {shlex.quote(log_dir)}"
+        "set -e && "
+        "ARCHIVE_DIR=$(mktemp -d -t sb-archive-XXXXXX) && "
+        "trap 'rm -rf \"$ARCHIVE_DIR\"' EXIT && "
+        "umask 077 && "
+        "printf '[Credentials]\\nlanguage=EN\\nendpoint=%s\\naccessKeyID=%s\\naccessKeySecret=%s\\n' "
+        f'{shlex.quote(endpoint)} "$OSS_ACCESS_KEY_ID" "$OSS_ACCESS_KEY_SECRET" '
+        '> "$ARCHIVE_DIR/ossconfig" && '
+        f'tar -czf "$ARCHIVE_DIR/archive.tar.gz" -C {shlex.quote(parent)} {shlex.quote(name)} && '
+        f'ossutil cp -c "$ARCHIVE_DIR/ossconfig" -f "$ARCHIVE_DIR/archive.tar.gz" {shlex.quote(oss_url)} && '
+        f"rm -rf {shlex.quote(log_dir)}"
     )

--- a/rock/utils/archive_command.py
+++ b/rock/utils/archive_command.py
@@ -1,4 +1,4 @@
-"""Pure functions for building sandbox-log archive bash commands and OSS keys.
+"""Sandbox-log archive bash command + OSS key builder.
 
 Used by SandboxLogArchiveTask to drive archival via `runtime.execute()` —
 no rocklet endpoint is added; the worker only needs `tar` and `ossutil`.
@@ -11,47 +11,56 @@ import shlex
 from pathlib import Path
 
 
-def build_sandbox_log_key(sandbox_id: str, prefix: str = "") -> str:
-    """Construct the OSS object key for a sandbox-log archive.
+class ArchiveCommand:
+    """Namespace for building sandbox-log archive commands and OSS keys.
 
-    Layout: ``<prefix>sandbox-logs/<sandbox_id>.tar.gz``. ``prefix`` may be
-    empty (flat layout under bucket root) or end with ``/``.
+    Stateless: all methods are `@staticmethod`. Grouped under a class so
+    admin / CLI sides go through one explicit entry point (``ArchiveCommand.build_key``,
+    ``ArchiveCommand.build_command``) and cannot drift on key layout / command shape.
     """
-    cleaned = (prefix or "").strip("/")
-    sub = f"sandbox-logs/{sandbox_id}.tar.gz"
-    return f"{cleaned}/{sub}" if cleaned else sub
 
+    @staticmethod
+    def build_key(sandbox_id: str, prefix: str = "") -> str:
+        """Construct the OSS object key for a sandbox-log archive.
 
-def build_archive_command(log_dir: str, oss_key: str, bucket: str, endpoint: str) -> str:
-    """Build the bash one-liner that tar+gzips ``log_dir`` and uploads to OSS.
+        Layout: ``<prefix>sandbox-logs/<sandbox_id>.tar.gz``. ``prefix`` may be
+        empty (flat layout under bucket root) or end with ``/``.
+        """
+        cleaned = (prefix or "").strip("/")
+        sub = f"sandbox-logs/{sandbox_id}.tar.gz"
+        return f"{cleaned}/{sub}" if cleaned else sub
 
-    Why a temp-file pipeline instead of ``tar | ossutil cp -``: ossutil
-    1.7.x neither reads ``OSS_ACCESS_KEY_ID`` env vars nor accepts stdin
-    (``-``) as source, so we materialize the tarball under ``mktemp -d``
-    and write a temporary ossutil config carrying the credentials.
+    @staticmethod
+    def build_command(log_dir: str, oss_key: str, bucket: str, endpoint: str) -> str:
+        """Build the bash one-liner that tar+gzips ``log_dir`` and uploads to OSS.
 
-    AK/SK still flow via ``OSS_ACCESS_KEY_ID`` / ``OSS_ACCESS_KEY_SECRET``
-    env vars set by the caller via ``SandboxCommand.env`` — they are
-    referenced by name in the command string, never substituted in, so
-    ``ps`` / shell history never sees the literal values.
+        Why a temp-file pipeline instead of ``tar | ossutil cp -``: ossutil
+        1.7.x neither reads ``OSS_ACCESS_KEY_ID`` env vars nor accepts stdin
+        (``-``) as source, so we materialize the tarball under ``mktemp -d``
+        and write a temporary ossutil config carrying the credentials.
 
-    ``set -e`` aborts the chain before the final ``rm -rf <log_dir>`` if
-    any step fails, so the caller can rely on the exit code to retry.
-    The scratch dir is removed via ``trap EXIT`` regardless of outcome.
-    """
-    log_path = Path(log_dir)
-    parent = str(log_path.parent)
-    name = log_path.name
-    oss_url = f"oss://{bucket}/{oss_key}"
-    return (
-        "set -e && "
-        "ARCHIVE_DIR=$(mktemp -d -t sb-archive-XXXXXX) && "
-        "trap 'rm -rf \"$ARCHIVE_DIR\"' EXIT && "
-        "umask 077 && "
-        "printf '[Credentials]\\nlanguage=EN\\nendpoint=%s\\naccessKeyID=%s\\naccessKeySecret=%s\\n' "
-        f'{shlex.quote(endpoint)} "$OSS_ACCESS_KEY_ID" "$OSS_ACCESS_KEY_SECRET" '
-        '> "$ARCHIVE_DIR/ossconfig" && '
-        f'tar -czf "$ARCHIVE_DIR/archive.tar.gz" -C {shlex.quote(parent)} {shlex.quote(name)} && '
-        f'ossutil cp -c "$ARCHIVE_DIR/ossconfig" -f "$ARCHIVE_DIR/archive.tar.gz" {shlex.quote(oss_url)} && '
-        f"rm -rf {shlex.quote(log_dir)}"
-    )
+        AK/SK still flow via ``OSS_ACCESS_KEY_ID`` / ``OSS_ACCESS_KEY_SECRET``
+        env vars set by the caller via ``SandboxCommand.env`` — they are
+        referenced by name in the command string, never substituted in, so
+        ``ps`` / shell history never sees the literal values.
+
+        ``set -e`` aborts the chain before the final ``rm -rf <log_dir>`` if
+        any step fails, so the caller can rely on the exit code to retry.
+        The scratch dir is removed via ``trap EXIT`` regardless of outcome.
+        """
+        log_path = Path(log_dir)
+        parent = str(log_path.parent)
+        name = log_path.name
+        oss_url = f"oss://{bucket}/{oss_key}"
+        return (
+            "set -e && "
+            "ARCHIVE_DIR=$(mktemp -d -t sb-archive-XXXXXX) && "
+            "trap 'rm -rf \"$ARCHIVE_DIR\"' EXIT && "
+            "umask 077 && "
+            "printf '[Credentials]\\nlanguage=EN\\nendpoint=%s\\naccessKeyID=%s\\naccessKeySecret=%s\\n' "
+            f'{shlex.quote(endpoint)} "$OSS_ACCESS_KEY_ID" "$OSS_ACCESS_KEY_SECRET" '
+            '> "$ARCHIVE_DIR/ossconfig" && '
+            f'tar -czf "$ARCHIVE_DIR/archive.tar.gz" -C {shlex.quote(parent)} {shlex.quote(name)} && '
+            f'ossutil cp -c "$ARCHIVE_DIR/ossconfig" -f "$ARCHIVE_DIR/archive.tar.gz" {shlex.quote(oss_url)} && '
+            f"rm -rf {shlex.quote(log_dir)}"
+        )

--- a/rock/utils/archive_command.py
+++ b/rock/utils/archive_command.py
@@ -1,0 +1,41 @@
+"""Pure functions for building sandbox-log archive bash commands and OSS keys.
+
+Used by SandboxLogArchiveTask to drive archival via `runtime.execute()` —
+no rocklet endpoint is added; the worker only needs `tar` and `ossutil`.
+
+Credentials must be passed via `SandboxCommand.env` (not in the command
+string), so they never appear in `ps` argv output.
+"""
+
+import shlex
+from pathlib import Path
+
+
+def build_sandbox_log_key(sandbox_id: str, prefix: str = "") -> str:
+    """Construct the OSS object key for a sandbox-log archive.
+
+    Layout: ``<prefix>sandbox-logs/<sandbox_id>.tar.gz``. ``prefix`` may be
+    empty (flat layout under bucket root) or end with ``/``.
+    """
+    cleaned = (prefix or "").strip("/")
+    sub = f"sandbox-logs/{sandbox_id}.tar.gz"
+    return f"{cleaned}/{sub}" if cleaned else sub
+
+
+def build_archive_command(log_dir: str, oss_key: str, bucket: str, endpoint: str) -> str:
+    """Build the bash one-liner that tar+gzips ``log_dir`` and streams to OSS.
+
+    On non-zero exit (tar / ossutil failure), the trailing ``rm -rf`` is
+    skipped — caller relies on the exit code to decide retry vs delete.
+    AK/SK come from ``OSS_ACCESS_KEY_ID`` / ``OSS_ACCESS_KEY_SECRET`` env
+    vars set by the caller via ``SandboxCommand.env``.
+    """
+    log_path = Path(log_dir)
+    parent = str(log_path.parent)
+    name = log_path.name
+    oss_url = f"oss://{bucket}/{oss_key}"
+    return (
+        f"tar -czf - -C {shlex.quote(parent)} {shlex.quote(name)} "
+        f"| ossutil cp -f - {shlex.quote(oss_url)} --endpoint {shlex.quote(endpoint)} "
+        f"&& rm -rf {shlex.quote(log_dir)}"
+    )

--- a/tests/unit/sandbox/test_sandbox_proxy.py
+++ b/tests/unit/sandbox/test_sandbox_proxy.py
@@ -97,6 +97,12 @@ class TestGenOssStsToken:
         service.oss_config = OssConfig(role_arn="test_role_arn")
         # gen_oss_sts_token routes by account name; legacy is the default.
         service._sts_clients = {"legacy": MagicMock(), "primary": MagicMock()}
+        # gen_oss_sts_token reads sandbox_config.log.archive_prefix and
+        # sandbox_config.file_transfer.prefix from rock_config after the
+        # SandboxLogConfig / SandboxFileTransferConfig extraction.
+        service._rock_config = MagicMock()
+        service._rock_config.sandbox_config.log.archive_prefix = ""
+        service._rock_config.sandbox_config.file_transfer.prefix = ""
         return service
 
     def test_success_returns_dict_with_extra_fields(self, sandbox_proxy_service):
@@ -108,7 +114,9 @@ class TestGenOssStsToken:
             b'"SecurityToken":"tok","Expiration":"2099-01-01T00:00:00Z"}}'
         )
         with (
-            patch.object(sandbox_proxy_service._sts_clients["legacy"], "do_action_with_exception", return_value=fake_token_body),
+            patch.object(
+                sandbox_proxy_service._sts_clients["legacy"], "do_action_with_exception", return_value=fake_token_body
+            ),
             patch("rock.sandbox.service.sandbox_proxy_service.env_vars") as mock_env,
         ):
             mock_env.ROCK_OSS_BUCKET_ENDPOINT = ""
@@ -138,7 +146,9 @@ class TestGenOssStsToken:
             b'"SecurityToken":"tok","Expiration":"2099-01-01T00:00:00Z"}}'
         )
         with (
-            patch.object(sandbox_proxy_service._sts_clients["legacy"], "do_action_with_exception", return_value=fake_token_body),
+            patch.object(
+                sandbox_proxy_service._sts_clients["legacy"], "do_action_with_exception", return_value=fake_token_body
+            ),
             patch("rock.sandbox.service.sandbox_proxy_service.env_vars") as mock_env,
         ):
             mock_env.ROCK_OSS_BUCKET_ENDPOINT = ""
@@ -161,7 +171,9 @@ class TestGenOssStsToken:
             b'"SecurityToken":"tok","Expiration":"2099-01-01T00:00:00Z"}}'
         )
         with (
-            patch.object(sandbox_proxy_service._sts_clients["legacy"], "do_action_with_exception", return_value=fake_token_body),
+            patch.object(
+                sandbox_proxy_service._sts_clients["legacy"], "do_action_with_exception", return_value=fake_token_body
+            ),
             patch("rock.sandbox.service.sandbox_proxy_service.env_vars") as mock_env,
         ):
             mock_env.ROCK_OSS_BUCKET_ENDPOINT = "env.endpoint"
@@ -184,7 +196,9 @@ class TestGenOssStsToken:
             b'"SecurityToken":"tok","Expiration":"2099-01-01T00:00:00Z"}}'
         )
         with (
-            patch.object(sandbox_proxy_service._sts_clients["legacy"], "do_action_with_exception", return_value=fake_token_body),
+            patch.object(
+                sandbox_proxy_service._sts_clients["legacy"], "do_action_with_exception", return_value=fake_token_body
+            ),
             patch("rock.sandbox.service.sandbox_proxy_service.env_vars") as mock_env,
         ):
             mock_env.ROCK_OSS_BUCKET_ENDPOINT = ""

--- a/tests/unit/sandbox/test_sandbox_proxy.py
+++ b/tests/unit/sandbox/test_sandbox_proxy.py
@@ -97,11 +97,10 @@ class TestGenOssStsToken:
         service.oss_config = OssConfig(role_arn="test_role_arn")
         # gen_oss_sts_token routes by account name; legacy is the default.
         service._sts_clients = {"legacy": MagicMock(), "primary": MagicMock()}
-        # gen_oss_sts_token reads sandbox_config.log.archive_prefix and
-        # sandbox_config.file_transfer.prefix from rock_config after the
-        # SandboxLogConfig / SandboxFileTransferConfig extraction.
+        # gen_oss_sts_token reads sandbox_config.file_transfer.prefix from
+        # rock_config (primary-account branch) after the SandboxFileTransferConfig
+        # extraction; legacy branch reads ROCK_OSS_TRANSFER_PREFIX env directly.
         service._rock_config = MagicMock()
-        service._rock_config.sandbox_config.log.archive_prefix = ""
         service._rock_config.sandbox_config.file_transfer.prefix = ""
         return service
 

--- a/tests/unit/sandbox/test_sts_dual_account.py
+++ b/tests/unit/sandbox/test_sts_dual_account.py
@@ -17,6 +17,7 @@ def _make_rock_config(
     primary_role: str,
     legacy_region: str = "cn-hangzhou",
     transfer_prefix: str = "rock-transfer/",
+    archive_prefix: str = "rock-archives/",
 ) -> RockConfig:
     return RockConfig(
         oss=OssConfig(
@@ -27,6 +28,7 @@ def _make_rock_config(
             role_arn=legacy_role,
             region=legacy_region,
             transfer_prefix=transfer_prefix,
+            archive_prefix=archive_prefix,
             primary=OssAccountConfig(
                 endpoint="oss-cn-hangzhou.aliyuncs.com",
                 bucket="chatos-rock",
@@ -123,6 +125,39 @@ def test_primary_prefix_is_none_when_yaml_does_not_set_it():
     svc._sts_clients["primary"].do_action_with_exception = _fake_assume("P-AK", "P-SK", "P-TOK")
     creds = svc.gen_oss_sts_token(account="primary")
     assert creds["Prefix"] is None
+
+
+def test_archive_prefix_returned_for_both_accounts():
+    # ArchivePrefix lives on oss_config root (not per-account), so legacy and primary
+    # should both surface the same value — `rock storage get` reads it to skip
+    # --archive-prefix, regardless of which account it queries.
+    svc = _build_service(
+        _make_rock_config(
+            legacy_role="acs:ram::1933967579503727:role/legacy-role",
+            primary_role="acs:ram::1771269394322852:role/chatos-rock-sts-role",
+            archive_prefix="rock-archives/",
+        )
+    )
+    svc._sts_clients["legacy"].do_action_with_exception = _fake_assume("L-AK", "L-SK", "L-TOK")
+    svc._sts_clients["primary"].do_action_with_exception = _fake_assume("P-AK", "P-SK", "P-TOK")
+
+    legacy = svc.gen_oss_sts_token()
+    primary = svc.gen_oss_sts_token(account="primary")
+    assert legacy["ArchivePrefix"] == "rock-archives/"
+    assert primary["ArchivePrefix"] == "rock-archives/"
+
+
+def test_archive_prefix_none_when_yaml_does_not_set_it():
+    svc = _build_service(
+        _make_rock_config(
+            legacy_role="acs:ram::1933967579503727:role/legacy-role",
+            primary_role="acs:ram::1771269394322852:role/chatos-rock-sts-role",
+            archive_prefix="",
+        )
+    )
+    svc._sts_clients["primary"].do_action_with_exception = _fake_assume("P-AK", "P-SK", "P-TOK")
+    creds = svc.gen_oss_sts_token(account="primary")
+    assert creds["ArchivePrefix"] is None
 
 
 def test_unknown_account_returns_none():

--- a/tests/unit/sandbox/test_sts_dual_account.py
+++ b/tests/unit/sandbox/test_sts_dual_account.py
@@ -9,7 +9,6 @@ from rock.config import (
     RuntimeConfig,
     SandboxConfig,
     SandboxFileTransferConfig,
-    SandboxLogConfig,
 )
 from rock.sandbox.service.sandbox_proxy_service import SandboxProxyService
 
@@ -20,7 +19,6 @@ def _make_rock_config(
     primary_role: str,
     legacy_region: str = "cn-hangzhou",
     transfer_prefix: str = "rock-transfer/",
-    archive_prefix: str = "rock-archives/",
 ) -> RockConfig:
     return RockConfig(
         oss=OssConfig(
@@ -40,7 +38,6 @@ def _make_rock_config(
             ),
         ),
         sandbox_config=SandboxConfig(
-            log=SandboxLogConfig(archive_prefix=archive_prefix),
             file_transfer=SandboxFileTransferConfig(prefix=transfer_prefix),
         ),
         proxy_service=ProxyServiceConfig(),
@@ -130,39 +127,6 @@ def test_primary_prefix_is_none_when_yaml_does_not_set_it():
     svc._sts_clients["primary"].do_action_with_exception = _fake_assume("P-AK", "P-SK", "P-TOK")
     creds = svc.gen_oss_sts_token(account="primary")
     assert creds["Prefix"] is None
-
-
-def test_archive_prefix_returned_for_both_accounts():
-    # ArchivePrefix lives on oss_config root (not per-account), so legacy and primary
-    # should both surface the same value — `rock storage get` reads it to skip
-    # --archive-prefix, regardless of which account it queries.
-    svc = _build_service(
-        _make_rock_config(
-            legacy_role="acs:ram::1933967579503727:role/legacy-role",
-            primary_role="acs:ram::1771269394322852:role/chatos-rock-sts-role",
-            archive_prefix="rock-archives/",
-        )
-    )
-    svc._sts_clients["legacy"].do_action_with_exception = _fake_assume("L-AK", "L-SK", "L-TOK")
-    svc._sts_clients["primary"].do_action_with_exception = _fake_assume("P-AK", "P-SK", "P-TOK")
-
-    legacy = svc.gen_oss_sts_token()
-    primary = svc.gen_oss_sts_token(account="primary")
-    assert legacy["ArchivePrefix"] == "rock-archives/"
-    assert primary["ArchivePrefix"] == "rock-archives/"
-
-
-def test_archive_prefix_none_when_yaml_does_not_set_it():
-    svc = _build_service(
-        _make_rock_config(
-            legacy_role="acs:ram::1933967579503727:role/legacy-role",
-            primary_role="acs:ram::1771269394322852:role/chatos-rock-sts-role",
-            archive_prefix="",
-        )
-    )
-    svc._sts_clients["primary"].do_action_with_exception = _fake_assume("P-AK", "P-SK", "P-TOK")
-    creds = svc.gen_oss_sts_token(account="primary")
-    assert creds["ArchivePrefix"] is None
 
 
 def test_unknown_account_returns_none():

--- a/tests/unit/sandbox/test_sts_dual_account.py
+++ b/tests/unit/sandbox/test_sts_dual_account.py
@@ -7,6 +7,9 @@ from rock.config import (
     ProxyServiceConfig,
     RockConfig,
     RuntimeConfig,
+    SandboxConfig,
+    SandboxFileTransferConfig,
+    SandboxLogConfig,
 )
 from rock.sandbox.service.sandbox_proxy_service import SandboxProxyService
 
@@ -27,8 +30,6 @@ def _make_rock_config(
             access_key_secret="legacy-sk",
             role_arn=legacy_role,
             region=legacy_region,
-            transfer_prefix=transfer_prefix,
-            archive_prefix=archive_prefix,
             primary=OssAccountConfig(
                 endpoint="oss-cn-hangzhou.aliyuncs.com",
                 bucket="chatos-rock",
@@ -37,6 +38,10 @@ def _make_rock_config(
                 role_arn=primary_role,
                 region="cn-hangzhou",
             ),
+        ),
+        sandbox_config=SandboxConfig(
+            log=SandboxLogConfig(archive_prefix=archive_prefix),
+            file_transfer=SandboxFileTransferConfig(prefix=transfer_prefix),
         ),
         proxy_service=ProxyServiceConfig(),
         runtime=RuntimeConfig(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -56,10 +56,15 @@ def test_oss_config_defaults():
     cfg = OssConfig()
     assert cfg.bucket == ""
     assert cfg.region == ""
-    assert cfg.transfer_prefix == ""  # default is now empty; deployments must opt-in via YAML
+    assert cfg.transfer_prefix == ""  # default empty; YAML must opt-in
     assert isinstance(cfg.primary, OssAccountConfig)
     assert cfg.primary.bucket == ""
     assert cfg.primary.region == ""
+    # archive defaults: prefix empty (YAML opt-in), other timing fields preset
+    assert cfg.archive_prefix == ""
+    assert cfg.archive_ttl_days == 30
+    assert cfg.keep_days_before_archive == 3
+    assert cfg.archive_max_attempts == 3
 
 
 def test_oss_config_primary_dict_coerced():
@@ -80,4 +85,20 @@ def test_oss_config_primary_dict_coerced():
     assert cfg.primary.region == "cn-hangzhou"
     # legacy 顶层字段未提供时仍为默认空,确认 primary 不会污染 legacy
     assert cfg.bucket == ""
+
+
+def test_oss_config_archive_fields_overridable():
+    from rock.config import OssConfig
+
+    cfg = OssConfig(
+        archive_prefix="custom-prefix/",
+        archive_ttl_days=7,
+        keep_days_before_archive=1,
+        archive_max_attempts=5,
+    )
+    assert cfg.archive_prefix == "custom-prefix/"
+    assert cfg.archive_ttl_days == 7
+    assert cfg.keep_days_before_archive == 1
+    assert cfg.archive_max_attempts == 5
+
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -56,14 +56,16 @@ def test_oss_config_defaults():
     cfg = OssConfig()
     assert cfg.bucket == ""
     assert cfg.region == ""
-    assert cfg.transfer_prefix == ""  # default empty; YAML must opt-in
     assert isinstance(cfg.primary, OssAccountConfig)
     assert cfg.primary.bucket == ""
     assert cfg.primary.region == ""
-    # archive defaults: prefix empty (YAML opt-in), other timing fields preset
-    assert cfg.archive_prefix == ""
-    assert cfg.keep_days_before_archive == 3
-    assert cfg.archive_max_attempts == 3
+    # transfer_prefix moved to SandboxConfig.file_transfer.prefix; archive_prefix /
+    # keep_days_before_archive / archive_max_attempts moved to SandboxConfig.log.
+    # OssConfig is now purely OSS connectivity (endpoint / bucket / credentials).
+    assert not hasattr(cfg, "transfer_prefix")
+    assert not hasattr(cfg, "archive_prefix")
+    assert not hasattr(cfg, "keep_days_before_archive")
+    assert not hasattr(cfg, "archive_max_attempts")
 
 
 def test_oss_config_primary_dict_coerced():
@@ -86,10 +88,21 @@ def test_oss_config_primary_dict_coerced():
     assert cfg.bucket == ""
 
 
-def test_oss_config_archive_fields_overridable():
-    from rock.config import OssConfig
+def test_sandbox_log_config_defaults():
+    from rock.config import SandboxLogConfig
 
-    cfg = OssConfig(
+    cfg = SandboxLogConfig()
+    # prefix defaults empty: each deployment YAML must opt-in to a value
+    # matching its OSS bucket lifecycle rule (e.g. "rock-archives/").
+    assert cfg.archive_prefix == ""
+    assert cfg.keep_days_before_archive == 3
+    assert cfg.archive_max_attempts == 3
+
+
+def test_sandbox_log_config_overridable():
+    from rock.config import SandboxLogConfig
+
+    cfg = SandboxLogConfig(
         archive_prefix="custom-prefix/",
         keep_days_before_archive=1,
         archive_max_attempts=5,
@@ -99,3 +112,36 @@ def test_oss_config_archive_fields_overridable():
     assert cfg.archive_max_attempts == 5
 
 
+def test_sandbox_file_transfer_config_defaults():
+    from rock.config import SandboxFileTransferConfig
+
+    cfg = SandboxFileTransferConfig()
+    # prefix defaults empty; YAML opts in to "rock-transfer/" for the
+    # primary bucket's lifecycle-managed transfer area.
+    assert cfg.prefix == ""
+
+
+def test_sandbox_config_nests_log_and_file_transfer():
+    # The reorg puts log + file_transfer under SandboxConfig (not OssConfig
+    # or root) since they're sandbox-domain concerns.
+    from rock.config import SandboxConfig, SandboxFileTransferConfig, SandboxLogConfig
+
+    cfg = SandboxConfig()
+    assert isinstance(cfg.log, SandboxLogConfig)
+    assert isinstance(cfg.file_transfer, SandboxFileTransferConfig)
+
+
+def test_sandbox_config_coerces_nested_dicts_from_yaml():
+    # yaml.safe_load returns dicts for nested keys; __post_init__ must coerce
+    # them into the right dataclass so callers can keep dotted access.
+    from rock.config import SandboxConfig, SandboxFileTransferConfig, SandboxLogConfig
+
+    cfg = SandboxConfig(
+        log={"archive_prefix": "rock-archives/", "keep_days_before_archive": 7},
+        file_transfer={"prefix": "rock-transfer/"},
+    )
+    assert isinstance(cfg.log, SandboxLogConfig)
+    assert cfg.log.archive_prefix == "rock-archives/"
+    assert cfg.log.keep_days_before_archive == 7
+    assert isinstance(cfg.file_transfer, SandboxFileTransferConfig)
+    assert cfg.file_transfer.prefix == "rock-transfer/"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -62,7 +62,6 @@ def test_oss_config_defaults():
     assert cfg.primary.region == ""
     # archive defaults: prefix empty (YAML opt-in), other timing fields preset
     assert cfg.archive_prefix == ""
-    assert cfg.archive_ttl_days == 30
     assert cfg.keep_days_before_archive == 3
     assert cfg.archive_max_attempts == 3
 
@@ -92,12 +91,10 @@ def test_oss_config_archive_fields_overridable():
 
     cfg = OssConfig(
         archive_prefix="custom-prefix/",
-        archive_ttl_days=7,
         keep_days_before_archive=1,
         archive_max_attempts=5,
     )
     assert cfg.archive_prefix == "custom-prefix/"
-    assert cfg.archive_ttl_days == 7
     assert cfg.keep_days_before_archive == 1
     assert cfg.archive_max_attempts == 5
 

--- a/tests/unit/utils/test_archive_command.py
+++ b/tests/unit/utils/test_archive_command.py
@@ -25,8 +25,10 @@ class TestArchiveCommandBuildCommand:
     def test_starts_with_set_e_so_failures_short_circuit(self):
         # `set -e` is what guarantees the trailing `rm -rf <log_dir>` is
         # skipped on tar / ossutil failure, so retry can re-archive cleanly.
+        # Triple-quoted multi-line string emits `set -e \\\n&& ...` (bash treats
+        # `\<newline>` as line continuation, so it's still one chained command).
         cmd = ArchiveCommand.build_command("/data/logs/sb-1", "k", "b", "e")
-        assert cmd.startswith("set -e &&")
+        assert cmd.startswith("set -e \\\n&&")
 
     def test_uses_mktemp_and_traps_exit_for_cleanup(self):
         # ossutil 1.7.x cannot read stdin, so we must land a temp tarball;

--- a/tests/unit/utils/test_archive_command.py
+++ b/tests/unit/utils/test_archive_command.py
@@ -1,0 +1,63 @@
+"""Tests for rock.utils.archive_command."""
+
+from rock.utils.archive_command import build_archive_command, build_sandbox_log_key
+
+
+class TestBuildSandboxLogKey:
+    def test_with_prefix(self):
+        assert build_sandbox_log_key("sb-123", "rock-archives/") == "rock-archives/sandbox-logs/sb-123.tar.gz"
+
+    def test_strips_leading_and_trailing_slashes(self):
+        # Avoid double slashes regardless of how the prefix is configured in YAML.
+        assert build_sandbox_log_key("sb-1", "/rock-archives//") == "rock-archives/sandbox-logs/sb-1.tar.gz"
+
+    def test_empty_prefix_yields_flat_layout(self):
+        assert build_sandbox_log_key("sb-1") == "sandbox-logs/sb-1.tar.gz"
+        assert build_sandbox_log_key("sb-1", "") == "sandbox-logs/sb-1.tar.gz"
+
+    def test_no_double_slash_at_join_boundary(self):
+        # Strip only guards against leading/trailing slash duplication; internal
+        # slashes are preserved as-is (caller's responsibility to pass a sane prefix).
+        assert build_sandbox_log_key("sb-1", "/a/b/").startswith("a/b/sandbox-logs/")
+
+
+class TestBuildArchiveCommand:
+    def test_contains_tar_pipe_ossutil_then_rm(self):
+        cmd = build_archive_command(
+            log_dir="/data/logs/sb-1",
+            oss_key="rock-archives/sandbox-logs/sb-1.tar.gz",
+            bucket="chatos-rock",
+            endpoint="oss-cn-hangzhou.aliyuncs.com",
+        )
+        # tar streams to ossutil, only rm on success (&& chains)
+        assert "tar -czf -" in cmd
+        assert "| ossutil cp -f -" in cmd
+        assert "&& rm -rf" in cmd
+
+    def test_uses_parent_dir_for_tar_so_archive_does_not_embed_full_path(self):
+        cmd = build_archive_command("/data/logs/sb-1", "k", "b", "e")
+        # `-C <parent> <basename>` keeps the tarball flat at <basename>/, not
+        # /data/logs/sb-1/ — important for restore.
+        assert "-C /data/logs sb-1" in cmd
+
+    def test_paths_are_shell_quoted(self):
+        cmd = build_archive_command(
+            log_dir="/data/logs/has space/sb-1",
+            oss_key="rock-archives/has space/sb-1.tar.gz",
+            bucket="b",
+            endpoint="e",
+        )
+        # shlex.quote wraps anything with spaces in single quotes
+        assert "'/data/logs/has space/sb-1'" in cmd
+        assert "'/data/logs/has space'" in cmd
+
+    def test_oss_url_is_built_from_bucket_and_key(self):
+        cmd = build_archive_command("/data/logs/sb-1", "rock-archives/sandbox-logs/sb-1.tar.gz", "chatos-rock", "e")
+        assert "oss://chatos-rock/rock-archives/sandbox-logs/sb-1.tar.gz" in cmd
+
+    def test_no_credentials_in_command_string(self):
+        # AK/SK MUST flow via SandboxCommand.env, never the command string.
+        cmd = build_archive_command("/data/logs/sb-1", "k", "b", "e")
+        assert "ACCESS_KEY" not in cmd.upper()
+        assert "SECRET" not in cmd.upper()
+        assert "--access-key" not in cmd

--- a/tests/unit/utils/test_archive_command.py
+++ b/tests/unit/utils/test_archive_command.py
@@ -1,37 +1,37 @@
 """Tests for rock.utils.archive_command."""
 
-from rock.utils.archive_command import build_archive_command, build_sandbox_log_key
+from rock.utils.archive_command import ArchiveCommand
 
 
-class TestBuildSandboxLogKey:
+class TestArchiveCommandBuildKey:
     def test_with_prefix(self):
-        assert build_sandbox_log_key("sb-123", "rock-archives/") == "rock-archives/sandbox-logs/sb-123.tar.gz"
+        assert ArchiveCommand.build_key("sb-123", "rock-archives/") == "rock-archives/sandbox-logs/sb-123.tar.gz"
 
     def test_strips_leading_and_trailing_slashes(self):
         # Avoid double slashes regardless of how the prefix is configured in YAML.
-        assert build_sandbox_log_key("sb-1", "/rock-archives//") == "rock-archives/sandbox-logs/sb-1.tar.gz"
+        assert ArchiveCommand.build_key("sb-1", "/rock-archives//") == "rock-archives/sandbox-logs/sb-1.tar.gz"
 
     def test_empty_prefix_yields_flat_layout(self):
-        assert build_sandbox_log_key("sb-1") == "sandbox-logs/sb-1.tar.gz"
-        assert build_sandbox_log_key("sb-1", "") == "sandbox-logs/sb-1.tar.gz"
+        assert ArchiveCommand.build_key("sb-1") == "sandbox-logs/sb-1.tar.gz"
+        assert ArchiveCommand.build_key("sb-1", "") == "sandbox-logs/sb-1.tar.gz"
 
     def test_no_double_slash_at_join_boundary(self):
         # Strip only guards against leading/trailing slash duplication; internal
         # slashes are preserved as-is (caller's responsibility to pass a sane prefix).
-        assert build_sandbox_log_key("sb-1", "/a/b/").startswith("a/b/sandbox-logs/")
+        assert ArchiveCommand.build_key("sb-1", "/a/b/").startswith("a/b/sandbox-logs/")
 
 
-class TestBuildArchiveCommand:
+class TestArchiveCommandBuildCommand:
     def test_starts_with_set_e_so_failures_short_circuit(self):
         # `set -e` is what guarantees the trailing `rm -rf <log_dir>` is
         # skipped on tar / ossutil failure, so retry can re-archive cleanly.
-        cmd = build_archive_command("/data/logs/sb-1", "k", "b", "e")
+        cmd = ArchiveCommand.build_command("/data/logs/sb-1", "k", "b", "e")
         assert cmd.startswith("set -e &&")
 
     def test_uses_mktemp_and_traps_exit_for_cleanup(self):
         # ossutil 1.7.x cannot read stdin, so we must land a temp tarball;
         # mktemp -d isolates concurrent archives, trap EXIT cleans up.
-        cmd = build_archive_command("/data/logs/sb-1", "k", "b", "e")
+        cmd = ArchiveCommand.build_command("/data/logs/sb-1", "k", "b", "e")
         assert "mktemp -d" in cmd
         assert "trap " in cmd and "EXIT" in cmd
 
@@ -39,7 +39,7 @@ class TestBuildArchiveCommand:
         # ossutil 1.7.x ignores OSS_ACCESS_KEY_* env vars, so we materialize
         # an [Credentials] config file. AK/SK are still passed by env-var
         # reference (printf "%s" + "$OSS_ACCESS_KEY_*"), never substituted.
-        cmd = build_archive_command("/data/logs/sb-1", "k", "b", "oss-cn-hangzhou.aliyuncs.com")
+        cmd = ArchiveCommand.build_command("/data/logs/sb-1", "k", "b", "oss-cn-hangzhou.aliyuncs.com")
         assert "[Credentials]" in cmd
         assert "language=EN" in cmd
         assert "endpoint=%s" in cmd
@@ -52,20 +52,20 @@ class TestBuildArchiveCommand:
         assert '"$OSS_ACCESS_KEY_SECRET"' in cmd
 
     def test_tar_then_ossutil_cp_against_temp_files(self):
-        cmd = build_archive_command("/data/logs/sb-1", "k", "b", "e")
+        cmd = ArchiveCommand.build_command("/data/logs/sb-1", "k", "b", "e")
         # tar produces a real file under the scratch dir.
         assert 'tar -czf "$ARCHIVE_DIR/archive.tar.gz"' in cmd
         # ossutil cp uses -c <config> -f <file> <oss_url> (1.7.x compatible).
         assert 'ossutil cp -c "$ARCHIVE_DIR/ossconfig" -f "$ARCHIVE_DIR/archive.tar.gz"' in cmd
 
     def test_uses_parent_dir_for_tar_so_archive_does_not_embed_full_path(self):
-        cmd = build_archive_command("/data/logs/sb-1", "k", "b", "e")
+        cmd = ArchiveCommand.build_command("/data/logs/sb-1", "k", "b", "e")
         # `-C <parent> <basename>` keeps the tarball flat at <basename>/, not
         # /data/logs/sb-1/ — important for restore.
         assert "-C /data/logs sb-1" in cmd
 
     def test_paths_are_shell_quoted(self):
-        cmd = build_archive_command(
+        cmd = ArchiveCommand.build_command(
             log_dir="/data/logs/has space/sb-1",
             oss_key="rock-archives/has space/sb-1.tar.gz",
             bucket="b",
@@ -76,19 +76,21 @@ class TestBuildArchiveCommand:
         assert "'/data/logs/has space'" in cmd
 
     def test_oss_url_is_built_from_bucket_and_key(self):
-        cmd = build_archive_command("/data/logs/sb-1", "rock-archives/sandbox-logs/sb-1.tar.gz", "chatos-rock", "e")
+        cmd = ArchiveCommand.build_command(
+            "/data/logs/sb-1", "rock-archives/sandbox-logs/sb-1.tar.gz", "chatos-rock", "e"
+        )
         assert "oss://chatos-rock/rock-archives/sandbox-logs/sb-1.tar.gz" in cmd
 
     def test_log_dir_rm_is_last_and_chained_on_success(self):
         # The final rm is gated by the && chain — set -e + && ensures it
         # never runs if any prior step failed.
-        cmd = build_archive_command("/data/logs/sb-1", "k", "b", "e")
+        cmd = ArchiveCommand.build_command("/data/logs/sb-1", "k", "b", "e")
         assert cmd.endswith("&& rm -rf /data/logs/sb-1")
 
     def test_no_literal_credentials_in_command_string(self):
         # AK/SK appear ONLY as env-var references; never as literals or
         # ossutil --access-key flag (which would expose them in argv).
-        cmd = build_archive_command("/data/logs/sb-1", "k", "b", "e")
+        cmd = ArchiveCommand.build_command("/data/logs/sb-1", "k", "b", "e")
         assert '"$OSS_ACCESS_KEY_ID"' in cmd
         assert '"$OSS_ACCESS_KEY_SECRET"' in cmd
         assert "--access-key" not in cmd

--- a/tests/unit/utils/test_archive_command.py
+++ b/tests/unit/utils/test_archive_command.py
@@ -22,17 +22,41 @@ class TestBuildSandboxLogKey:
 
 
 class TestBuildArchiveCommand:
-    def test_contains_tar_pipe_ossutil_then_rm(self):
-        cmd = build_archive_command(
-            log_dir="/data/logs/sb-1",
-            oss_key="rock-archives/sandbox-logs/sb-1.tar.gz",
-            bucket="chatos-rock",
-            endpoint="oss-cn-hangzhou.aliyuncs.com",
-        )
-        # tar streams to ossutil, only rm on success (&& chains)
-        assert "tar -czf -" in cmd
-        assert "| ossutil cp -f -" in cmd
-        assert "&& rm -rf" in cmd
+    def test_starts_with_set_e_so_failures_short_circuit(self):
+        # `set -e` is what guarantees the trailing `rm -rf <log_dir>` is
+        # skipped on tar / ossutil failure, so retry can re-archive cleanly.
+        cmd = build_archive_command("/data/logs/sb-1", "k", "b", "e")
+        assert cmd.startswith("set -e &&")
+
+    def test_uses_mktemp_and_traps_exit_for_cleanup(self):
+        # ossutil 1.7.x cannot read stdin, so we must land a temp tarball;
+        # mktemp -d isolates concurrent archives, trap EXIT cleans up.
+        cmd = build_archive_command("/data/logs/sb-1", "k", "b", "e")
+        assert "mktemp -d" in cmd
+        assert "trap " in cmd and "EXIT" in cmd
+
+    def test_writes_ossutil_config_with_endpoint_and_env_var_credentials(self):
+        # ossutil 1.7.x ignores OSS_ACCESS_KEY_* env vars, so we materialize
+        # an [Credentials] config file. AK/SK are still passed by env-var
+        # reference (printf "%s" + "$OSS_ACCESS_KEY_*"), never substituted.
+        cmd = build_archive_command("/data/logs/sb-1", "k", "b", "oss-cn-hangzhou.aliyuncs.com")
+        assert "[Credentials]" in cmd
+        assert "language=EN" in cmd
+        assert "endpoint=%s" in cmd
+        assert "accessKeyID=%s" in cmd
+        assert "accessKeySecret=%s" in cmd
+        assert (
+            "oss-cn-hangzhou.aliyuncs.com" in cmd
+        )  # endpoint passed through (shlex.quote skips quoting for safe chars)
+        assert '"$OSS_ACCESS_KEY_ID"' in cmd
+        assert '"$OSS_ACCESS_KEY_SECRET"' in cmd
+
+    def test_tar_then_ossutil_cp_against_temp_files(self):
+        cmd = build_archive_command("/data/logs/sb-1", "k", "b", "e")
+        # tar produces a real file under the scratch dir.
+        assert 'tar -czf "$ARCHIVE_DIR/archive.tar.gz"' in cmd
+        # ossutil cp uses -c <config> -f <file> <oss_url> (1.7.x compatible).
+        assert 'ossutil cp -c "$ARCHIVE_DIR/ossconfig" -f "$ARCHIVE_DIR/archive.tar.gz"' in cmd
 
     def test_uses_parent_dir_for_tar_so_archive_does_not_embed_full_path(self):
         cmd = build_archive_command("/data/logs/sb-1", "k", "b", "e")
@@ -55,9 +79,18 @@ class TestBuildArchiveCommand:
         cmd = build_archive_command("/data/logs/sb-1", "rock-archives/sandbox-logs/sb-1.tar.gz", "chatos-rock", "e")
         assert "oss://chatos-rock/rock-archives/sandbox-logs/sb-1.tar.gz" in cmd
 
-    def test_no_credentials_in_command_string(self):
-        # AK/SK MUST flow via SandboxCommand.env, never the command string.
+    def test_log_dir_rm_is_last_and_chained_on_success(self):
+        # The final rm is gated by the && chain — set -e + && ensures it
+        # never runs if any prior step failed.
         cmd = build_archive_command("/data/logs/sb-1", "k", "b", "e")
-        assert "ACCESS_KEY" not in cmd.upper()
-        assert "SECRET" not in cmd.upper()
+        assert cmd.endswith("&& rm -rf /data/logs/sb-1")
+
+    def test_no_literal_credentials_in_command_string(self):
+        # AK/SK appear ONLY as env-var references; never as literals or
+        # ossutil --access-key flag (which would expose them in argv).
+        cmd = build_archive_command("/data/logs/sb-1", "k", "b", "e")
+        assert '"$OSS_ACCESS_KEY_ID"' in cmd
+        assert '"$OSS_ACCESS_KEY_SECRET"' in cmd
         assert "--access-key" not in cmd
+        # `LTAI` is the prefix of every alibaba live AK — cheap regression check.
+        assert "LTAI" not in cmd


### PR DESCRIPTION
## Summary

  - 新增 `rock/utils/archive_command.py`,纯函数构造 tar+ossutil 命令字符串(`shlex.quote`
  转义)
  - 新增 `build_sandbox_log_key(sandbox_id, prefix)`
  命名约定:`<prefix>sandbox-logs/<sandbox_id>.tar.gz`
  - `OssConfig` 增加 `archive_prefix` / `archive_ttl_days` / `keep_days_before_archive` /
  `archive_max_attempts` 4 字段,`archive_prefix` 默认空与 `transfer_prefix` 一致(YAML
  opt-in)
  - 删除 `SandboxConfig.sandbox_log_cleanup_policy_default` 与 3 策略枚举(过度设计)
  - AK/SK 不进命令字符串,由调用方走 `Command.env` 传(防 ps 输出泄露)

  ## Test plan

  - [x] `uv run pytest tests/unit/utils/test_archive_command.py tests/unit/test_config.py
  -v` (14 passed)
  - [x] 覆盖:命令构造、shlex 转义、key 命名、config 默认值、命令字符串无凭证关键词(防回归)

  fixes #956