### PR TITLE
feature(scheduler): SandboxLogArchiveTask drives 3-day deferred archival via /execute

### DIFF
--- a/rock/admin/metrics/constants.py
+++ b/rock/admin/metrics/constants.py
@@ -31,3 +31,7 @@ class MetricsConstants:
     METASTORE_DB_SUCCESS = "meta_store.db.success"
     METASTORE_DB_FAILURE = "meta_store.db.failure"
     METASTORE_DB_RT = "meta_store.db.rt"
+
+    # Disk governance: deferred sandbox log archival
+    SANDBOX_LOG_ARCHIVE_FAILED_PERSIST = "sandbox.log.archive.failed_persist"
+    """Counter: dirs that exceeded archive_max_attempts; preserved for FileCleanupTask."""

--- a/rock/admin/metrics/monitor.py
+++ b/rock/admin/metrics/monitor.py
@@ -115,6 +115,12 @@ class MetricsMonitor:
         self._register_counter(MetricsConstants.METASTORE_DB_TOTAL, "Number of total DB operations")
         self._register_gauge(MetricsConstants.METASTORE_DB_RT, "DB operation response time", "ms")
 
+        # Disk governance: deferred sandbox log archival
+        self._register_counter(
+            MetricsConstants.SANDBOX_LOG_ARCHIVE_FAILED_PERSIST,
+            "Dirs exceeding archive_max_attempts; preserved for FileCleanupTask",
+        )
+
     def _register_counter(self, name: str, description: str, unit: str = "1"):
         self.counters[name] = self.create_counter(name, description, unit)
 

--- a/rock/admin/scheduler/tasks/__init__.py
+++ b/rock/admin/scheduler/tasks/__init__.py
@@ -3,5 +3,12 @@ from rock.admin.scheduler.tasks.container_cleanup_task import ContainerCleanupTa
 from rock.admin.scheduler.tasks.file_cleanup_task import FileCleanupTask
 from rock.admin.scheduler.tasks.image_cleanup_task import ImageCleanupTask
 from rock.admin.scheduler.tasks.image_pull_task import ImagePullTask
+from rock.admin.scheduler.tasks.sandbox_log_archive_task import SandboxLogArchiveTask
 
-__all__ = ["ContainerCleanupTask", "FileCleanupTask", "ImageCleanupTask", "ImagePullTask"]
+__all__ = [
+    "ContainerCleanupTask",
+    "FileCleanupTask",
+    "ImageCleanupTask",
+    "ImagePullTask",
+    "SandboxLogArchiveTask",
+]

--- a/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
+++ b/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
@@ -23,8 +23,8 @@ from rock.common.constants import SCHEDULER_LOG_NAME
 from rock.config import RockConfig
 from rock.deployments.log_cleanup_sentinel import (
     LOG_STOPPED_SENTINEL,
+    Sentinel,
     SentinelState,
-    dump_state,
 )
 from rock.logger import init_logger
 from rock.sandbox.remote_sandbox import RemoteSandboxRuntime
@@ -183,7 +183,7 @@ class SandboxLogArchiveTask(BaseTask):
             await runtime.write_file(
                 WriteFileRequest(
                     path=sentinel_remote_path,
-                    content=dump_state(new_state),
+                    content=Sentinel.dump(new_state),
                 )
             )
         except Exception as e:

--- a/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
+++ b/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
@@ -28,7 +28,7 @@ from rock.deployments.log_cleanup_sentinel import (
 )
 from rock.logger import init_logger
 from rock.sandbox.remote_sandbox import RemoteSandboxRuntime
-from rock.utils.archive_command import build_archive_command, build_sandbox_log_key
+from rock.utils.archive_command import ArchiveCommand
 
 logger = init_logger(name="sandbox_log_archive", file_name=SCHEDULER_LOG_NAME)
 
@@ -59,7 +59,8 @@ class SandboxLogArchiveTask(BaseTask):
             logger.warning(f"[{self.type}] ROCK_LOGGING_PATH is empty; skip")
             return {"status": TaskStatusEnum.SUCCESS, "message": "no log root configured"}
 
-        oss = RockConfig.from_env().oss
+        rock_config = RockConfig.from_env()
+        oss = rock_config.oss
         primary = oss.primary
         bucket = primary.bucket or env_vars.ROCK_OSS_BUCKET_NAME or oss.bucket
         endpoint = primary.endpoint or env_vars.ROCK_OSS_BUCKET_ENDPOINT or oss.endpoint
@@ -70,9 +71,10 @@ class SandboxLogArchiveTask(BaseTask):
             logger.warning(f"[{self.type}] OSS primary account incomplete; skip archival")
             return {"status": TaskStatusEnum.SUCCESS, "message": "oss primary account not configured"}
 
-        keep_days = int(oss.keep_days_before_archive or 3)
-        max_attempts = int(oss.archive_max_attempts or 3)
-        archive_prefix = oss.archive_prefix or ""
+        sandbox_log = rock_config.sandbox_config.log
+        keep_days = int(sandbox_log.keep_days_before_archive or 3)
+        max_attempts = int(sandbox_log.archive_max_attempts or 3)
+        archive_prefix = sandbox_log.archive_prefix or ""
 
         candidate_dirs = await self._discover_candidates(runtime)
 
@@ -150,8 +152,8 @@ class SandboxLogArchiveTask(BaseTask):
             return "too_young"
 
         sandbox_id = log_dir.rstrip("/").split("/")[-1] or "unknown"
-        oss_key = build_sandbox_log_key(sandbox_id, archive_prefix)
-        cmd_str = build_archive_command(
+        oss_key = ArchiveCommand.build_key(sandbox_id, archive_prefix)
+        cmd_str = ArchiveCommand.build_command(
             log_dir=log_dir,
             oss_key=oss_key,
             bucket=bucket,

--- a/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
+++ b/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
@@ -118,10 +118,10 @@ class SandboxLogArchiveTask(BaseTask):
     async def _discover_candidates(self, runtime: RemoteSandboxRuntime) -> list[str]:
         cmd = (
             f'find "{self.log_root}" -maxdepth 2 -mindepth 2 '
-            f'-type f -name "{LOG_STOPPED_SENTINEL}" -printf "%h\\n" 2>/dev/null || true'
+            f'-type f -name "{LOG_STOPPED_SENTINEL}" -exec dirname {{}} \\; 2>/dev/null || true'
         )
         result = await runtime.execute(Command(command=cmd, shell=True, check=False))
-        return [d for d in (result.stdout or "").splitlines() if d.strip()]
+        return list(dict.fromkeys(d for d in (result.stdout or "").splitlines() if d.strip()))
 
     async def _process_one(
         self,

--- a/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
+++ b/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
@@ -1,0 +1,225 @@
+"""Deferred archival of stopped sandbox log dirs.
+
+Per-worker daily run:
+  1. /execute: walk ${ROCK_LOGGING_PATH}/* on the worker (find -name sentinel)
+  2. /read_file: read each sentinel JSON; skip when age < keep_days
+  3. /execute: tar | ossutil cp && rm -rf  (AK/SK via SandboxCommand.env,
+     never argv) — single shell pipeline, no new RPC endpoint
+  4. /write_file: on failure, bump attempts in the sentinel JSON; once
+     attempts >= max_attempts, return failed_persist and leave the dir
+     for FileCleanupTask to eventually reap.
+"""
+
+import json
+from datetime import datetime, timezone
+
+from rock import env_vars
+from rock.actions import ReadFileRequest, WriteFileRequest
+from rock.admin.metrics.constants import MetricsConstants
+from rock.admin.metrics.monitor import MetricsMonitor
+from rock.admin.proto.request import SandboxCommand as Command
+from rock.admin.scheduler.task_base import BaseTask, IdempotencyType, TaskStatusEnum
+from rock.common.constants import SCHEDULER_LOG_NAME
+from rock.config import RockConfig
+from rock.deployments.log_cleanup_sentinel import (
+    LOG_STOPPED_SENTINEL,
+    SentinelState,
+    dump_state,
+)
+from rock.logger import init_logger
+from rock.sandbox.remote_sandbox import RemoteSandboxRuntime
+from rock.utils.archive_command import build_archive_command, build_sandbox_log_key
+
+logger = init_logger(name="sandbox_log_archive", file_name=SCHEDULER_LOG_NAME)
+
+
+class SandboxLogArchiveTask(BaseTask):
+    def __init__(
+        self,
+        interval_seconds: int = 86400,
+        log_root: str | None = None,
+    ):
+        super().__init__(
+            type="sandbox_log_archive",
+            interval_seconds=interval_seconds,
+            idempotency=IdempotencyType.IDEMPOTENT,
+        )
+        self.log_root = log_root or env_vars.ROCK_LOGGING_PATH
+        self.metrics_monitor = MetricsMonitor.create(metric_prefix="disk_governance")
+
+    @classmethod
+    def from_config(cls, task_config) -> "SandboxLogArchiveTask":
+        return cls(
+            interval_seconds=task_config.interval_seconds,
+            log_root=task_config.params.get("log_root"),
+        )
+
+    async def run_action(self, runtime: RemoteSandboxRuntime) -> dict:
+        if not self.log_root:
+            logger.warning(f"[{self.type}] ROCK_LOGGING_PATH is empty; skip")
+            return {"status": TaskStatusEnum.SUCCESS, "message": "no log root configured"}
+
+        oss = RockConfig.from_env().oss
+        primary = oss.primary
+        bucket = primary.bucket or env_vars.ROCK_OSS_BUCKET_NAME or oss.bucket
+        endpoint = primary.endpoint or env_vars.ROCK_OSS_BUCKET_ENDPOINT or oss.endpoint
+        access_key_id = primary.access_key_id or oss.access_key_id
+        access_key_secret = primary.access_key_secret or oss.access_key_secret
+
+        if not (bucket and endpoint and access_key_id and access_key_secret):
+            logger.warning(f"[{self.type}] OSS primary account incomplete; skip archival")
+            return {"status": TaskStatusEnum.SUCCESS, "message": "oss primary account not configured"}
+
+        keep_days = int(oss.keep_days_before_archive or 3)
+        max_attempts = int(oss.archive_max_attempts or 3)
+        archive_prefix = oss.archive_prefix or ""
+
+        candidate_dirs = await self._discover_candidates(runtime)
+
+        archived = 0
+        skipped_too_young = 0
+        failed_pending = 0
+        failed_persist = 0
+        skipped_no_sentinel = 0
+
+        for log_dir in candidate_dirs:
+            outcome = await self._process_one(
+                runtime=runtime,
+                log_dir=log_dir,
+                keep_days=keep_days,
+                max_attempts=max_attempts,
+                archive_prefix=archive_prefix,
+                bucket=bucket,
+                endpoint=endpoint,
+                access_key_id=access_key_id,
+                access_key_secret=access_key_secret,
+            )
+            if outcome == "archived":
+                archived += 1
+            elif outcome == "too_young":
+                skipped_too_young += 1
+            elif outcome == "failed_pending":
+                failed_pending += 1
+            elif outcome == "failed_persist":
+                failed_persist += 1
+                self._emit_failed_persist(log_dir)
+            elif outcome == "skipped_no_sentinel":
+                skipped_no_sentinel += 1
+
+        return {
+            "status": TaskStatusEnum.SUCCESS,
+            "archived": archived,
+            "skipped_too_young": skipped_too_young,
+            "failed_pending": failed_pending,
+            "failed_persist": failed_persist,
+            "skipped_no_sentinel": skipped_no_sentinel,
+        }
+
+    async def _discover_candidates(self, runtime: RemoteSandboxRuntime) -> list[str]:
+        cmd = (
+            f'find "{self.log_root}" -maxdepth 2 -mindepth 2 '
+            f'-type f -name "{LOG_STOPPED_SENTINEL}" -printf "%h\\n" 2>/dev/null || true'
+        )
+        result = await runtime.execute(Command(command=cmd, shell=True, check=False))
+        return [d for d in (result.stdout or "").splitlines() if d.strip()]
+
+    async def _process_one(
+        self,
+        runtime: RemoteSandboxRuntime,
+        log_dir: str,
+        keep_days: int,
+        max_attempts: int,
+        archive_prefix: str,
+        bucket: str,
+        endpoint: str,
+        access_key_id: str,
+        access_key_secret: str,
+    ) -> str:
+        """Returns one of: archived / too_young / failed_pending / failed_persist / skipped_no_sentinel."""
+        sentinel_remote_path = f"{log_dir.rstrip('/')}/{LOG_STOPPED_SENTINEL}"
+        state = await self._read_sentinel(runtime, sentinel_remote_path)
+        if state is None:
+            return "skipped_no_sentinel"
+
+        try:
+            stopped_at = datetime.fromisoformat(state.stopped_at)
+        except Exception:
+            stopped_at = datetime.now(timezone.utc)
+        age_days = (datetime.now(stopped_at.tzinfo or timezone.utc) - stopped_at).days
+        if age_days < keep_days:
+            return "too_young"
+
+        sandbox_id = log_dir.rstrip("/").split("/")[-1] or "unknown"
+        oss_key = build_sandbox_log_key(sandbox_id, archive_prefix)
+        cmd_str = build_archive_command(
+            log_dir=log_dir,
+            oss_key=oss_key,
+            bucket=bucket,
+            endpoint=endpoint,
+        )
+        result = await runtime.execute(
+            Command(
+                command=cmd_str,
+                shell=True,
+                check=False,
+                env={
+                    "OSS_ACCESS_KEY_ID": access_key_id,
+                    "OSS_ACCESS_KEY_SECRET": access_key_secret,
+                },
+            )
+        )
+        if (result.exit_code or 0) == 0:
+            return "archived"
+
+        new_attempts = state.attempts + 1
+        new_state = SentinelState(
+            stopped_at=state.stopped_at,
+            attempts=new_attempts,
+            version=state.version,
+        )
+        try:
+            await runtime.write_file(
+                WriteFileRequest(
+                    path=sentinel_remote_path,
+                    content=dump_state(new_state),
+                )
+            )
+        except Exception as e:
+            logger.warning(f"[{self.type}] sentinel bump failed for {sentinel_remote_path}: {e}")
+
+        if new_attempts >= max_attempts:
+            logger.error(
+                f"[{self.type}] archive gave up after {new_attempts} attempts: "
+                f"{log_dir} (stderr={result.stderr[:200]!r})"
+            )
+            return "failed_persist"
+        return "failed_pending"
+
+    async def _read_sentinel(self, runtime: RemoteSandboxRuntime, path: str) -> SentinelState | None:
+        try:
+            resp = await runtime.read_file(ReadFileRequest(path=path))
+        except Exception as e:
+            logger.warning(f"[{self.type}] failed to read sentinel at {path}: {e}")
+            return None
+        if not resp.content:
+            return None
+        try:
+            data = json.loads(resp.content)
+            return SentinelState(
+                stopped_at=data["stopped_at"],
+                attempts=int(data.get("attempts", 0)),
+                version=int(data.get("version", 1)),
+            )
+        except Exception as e:
+            logger.warning(f"[{self.type}] sentinel parse failed for {path}: {e}")
+            return None
+
+    def _emit_failed_persist(self, log_dir: str) -> None:
+        if not self.metrics_monitor:
+            return
+        sandbox_id = log_dir.rstrip("/").split("/")[-1] or "unknown"
+        self.metrics_monitor.record_counter_by_name(
+            MetricsConstants.SANDBOX_LOG_ARCHIVE_FAILED_PERSIST,
+            1,
+            {"sandbox_id": sandbox_id},
+        )

--- a/rock/deployments/docker.py
+++ b/rock/deployments/docker.py
@@ -624,77 +624,106 @@ class DockerDeployment(AbstractDeployment):
         if self._runtime:
             await loop.run_in_executor(stop_executor, self._stop)
 
+    def _try_mark_sentinel(self, container_name: str | None) -> None:
+        """Best-effort: write .rock_stopped_at sentinel for deferred archival.
+
+        Caller MUST pass container_name (snapshotted at _stop() entry), since
+        self._container_name is reset mid-flow before this method is called.
+        Never raises — sentinel writing is housekeeping, must not break stop flow.
+        All branches log explicitly so root cause is traceable from worker logs.
+        """
+        try:
+            log_path = env_vars.ROCK_LOGGING_PATH
+            if not log_path:
+                logger.warning("[sentinel] skip: ROCK_LOGGING_PATH is empty")
+                return
+            if not container_name:
+                logger.warning("[sentinel] skip: container_name is empty (None at _stop entry)")
+                return
+            log_dir = Path(log_path) / container_name
+            logger.info(f"[sentinel] resolved log_dir={log_dir}")
+            if not log_dir.is_dir():
+                logger.warning(f"[sentinel] skip: log_dir does not exist: {log_dir}")
+                return
+            if sentinel_path(log_dir).exists():
+                logger.info(f"[sentinel] skip: sentinel already exists at {sentinel_path(log_dir)}")
+                return
+            write_sentinel(log_dir)
+            logger.info(f"[sentinel] WRITE_OK at {sentinel_path(log_dir)}")
+        except Exception as e:
+            logger.exception(f"[sentinel] _try_mark_sentinel unexpected error: {e}")
+
+
     def _stop(self):
         """Stops the runtime."""
-        if self._container_name in ENV_POOL:
-            del ENV_POOL[self._container_name]
-        if self._runtime is not None:
-            try:
-                with timeout(5):
-                    self._runtime.close()
-            except TimeoutError as e:
-                logger.error("close timeout", exc_info=e)
-            except Exception as e:
-                logger.error("close failed", exc_info=e)
-            self._runtime = None
+        container_name_for_sentinel = self._container_name
 
-        if self._container_process is not None:
-            try:
-                subprocess.check_call(
-                    ["docker", "kill", self._container_name],  # type: ignore
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    timeout=10,
-                )
-            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-                logger.warning(
-                    f"Failed to kill container {self._container_name}: {e}. Will try harder.", exc_info=False
-                )
-            for _ in range(3):
-                self._container_process.kill()
+        try:
+            if self._container_name in ENV_POOL:
+                del ENV_POOL[self._container_name]
+            if self._runtime is not None:
                 try:
-                    self._container_process.wait(timeout=5)
-                    break
-                except subprocess.TimeoutExpired:
-                    continue
-            else:
-                logger.warning(f"Failed to kill container {self._container_name} with SIGKILL")
+                    with timeout(5):
+                        self._runtime.close()
+                except TimeoutError as e:
+                    logger.error("close timeout", exc_info=e)
+                except Exception as e:
+                    logger.error("close failed", exc_info=e)
+                self._runtime = None
 
-            self._container_process = None
-            self._cleanup_kata_disk()
-            self._cleanup_log_dir_xfs_quota()
-            self._container_name = None
+            if self._container_process is not None:
+                try:
+                    subprocess.check_call(
+                        ["docker", "kill", self._container_name],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        timeout=10,
+                    )
+                except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+                    logger.warning(
+                        f"Failed to kill container {self._container_name}: {e}. Will try harder.", exc_info=False
+                    )
+                for _ in range(3):
+                    self._container_process.kill()
+                    try:
+                        self._container_process.wait(timeout=5)
+                        break
+                    except subprocess.TimeoutExpired:
+                        continue
+                else:
+                    logger.warning(f"Failed to kill container {self._container_name} with SIGKILL")
 
-        if self._config and self._config.remove_images and DockerUtil.is_image_available(self._config.image):
-            logger.info(f"Removing image {self._config.image}")
+                self._container_process = None
+                self._cleanup_kata_disk()
+                self._cleanup_log_dir_xfs_quota()
+                self._container_name = None
+
+            if self._config and self._config.remove_images and DockerUtil.is_image_available(self._config.image):
+                logger.info(f"Removing image {self._config.image}")
+                try:
+                    DockerUtil.remove_image(self._config.image)
+                except subprocess.CalledProcessError:
+                    logger.error(f"Failed to remove image {self._config.image}", exc_info=True)
+
+            if self._check_stop_task is not None:
+                logger.info("Stopping check task")
+                self._check_stop_task.cancel()
+                self._check_stop_task = None
+
+            # service_status / port release 失败不影响 sentinel
             try:
-                DockerUtil.remove_image(self._config.image)
-            except subprocess.CalledProcessError:
-                logger.error(f"Failed to remove image {self._config.image}", exc_info=True)
-
-        if self._check_stop_task is not None:
-            logger.info("Stopping check task")
-            self._check_stop_task.cancel()
-            self._check_stop_task = None
-
-        service_status = self.get_status()
-        for _, port in service_status.get_port_mapping().items():
-            release_port(port)
-
-        # Mark per-sandbox host log dir for deferred archive. Only touches
-        # ${ROCK_LOGGING_PATH}/<container_name>/, not host-side
-        # /data/logs/*.log (managed by logrotate). The sentinel drives
-        # SandboxLogArchiveTask, which tar+uploads + rms after
-        # `oss.keep_days_before_archive` days.
-        if env_vars.ROCK_LOGGING_PATH and self._container_name:
-            log_dir = Path(env_vars.ROCK_LOGGING_PATH) / self._container_name
-            if log_dir.is_dir() and not sentinel_path(log_dir).exists():
-                # _stop() may be called twice (e.g. ray actor restart);
-                # do not bump stopped_at on the second call.
-                write_sentinel(log_dir)
-                logger.info(f"Marked sandbox log dir for deferred archive: {log_dir}")
-
-        self._config = None
+                service_status = self.get_status()
+                for _, port in service_status.get_port_mapping().items():
+                    release_port(port)
+            except Exception as e:
+                logger.warning(
+                    f"[sentinel] pre-stop service_status/port_release failed (non-fatal): {e}",
+                    exc_info=True,
+                )
+        finally:
+            # 用 snapshot 的 container_name,绕开 self._container_name 已被清空的问题
+            self._try_mark_sentinel(container_name_for_sentinel)
+            self._config = None
 
     @property
     def runtime(self) -> RemoteSandboxRuntime:

--- a/rock/deployments/docker.py
+++ b/rock/deployments/docker.py
@@ -21,7 +21,7 @@ from rock.deployments.config import DockerDeploymentConfig
 from rock.deployments.constants import Port, Status
 from rock.deployments.docker_client import TempAuthDockerClient, TempAuthDockerClientError
 from rock.deployments.hooks.abstract import CombinedDeploymentHook, DeploymentHook
-from rock.deployments.log_cleanup_sentinel import sentinel_path, write_sentinel
+from rock.deployments.log_cleanup_sentinel import Sentinel
 from rock.deployments.runtime_env import DockerRuntimeEnv, LocalRuntimeEnv, PipRuntimeEnv, UvRuntimeEnv
 from rock.deployments.sandbox_validator import DockerSandboxValidator
 from rock.deployments.status import PersistedServiceStatus, ServiceStatus
@@ -44,8 +44,8 @@ from rock.utils import (
 
 __all__ = ["DockerDeployment", "DockerDeploymentConfig"]
 CHECK_CLEAR_INTERVAL_SECONDS = 300
-XFS_PRJID_MIN = (1 << 31)                      # low project IDs are reserved for Docker
-XFS_PRJID_RANGE = (1 << 32) - XFS_PRJID_MIN   # use remaining 32-bit space: [XFS_PRJID_MIN, 2^32)
+XFS_PRJID_MIN = 1 << 31  # low project IDs are reserved for Docker
+XFS_PRJID_RANGE = (1 << 32) - XFS_PRJID_MIN  # use remaining 32-bit space: [XFS_PRJID_MIN, 2^32)
 
 
 logger = init_logger(__name__)
@@ -425,7 +425,9 @@ class DockerDeployment(AbstractDeployment):
             return
 
         # Derive a deterministic project id from container name; reserve low ids.
-        project_id = (int(hashlib.sha1(self.container_name.encode("utf-8")).hexdigest()[:8], 16) % XFS_PRJID_RANGE) + XFS_PRJID_MIN
+        project_id = (
+            int(hashlib.sha1(self.container_name.encode("utf-8")).hexdigest()[:8], 16) % XFS_PRJID_RANGE
+        ) + XFS_PRJID_MIN
         try:
             findmnt_result = subprocess.run(
                 ["findmnt", "-T", log_file_path, "-o", "TARGET", "--noheadings"],
@@ -645,14 +647,13 @@ class DockerDeployment(AbstractDeployment):
             if not log_dir.is_dir():
                 logger.warning(f"[sentinel] skip: log_dir does not exist: {log_dir}")
                 return
-            if sentinel_path(log_dir).exists():
-                logger.info(f"[sentinel] skip: sentinel already exists at {sentinel_path(log_dir)}")
+            if Sentinel.path(log_dir).exists():
+                logger.info(f"[sentinel] skip: sentinel already exists at {Sentinel.path(log_dir)}")
                 return
-            write_sentinel(log_dir)
-            logger.info(f"[sentinel] WRITE_OK at {sentinel_path(log_dir)}")
+            Sentinel.write(log_dir)
+            logger.info(f"[sentinel] WRITE_OK at {Sentinel.path(log_dir)}")
         except Exception as e:
             logger.exception(f"[sentinel] _try_mark_sentinel unexpected error: {e}")
-
 
     def _stop(self):
         """Stops the runtime."""

--- a/rock/deployments/docker.py
+++ b/rock/deployments/docker.py
@@ -21,6 +21,7 @@ from rock.deployments.config import DockerDeploymentConfig
 from rock.deployments.constants import Port, Status
 from rock.deployments.docker_client import TempAuthDockerClient, TempAuthDockerClientError
 from rock.deployments.hooks.abstract import CombinedDeploymentHook, DeploymentHook
+from rock.deployments.log_cleanup_sentinel import sentinel_path, write_sentinel
 from rock.deployments.runtime_env import DockerRuntimeEnv, LocalRuntimeEnv, PipRuntimeEnv, UvRuntimeEnv
 from rock.deployments.sandbox_validator import DockerSandboxValidator
 from rock.deployments.status import PersistedServiceStatus, ServiceStatus
@@ -679,6 +680,19 @@ class DockerDeployment(AbstractDeployment):
         service_status = self.get_status()
         for _, port in service_status.get_port_mapping().items():
             release_port(port)
+
+        # Mark per-sandbox host log dir for deferred archive. Only touches
+        # ${ROCK_LOGGING_PATH}/<container_name>/, not host-side
+        # /data/logs/*.log (managed by logrotate). The sentinel drives
+        # SandboxLogArchiveTask, which tar+uploads + rms after
+        # `oss.keep_days_before_archive` days.
+        if env_vars.ROCK_LOGGING_PATH and self._container_name:
+            log_dir = Path(env_vars.ROCK_LOGGING_PATH) / self._container_name
+            if log_dir.is_dir() and not sentinel_path(log_dir).exists():
+                # _stop() may be called twice (e.g. ray actor restart);
+                # do not bump stopped_at on the second call.
+                write_sentinel(log_dir)
+                logger.info(f"Marked sandbox log dir for deferred archive: {log_dir}")
 
         self._config = None
 

--- a/rock/deployments/log_cleanup_sentinel.py
+++ b/rock/deployments/log_cleanup_sentinel.py
@@ -2,7 +2,7 @@
 
 The sentinel is a small JSON file dropped into a stopped sandbox's log
 directory by DockerDeployment._stop(); SandboxLogArchiveTask later picks
-up dirs whose sentinel is older than `oss.keep_days_before_archive` and
+up dirs whose sentinel is older than `sandbox_config.log.keep_days_before_archive` and
 ships them to OSS.
 
 Sentinel JSON shape (versioned for future evolution):

--- a/rock/deployments/log_cleanup_sentinel.py
+++ b/rock/deployments/log_cleanup_sentinel.py
@@ -39,67 +39,80 @@ class SentinelState:
         return cls(stopped_at=datetime.now().astimezone().isoformat(), attempts=0)
 
 
-def sentinel_path(log_dir: Path) -> Path:
-    return log_dir / LOG_STOPPED_SENTINEL
+class Sentinel:
+    """Namespace for sentinel file read/write operations.
 
+    Stateless: all methods are `@staticmethod`. Grouped under a class so
+    deployment / scheduler / test sides go through one explicit entry point
+    (``Sentinel.path``, ``Sentinel.read``, ``Sentinel.write``, etc.) and
+    cannot drift on path / serialization conventions.
 
-def dump_state(state: SentinelState) -> str:
-    """Serialize a SentinelState to its on-disk JSON form.
-
-    Single source of truth for the schema — admin-side code that needs to
-    overwrite a remote worker's sentinel via runtime.write_file() reuses
-    this so the JSON layout stays consistent with local writes.
+    The on-disk JSON shape lives on `SentinelState` (a separate dataclass);
+    this class only handles I/O.
     """
-    return json.dumps(asdict(state), ensure_ascii=False)
 
+    @staticmethod
+    def path(log_dir: Path) -> Path:
+        return log_dir / LOG_STOPPED_SENTINEL
 
-def _atomic_write(target: Path, content: str) -> None:
-    # tempfile + rename inside the same directory: rename is POSIX atomic,
-    # so a crashed write never leaves a half-written sentinel on disk.
-    target.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_name = tempfile.mkstemp(prefix=target.name + ".", suffix=".tmp", dir=str(target.parent))
-    try:
-        with os.fdopen(fd, "w") as f:
-            f.write(content)
-        os.replace(tmp_name, target)
-    except Exception as e:
-        logger.warning(f"[sentinel] _atomic_write failed for {target}: {e}", exc_info=True)
+    @staticmethod
+    def dump(state: SentinelState) -> str:
+        """Serialize a SentinelState to its on-disk JSON form.
+
+        Single source of truth for the schema — admin-side code that needs to
+        overwrite a remote worker's sentinel via runtime.write_file() reuses
+        this so the JSON layout stays consistent with local writes.
+        """
+        return json.dumps(asdict(state), ensure_ascii=False)
+
+    @staticmethod
+    def _atomic_write(target: Path, content: str) -> None:
+        # tempfile + rename inside the same directory: rename is POSIX atomic,
+        # so a crashed write never leaves a half-written sentinel on disk.
+        target.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(prefix=target.name + ".", suffix=".tmp", dir=str(target.parent))
         try:
-            os.unlink(tmp_name)
-        except OSError:
-            pass
-        raise
+            with os.fdopen(fd, "w") as f:
+                f.write(content)
+            os.replace(tmp_name, target)
+        except Exception as e:
+            logger.warning(f"[sentinel] _atomic_write failed for {target}: {e}", exc_info=True)
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+            raise
 
+    @staticmethod
+    def write(log_dir: Path, state: SentinelState | None = None) -> None:
+        target = Sentinel.path(log_dir)
+        if state is None:
+            state = SentinelState.now()
+        Sentinel._atomic_write(target, Sentinel.dump(state))
 
-def write_sentinel(log_dir: Path, state: SentinelState | None = None) -> None:
-    target = sentinel_path(log_dir)
-    if state is None:
-        state = SentinelState.now()
-    _atomic_write(target, dump_state(state))
+    @staticmethod
+    def read(log_dir: Path) -> SentinelState | None:
+        """Returns None when sentinel missing or unreadable. Caller treats
+        None as "not yet stopped" (i.e. skip archive)."""
+        target = Sentinel.path(log_dir)
+        if not target.is_file():
+            return None
+        try:
+            data = json.loads(target.read_text())
+            return SentinelState(
+                stopped_at=data["stopped_at"],
+                attempts=int(data.get("attempts", 0)),
+                version=int(data.get("version", _SENTINEL_VERSION)),
+            )
+        except Exception as e:
+            logger.warning(f"sentinel read failed for {target}: {e}")
+            return None
 
-
-def read_sentinel(log_dir: Path) -> SentinelState | None:
-    """Returns None when sentinel missing or unreadable. Caller treats
-    None as "not yet stopped" (i.e. skip archive)."""
-    target = sentinel_path(log_dir)
-    if not target.is_file():
-        return None
-    try:
-        data = json.loads(target.read_text())
-        return SentinelState(
-            stopped_at=data["stopped_at"],
-            attempts=int(data.get("attempts", 0)),
-            version=int(data.get("version", _SENTINEL_VERSION)),
-        )
-    except Exception as e:
-        logger.warning(f"sentinel read failed for {target}: {e}")
-        return None
-
-
-def bump_attempts(log_dir: Path) -> int:
-    """Increment attempts on the sentinel; returns new value.
-    If sentinel is missing, recreate with attempts=1 (best-effort)."""
-    state = read_sentinel(log_dir) or SentinelState.now()
-    state.attempts += 1
-    write_sentinel(log_dir, state)
-    return state.attempts
+    @staticmethod
+    def bump_attempts(log_dir: Path) -> int:
+        """Increment attempts on the sentinel; returns new value.
+        If sentinel is missing, recreate with attempts=1 (best-effort)."""
+        state = Sentinel.read(log_dir) or SentinelState.now()
+        state.attempts += 1
+        Sentinel.write(log_dir, state)
+        return state.attempts

--- a/rock/deployments/log_cleanup_sentinel.py
+++ b/rock/deployments/log_cleanup_sentinel.py
@@ -62,7 +62,8 @@ def _atomic_write(target: Path, content: str) -> None:
         with os.fdopen(fd, "w") as f:
             f.write(content)
         os.replace(tmp_name, target)
-    except Exception:
+    except Exception as e:
+        logger.warning(f"[sentinel] _atomic_write failed for {target}: {e}", exc_info=True)
         try:
             os.unlink(tmp_name)
         except OSError:

--- a/rock/deployments/log_cleanup_sentinel.py
+++ b/rock/deployments/log_cleanup_sentinel.py
@@ -1,0 +1,104 @@
+"""Sentinel file read/write helpers for deferred sandbox log archival.
+
+The sentinel is a small JSON file dropped into a stopped sandbox's log
+directory by DockerDeployment._stop(); SandboxLogArchiveTask later picks
+up dirs whose sentinel is older than `oss.keep_days_before_archive` and
+ships them to OSS.
+
+Sentinel JSON shape (versioned for future evolution):
+    {
+        "version": 1,
+        "stopped_at": "2026-05-13T10:30:00+08:00",  // ISO 8601, tz-aware
+        "attempts": 0                                // archive retry count
+    }
+"""
+
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+
+from rock.logger import init_logger
+
+logger = init_logger(__name__)
+
+LOG_STOPPED_SENTINEL = ".rock_stopped_at"
+_SENTINEL_VERSION = 1
+
+
+@dataclass
+class SentinelState:
+    stopped_at: str
+    attempts: int = 0
+    version: int = _SENTINEL_VERSION
+
+    @classmethod
+    def now(cls) -> "SentinelState":
+        return cls(stopped_at=datetime.now().astimezone().isoformat(), attempts=0)
+
+
+def sentinel_path(log_dir: Path) -> Path:
+    return log_dir / LOG_STOPPED_SENTINEL
+
+
+def dump_state(state: SentinelState) -> str:
+    """Serialize a SentinelState to its on-disk JSON form.
+
+    Single source of truth for the schema — admin-side code that needs to
+    overwrite a remote worker's sentinel via runtime.write_file() reuses
+    this so the JSON layout stays consistent with local writes.
+    """
+    return json.dumps(asdict(state), ensure_ascii=False)
+
+
+def _atomic_write(target: Path, content: str) -> None:
+    # tempfile + rename inside the same directory: rename is POSIX atomic,
+    # so a crashed write never leaves a half-written sentinel on disk.
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=target.name + ".", suffix=".tmp", dir=str(target.parent))
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        os.replace(tmp_name, target)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_sentinel(log_dir: Path, state: SentinelState | None = None) -> None:
+    target = sentinel_path(log_dir)
+    if state is None:
+        state = SentinelState.now()
+    _atomic_write(target, dump_state(state))
+
+
+def read_sentinel(log_dir: Path) -> SentinelState | None:
+    """Returns None when sentinel missing or unreadable. Caller treats
+    None as "not yet stopped" (i.e. skip archive)."""
+    target = sentinel_path(log_dir)
+    if not target.is_file():
+        return None
+    try:
+        data = json.loads(target.read_text())
+        return SentinelState(
+            stopped_at=data["stopped_at"],
+            attempts=int(data.get("attempts", 0)),
+            version=int(data.get("version", _SENTINEL_VERSION)),
+        )
+    except Exception as e:
+        logger.warning(f"sentinel read failed for {target}: {e}")
+        return None
+
+
+def bump_attempts(log_dir: Path) -> int:
+    """Increment attempts on the sentinel; returns new value.
+    If sentinel is missing, recreate with attempts=1 (best-effort)."""
+    state = read_sentinel(log_dir) or SentinelState.now()
+    state.attempts += 1
+    write_sentinel(log_dir, state)
+    return state.attempts

--- a/tests/unit/admin/scheduler/test_sandbox_log_archive_task.py
+++ b/tests/unit/admin/scheduler/test_sandbox_log_archive_task.py
@@ -5,7 +5,7 @@ Architecture under test:
   - admin reads sentinel JSON via /read_file
   - admin runs `tar | ossutil cp && rm -rf` via /execute, with AK/SK in
     SandboxCommand.env so they never leak into argv
-  - on failure, admin bumps attempts via /write_file (dump_state JSON)
+  - on failure, admin bumps attempts via /write_file (Sentinel.dump JSON)
   - exceeding archive_max_attempts → outcome `failed_persist`, dir is
     left intact for FileCleanupTask
 """

--- a/tests/unit/admin/scheduler/test_sandbox_log_archive_task.py
+++ b/tests/unit/admin/scheduler/test_sandbox_log_archive_task.py
@@ -37,9 +37,9 @@ def mock_oss_config():
     cfg.oss.endpoint = ""
     cfg.oss.access_key_id = ""
     cfg.oss.access_key_secret = ""
-    cfg.oss.archive_prefix = "rock-archives/"
-    cfg.oss.keep_days_before_archive = 3
-    cfg.oss.archive_max_attempts = 3
+    cfg.sandbox_config.log.archive_prefix = "rock-archives/"
+    cfg.sandbox_config.log.keep_days_before_archive = 3
+    cfg.sandbox_config.log.archive_max_attempts = 3
     return cfg
 
 
@@ -171,8 +171,10 @@ class TestProcessOne:
         assert cmd_arg.env == {"OSS_ACCESS_KEY_ID": "LEAKY_AK", "OSS_ACCESS_KEY_SECRET": "LEAKY_SK"}
         assert "LEAKY_AK" not in cmd_arg.command
         assert "LEAKY_SK" not in cmd_arg.command
-        # Sanity: actually a tar|ossutil pipeline targeting the right OSS object
-        assert "tar -czf -" in cmd_arg.command
+        # Sanity: actually a tar + ossutil cp pipeline targeting the right OSS object
+        # (build_command rewrites tar into a temp file under mktemp -d, then ossutil cp
+        # reads it with a temp credentials file; no stdin pipe for ossutil 1.7.x compat).
+        assert "tar -czf" in cmd_arg.command
         assert "ossutil cp" in cmd_arg.command
         assert "oss://chatos-rock/rock-archives/sandbox-logs/sb-old.tar.gz" in cmd_arg.command
         assert cmd_arg.shell is True

--- a/tests/unit/admin/scheduler/test_sandbox_log_archive_task.py
+++ b/tests/unit/admin/scheduler/test_sandbox_log_archive_task.py
@@ -1,0 +1,327 @@
+"""Tests for SandboxLogArchiveTask — deferred archival via /execute.
+
+Architecture under test:
+  - admin discovers candidate dirs via /execute (find … -name sentinel)
+  - admin reads sentinel JSON via /read_file
+  - admin runs `tar | ossutil cp && rm -rf` via /execute, with AK/SK in
+    SandboxCommand.env so they never leak into argv
+  - on failure, admin bumps attempts via /write_file (dump_state JSON)
+  - exceeding archive_max_attempts → outcome `failed_persist`, dir is
+    left intact for FileCleanupTask
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from rock.admin.metrics.constants import MetricsConstants
+from rock.admin.scheduler.task_base import TaskStatusEnum
+
+
+def _sentinel_json(days_ago: int, attempts: int = 0) -> str:
+    stopped_at = (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
+    return json.dumps({"stopped_at": stopped_at, "attempts": attempts, "version": 1})
+
+
+@pytest.fixture
+def mock_oss_config():
+    """Fully-populated primary OSS account so run_action does not early-return."""
+    cfg = MagicMock()
+    cfg.oss.primary.bucket = "chatos-rock"
+    cfg.oss.primary.endpoint = "oss-cn-hangzhou.aliyuncs.com"
+    cfg.oss.primary.access_key_id = "PRIMARY_AK"
+    cfg.oss.primary.access_key_secret = "PRIMARY_SK"
+    cfg.oss.bucket = ""
+    cfg.oss.endpoint = ""
+    cfg.oss.access_key_id = ""
+    cfg.oss.access_key_secret = ""
+    cfg.oss.archive_prefix = "rock-archives/"
+    cfg.oss.keep_days_before_archive = 3
+    cfg.oss.archive_max_attempts = 3
+    return cfg
+
+
+def _make_task(log_root: str = "/data/sandbox_logs"):
+    with patch("rock.admin.scheduler.tasks.sandbox_log_archive_task.MetricsMonitor") as mock_metrics:
+        mock_metrics.create.return_value = MagicMock()
+        from rock.admin.scheduler.tasks.sandbox_log_archive_task import SandboxLogArchiveTask
+
+        return SandboxLogArchiveTask(log_root=log_root)
+
+
+def _runtime(execute_returns=None, read_file_content: str = "", write_file_ok: bool = True):
+    runtime = MagicMock()
+    if execute_returns is None:
+        execute_returns = [MagicMock(stdout="", exit_code=0, stderr="")]
+    if not isinstance(execute_returns, list):
+        execute_returns = [execute_returns]
+    runtime.execute = AsyncMock(side_effect=execute_returns)
+    runtime.read_file = AsyncMock(return_value=MagicMock(content=read_file_content))
+    runtime.write_file = AsyncMock(
+        return_value=MagicMock(success=write_file_ok, message="ok" if write_file_ok else "fail")
+    )
+    return runtime
+
+
+class TestProcessOne:
+    @pytest.mark.asyncio
+    async def test_too_young_skips_archive(self):
+        task = _make_task()
+        runtime = _runtime(read_file_content=_sentinel_json(days_ago=1))
+
+        outcome = await task._process_one(
+            runtime=runtime,
+            log_dir="/data/sandbox_logs/young-sb",
+            keep_days=3,
+            max_attempts=3,
+            archive_prefix="rock-archives/",
+            bucket="b",
+            endpoint="e",
+            access_key_id="ak",
+            access_key_secret="sk",
+        )
+        assert outcome == "too_young"
+        runtime.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skipped_when_sentinel_empty(self):
+        task = _make_task()
+        runtime = _runtime(read_file_content="")
+
+        outcome = await task._process_one(
+            runtime=runtime,
+            log_dir="/data/sandbox_logs/empty",
+            keep_days=3,
+            max_attempts=3,
+            archive_prefix="",
+            bucket="b",
+            endpoint="e",
+            access_key_id="ak",
+            access_key_secret="sk",
+        )
+        assert outcome == "skipped_no_sentinel"
+
+    @pytest.mark.asyncio
+    async def test_skipped_when_read_file_raises(self):
+        task = _make_task()
+        runtime = MagicMock()
+        runtime.read_file = AsyncMock(side_effect=Exception("not found"))
+        runtime.execute = AsyncMock()
+
+        outcome = await task._process_one(
+            runtime=runtime,
+            log_dir="/data/sandbox_logs/missing",
+            keep_days=3,
+            max_attempts=3,
+            archive_prefix="",
+            bucket="b",
+            endpoint="e",
+            access_key_id="ak",
+            access_key_secret="sk",
+        )
+        assert outcome == "skipped_no_sentinel"
+        runtime.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skipped_on_corrupt_sentinel(self):
+        task = _make_task()
+        runtime = _runtime(read_file_content="not-json {{{")
+
+        outcome = await task._process_one(
+            runtime=runtime,
+            log_dir="/data/sandbox_logs/corrupt",
+            keep_days=3,
+            max_attempts=3,
+            archive_prefix="",
+            bucket="b",
+            endpoint="e",
+            access_key_id="ak",
+            access_key_secret="sk",
+        )
+        assert outcome == "skipped_no_sentinel"
+
+    @pytest.mark.asyncio
+    async def test_archive_success_runs_pipeline_with_ak_in_env_only(self):
+        task = _make_task()
+        runtime = _runtime(
+            execute_returns=[MagicMock(stdout="", exit_code=0, stderr="")],
+            read_file_content=_sentinel_json(days_ago=5),
+        )
+
+        outcome = await task._process_one(
+            runtime=runtime,
+            log_dir="/data/sandbox_logs/sb-old",
+            keep_days=3,
+            max_attempts=3,
+            archive_prefix="rock-archives/",
+            bucket="chatos-rock",
+            endpoint="oss-cn-hangzhou.aliyuncs.com",
+            access_key_id="LEAKY_AK",
+            access_key_secret="LEAKY_SK",
+        )
+        assert outcome == "archived"
+
+        # Inspect the SandboxCommand passed to /execute
+        runtime.execute.assert_awaited_once()
+        cmd_arg = runtime.execute.await_args.args[0]
+        # AK/SK MUST be in env, not in command string. Defense against the
+        # most expensive regression in this PR (credential leak via `ps`).
+        assert cmd_arg.env == {"OSS_ACCESS_KEY_ID": "LEAKY_AK", "OSS_ACCESS_KEY_SECRET": "LEAKY_SK"}
+        assert "LEAKY_AK" not in cmd_arg.command
+        assert "LEAKY_SK" not in cmd_arg.command
+        # Sanity: actually a tar|ossutil pipeline targeting the right OSS object
+        assert "tar -czf -" in cmd_arg.command
+        assert "ossutil cp" in cmd_arg.command
+        assert "oss://chatos-rock/rock-archives/sandbox-logs/sb-old.tar.gz" in cmd_arg.command
+        assert cmd_arg.shell is True
+
+    @pytest.mark.asyncio
+    async def test_failed_pending_bumps_attempts_via_write_file(self):
+        task = _make_task()
+        runtime = _runtime(
+            execute_returns=[MagicMock(stdout="", exit_code=1, stderr="ossutil: timeout")],
+            read_file_content=_sentinel_json(days_ago=4, attempts=0),
+        )
+
+        outcome = await task._process_one(
+            runtime=runtime,
+            log_dir="/data/sandbox_logs/sb-flaky",
+            keep_days=3,
+            max_attempts=3,
+            archive_prefix="",
+            bucket="b",
+            endpoint="e",
+            access_key_id="ak",
+            access_key_secret="sk",
+        )
+        assert outcome == "failed_pending"
+        runtime.write_file.assert_awaited_once()
+        write_arg = runtime.write_file.await_args.args[0]
+        assert write_arg.path.endswith("/.rock_stopped_at")
+        # bumped attempts persisted as JSON
+        body = json.loads(write_arg.content)
+        assert body["attempts"] == 1
+        assert body["version"] == 1
+
+    @pytest.mark.asyncio
+    async def test_failed_persist_when_attempts_reach_max(self):
+        task = _make_task()
+        runtime = _runtime(
+            execute_returns=[MagicMock(stdout="", exit_code=1, stderr="dead")],
+            read_file_content=_sentinel_json(days_ago=10, attempts=2),
+        )
+
+        outcome = await task._process_one(
+            runtime=runtime,
+            log_dir="/data/sandbox_logs/sb-dead",
+            keep_days=3,
+            max_attempts=3,
+            archive_prefix="",
+            bucket="b",
+            endpoint="e",
+            access_key_id="ak",
+            access_key_secret="sk",
+        )
+        assert outcome == "failed_persist"
+        # The sentinel still gets bumped (attempts=3) so a future tick
+        # doesn't endlessly retry the same dir.
+        body = json.loads(runtime.write_file.await_args.args[0].content)
+        assert body["attempts"] == 3
+
+
+class TestRunAction:
+    @pytest.mark.asyncio
+    async def test_empty_log_root_returns_success(self, mock_oss_config):
+        task = _make_task()
+        task.log_root = ""  # force empty: env_vars fallback may otherwise populate it
+        runtime = AsyncMock()
+        with patch("rock.admin.scheduler.tasks.sandbox_log_archive_task.RockConfig") as rc:
+            rc.from_env.return_value = mock_oss_config
+            result = await task.run_action(runtime)
+        assert result["status"] == TaskStatusEnum.SUCCESS
+        assert "no log root" in result.get("message", "")
+
+    @pytest.mark.asyncio
+    async def test_skips_when_oss_primary_incomplete(self, mock_oss_config):
+        mock_oss_config.oss.primary.bucket = ""  # disables archival
+        task = _make_task()
+        runtime = MagicMock()
+        runtime.execute = AsyncMock()  # must NOT be called when primary missing
+        with patch("rock.admin.scheduler.tasks.sandbox_log_archive_task.RockConfig") as rc:
+            rc.from_env.return_value = mock_oss_config
+            result = await task.run_action(runtime)
+        assert result["status"] == TaskStatusEnum.SUCCESS
+        assert "oss primary" in result.get("message", "")
+        runtime.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_candidates_returns_zero_counts(self, mock_oss_config):
+        task = _make_task()
+        runtime = _runtime(execute_returns=[MagicMock(stdout="", exit_code=0, stderr="")])
+        with patch("rock.admin.scheduler.tasks.sandbox_log_archive_task.RockConfig") as rc:
+            rc.from_env.return_value = mock_oss_config
+            result = await task.run_action(runtime)
+        assert result["status"] == TaskStatusEnum.SUCCESS
+        assert result["archived"] == 0
+        assert result["skipped_too_young"] == 0
+        assert result["failed_pending"] == 0
+        assert result["failed_persist"] == 0
+
+    @pytest.mark.asyncio
+    async def test_aggregates_mixed_outcomes_and_emits_failed_persist_metric(self, mock_oss_config):
+        task = _make_task()
+        runtime = MagicMock()
+        # 1) discovery `find`
+        # 2) archive sb-old (success)
+        # 3) archive sb-dead (fail with attempts=2 -> failed_persist)
+        runtime.execute = AsyncMock(
+            side_effect=[
+                MagicMock(
+                    stdout="/data/sandbox_logs/sb-old\n/data/sandbox_logs/sb-young\n/data/sandbox_logs/sb-dead\n",
+                    exit_code=0,
+                    stderr="",
+                ),
+                MagicMock(stdout="", exit_code=0, stderr=""),
+                MagicMock(stdout="", exit_code=1, stderr="ossutil fail"),
+            ]
+        )
+        runtime.read_file = AsyncMock(
+            side_effect=[
+                MagicMock(content=_sentinel_json(days_ago=5)),
+                MagicMock(content=_sentinel_json(days_ago=1)),
+                MagicMock(content=_sentinel_json(days_ago=10, attempts=2)),
+            ]
+        )
+        runtime.write_file = AsyncMock(return_value=MagicMock(success=True, message=""))
+
+        with patch("rock.admin.scheduler.tasks.sandbox_log_archive_task.RockConfig") as rc:
+            rc.from_env.return_value = mock_oss_config
+            result = await task.run_action(runtime)
+
+        assert result["archived"] == 1
+        assert result["skipped_too_young"] == 1
+        assert result["failed_persist"] == 1
+        assert result["failed_pending"] == 0
+
+        # Metric: only failed_persist increments, with a sandbox_id label
+        task.metrics_monitor.record_counter_by_name.assert_called_once()
+        call = task.metrics_monitor.record_counter_by_name.call_args
+        assert call.args[0] == MetricsConstants.SANDBOX_LOG_ARCHIVE_FAILED_PERSIST
+        assert call.args[1] == 1
+        assert call.args[2] == {"sandbox_id": "sb-dead"}
+
+
+class TestFromConfig:
+    def test_from_config_with_params(self):
+        with patch("rock.admin.scheduler.tasks.sandbox_log_archive_task.MetricsMonitor") as mock_metrics:
+            mock_metrics.create.return_value = MagicMock()
+            from rock.admin.scheduler.tasks.sandbox_log_archive_task import SandboxLogArchiveTask
+
+            cfg = MagicMock()
+            cfg.interval_seconds = 43200
+            cfg.params = {"log_root": "/custom/path"}
+            task = SandboxLogArchiveTask.from_config(cfg)
+            assert task.log_root == "/custom/path"
+            assert task.interval_seconds == 43200

--- a/tests/unit/deployments/test_log_cleanup_sentinel.py
+++ b/tests/unit/deployments/test_log_cleanup_sentinel.py
@@ -7,12 +7,8 @@ import pytest
 
 from rock.deployments.log_cleanup_sentinel import (
     LOG_STOPPED_SENTINEL,
+    Sentinel,
     SentinelState,
-    bump_attempts,
-    dump_state,
-    read_sentinel,
-    sentinel_path,
-    write_sentinel,
 )
 
 
@@ -26,14 +22,14 @@ def log_dir(tmp_path):
 
 class TestSentinelPath:
     def test_returns_correct_path(self, log_dir):
-        result = sentinel_path(log_dir)
+        result = Sentinel.path(log_dir)
         assert result == log_dir / LOG_STOPPED_SENTINEL
 
 
 class TestWriteSentinel:
     def test_writes_default_state(self, log_dir):
-        write_sentinel(log_dir)
-        target = sentinel_path(log_dir)
+        Sentinel.write(log_dir)
+        target = Sentinel.path(log_dir)
         assert target.is_file()
         data = json.loads(target.read_text())
         assert data["version"] == 1
@@ -44,67 +40,67 @@ class TestWriteSentinel:
 
     def test_writes_custom_state(self, log_dir):
         state = SentinelState(stopped_at="2026-05-10T10:00:00+08:00", attempts=2, version=1)
-        write_sentinel(log_dir, state)
-        data = json.loads(sentinel_path(log_dir).read_text())
+        Sentinel.write(log_dir, state)
+        data = json.loads(Sentinel.path(log_dir).read_text())
         assert data["stopped_at"] == "2026-05-10T10:00:00+08:00"
         assert data["attempts"] == 2
         assert data["version"] == 1
 
     def test_overwrites_existing_sentinel(self, log_dir):
-        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-01T00:00:00+08:00", attempts=0))
-        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-02T00:00:00+08:00", attempts=1))
-        data = json.loads(sentinel_path(log_dir).read_text())
+        Sentinel.write(log_dir, SentinelState(stopped_at="2026-05-01T00:00:00+08:00", attempts=0))
+        Sentinel.write(log_dir, SentinelState(stopped_at="2026-05-02T00:00:00+08:00", attempts=1))
+        data = json.loads(Sentinel.path(log_dir).read_text())
         assert data["stopped_at"] == "2026-05-02T00:00:00+08:00"
         assert data["attempts"] == 1
 
 
 class TestReadSentinel:
     def test_reads_valid_sentinel(self, log_dir):
-        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-10T12:00:00+08:00", attempts=1))
-        state = read_sentinel(log_dir)
+        Sentinel.write(log_dir, SentinelState(stopped_at="2026-05-10T12:00:00+08:00", attempts=1))
+        state = Sentinel.read(log_dir)
         assert state is not None
         assert state.stopped_at == "2026-05-10T12:00:00+08:00"
         assert state.attempts == 1
         assert state.version == 1
 
     def test_returns_none_when_missing(self, log_dir):
-        assert read_sentinel(log_dir) is None
+        assert Sentinel.read(log_dir) is None
 
     def test_returns_none_on_corrupt_json(self, log_dir):
-        sentinel_path(log_dir).write_text("not valid json {{{")
-        assert read_sentinel(log_dir) is None
+        Sentinel.path(log_dir).write_text("not valid json {{{")
+        assert Sentinel.read(log_dir) is None
 
     def test_returns_none_on_missing_stopped_at_key(self, log_dir):
-        sentinel_path(log_dir).write_text(json.dumps({"version": 1, "attempts": 0}))
-        assert read_sentinel(log_dir) is None
+        Sentinel.path(log_dir).write_text(json.dumps({"version": 1, "attempts": 0}))
+        assert Sentinel.read(log_dir) is None
 
     def test_defaults_attempts_to_zero(self, log_dir):
-        sentinel_path(log_dir).write_text(json.dumps({"stopped_at": "2026-05-10T00:00:00Z"}))
-        state = read_sentinel(log_dir)
+        Sentinel.path(log_dir).write_text(json.dumps({"stopped_at": "2026-05-10T00:00:00Z"}))
+        state = Sentinel.read(log_dir)
         assert state is not None
         assert state.attempts == 0
 
 
 class TestBumpAttempts:
     def test_increments_existing_sentinel(self, log_dir):
-        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-10T00:00:00+08:00", attempts=0))
-        result = bump_attempts(log_dir)
+        Sentinel.write(log_dir, SentinelState(stopped_at="2026-05-10T00:00:00+08:00", attempts=0))
+        result = Sentinel.bump_attempts(log_dir)
         assert result == 1
-        state = read_sentinel(log_dir)
+        state = Sentinel.read(log_dir)
         assert state.attempts == 1
 
     def test_increments_multiple_times(self, log_dir):
-        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-10T00:00:00+08:00", attempts=0))
-        bump_attempts(log_dir)
-        bump_attempts(log_dir)
-        result = bump_attempts(log_dir)
+        Sentinel.write(log_dir, SentinelState(stopped_at="2026-05-10T00:00:00+08:00", attempts=0))
+        Sentinel.bump_attempts(log_dir)
+        Sentinel.bump_attempts(log_dir)
+        result = Sentinel.bump_attempts(log_dir)
         assert result == 3
 
     def test_creates_sentinel_if_missing(self, log_dir):
         """If sentinel is missing, bump_attempts recreates with attempts=1."""
-        result = bump_attempts(log_dir)
+        result = Sentinel.bump_attempts(log_dir)
         assert result == 1
-        state = read_sentinel(log_dir)
+        state = Sentinel.read(log_dir)
         assert state is not None
         assert state.attempts == 1
 
@@ -121,27 +117,27 @@ class TestSentinelState:
     def test_round_trip(self, log_dir):
         """Write and read back should produce identical state."""
         original = SentinelState(stopped_at="2026-05-13T15:30:00+08:00", attempts=2, version=1)
-        write_sentinel(log_dir, original)
-        restored = read_sentinel(log_dir)
+        Sentinel.write(log_dir, original)
+        restored = Sentinel.read(log_dir)
         assert restored.stopped_at == original.stopped_at
         assert restored.attempts == original.attempts
         assert restored.version == original.version
 
 
-class TestDumpState:
-    """dump_state is the single source of truth for the sentinel JSON shape;
+class TestSentinelDump:
+    """Sentinel.dump is the single source of truth for the sentinel JSON shape;
     admin-side code that overwrites a remote worker's sentinel via
     runtime.write_file() reuses it to avoid schema drift."""
 
     def test_returns_json_string_with_all_fields(self):
         s = SentinelState(stopped_at="2026-05-13T10:00:00+08:00", attempts=2, version=1)
-        result = json.loads(dump_state(s))
+        result = json.loads(Sentinel.dump(s))
         assert result == {"stopped_at": "2026-05-13T10:00:00+08:00", "attempts": 2, "version": 1}
 
     def test_dump_then_load_round_trip(self, log_dir):
         original = SentinelState(stopped_at="2026-05-13T10:00:00+08:00", attempts=3, version=1)
-        sentinel_path(log_dir).write_text(dump_state(original))
-        restored = read_sentinel(log_dir)
+        Sentinel.path(log_dir).write_text(Sentinel.dump(original))
+        restored = Sentinel.read(log_dir)
         assert restored.stopped_at == original.stopped_at
         assert restored.attempts == original.attempts
 
@@ -149,6 +145,6 @@ class TestDumpState:
 class TestAtomicWrite:
     def test_no_partial_file_left_on_disk_after_write(self, log_dir):
         """After a successful write, only the sentinel exists; no .tmp leftover."""
-        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-13T10:00:00+08:00"))
+        Sentinel.write(log_dir, SentinelState(stopped_at="2026-05-13T10:00:00+08:00"))
         leftovers = [p.name for p in log_dir.iterdir() if p.name.endswith(".tmp")]
         assert leftovers == []

--- a/tests/unit/deployments/test_log_cleanup_sentinel.py
+++ b/tests/unit/deployments/test_log_cleanup_sentinel.py
@@ -1,0 +1,154 @@
+"""Tests for rock.deployments.log_cleanup_sentinel — sentinel read/write/bump helpers."""
+
+import json
+from datetime import datetime
+
+import pytest
+
+from rock.deployments.log_cleanup_sentinel import (
+    LOG_STOPPED_SENTINEL,
+    SentinelState,
+    bump_attempts,
+    dump_state,
+    read_sentinel,
+    sentinel_path,
+    write_sentinel,
+)
+
+
+@pytest.fixture
+def log_dir(tmp_path):
+    """Create a temporary directory simulating a sandbox log directory."""
+    d = tmp_path / "sandbox-abc123"
+    d.mkdir()
+    return d
+
+
+class TestSentinelPath:
+    def test_returns_correct_path(self, log_dir):
+        result = sentinel_path(log_dir)
+        assert result == log_dir / LOG_STOPPED_SENTINEL
+
+
+class TestWriteSentinel:
+    def test_writes_default_state(self, log_dir):
+        write_sentinel(log_dir)
+        target = sentinel_path(log_dir)
+        assert target.is_file()
+        data = json.loads(target.read_text())
+        assert data["version"] == 1
+        assert data["attempts"] == 0
+        assert "stopped_at" in data
+        # stopped_at should be a valid ISO 8601 timestamp
+        datetime.fromisoformat(data["stopped_at"])
+
+    def test_writes_custom_state(self, log_dir):
+        state = SentinelState(stopped_at="2026-05-10T10:00:00+08:00", attempts=2, version=1)
+        write_sentinel(log_dir, state)
+        data = json.loads(sentinel_path(log_dir).read_text())
+        assert data["stopped_at"] == "2026-05-10T10:00:00+08:00"
+        assert data["attempts"] == 2
+        assert data["version"] == 1
+
+    def test_overwrites_existing_sentinel(self, log_dir):
+        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-01T00:00:00+08:00", attempts=0))
+        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-02T00:00:00+08:00", attempts=1))
+        data = json.loads(sentinel_path(log_dir).read_text())
+        assert data["stopped_at"] == "2026-05-02T00:00:00+08:00"
+        assert data["attempts"] == 1
+
+
+class TestReadSentinel:
+    def test_reads_valid_sentinel(self, log_dir):
+        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-10T12:00:00+08:00", attempts=1))
+        state = read_sentinel(log_dir)
+        assert state is not None
+        assert state.stopped_at == "2026-05-10T12:00:00+08:00"
+        assert state.attempts == 1
+        assert state.version == 1
+
+    def test_returns_none_when_missing(self, log_dir):
+        assert read_sentinel(log_dir) is None
+
+    def test_returns_none_on_corrupt_json(self, log_dir):
+        sentinel_path(log_dir).write_text("not valid json {{{")
+        assert read_sentinel(log_dir) is None
+
+    def test_returns_none_on_missing_stopped_at_key(self, log_dir):
+        sentinel_path(log_dir).write_text(json.dumps({"version": 1, "attempts": 0}))
+        assert read_sentinel(log_dir) is None
+
+    def test_defaults_attempts_to_zero(self, log_dir):
+        sentinel_path(log_dir).write_text(json.dumps({"stopped_at": "2026-05-10T00:00:00Z"}))
+        state = read_sentinel(log_dir)
+        assert state is not None
+        assert state.attempts == 0
+
+
+class TestBumpAttempts:
+    def test_increments_existing_sentinel(self, log_dir):
+        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-10T00:00:00+08:00", attempts=0))
+        result = bump_attempts(log_dir)
+        assert result == 1
+        state = read_sentinel(log_dir)
+        assert state.attempts == 1
+
+    def test_increments_multiple_times(self, log_dir):
+        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-10T00:00:00+08:00", attempts=0))
+        bump_attempts(log_dir)
+        bump_attempts(log_dir)
+        result = bump_attempts(log_dir)
+        assert result == 3
+
+    def test_creates_sentinel_if_missing(self, log_dir):
+        """If sentinel is missing, bump_attempts recreates with attempts=1."""
+        result = bump_attempts(log_dir)
+        assert result == 1
+        state = read_sentinel(log_dir)
+        assert state is not None
+        assert state.attempts == 1
+
+
+class TestSentinelState:
+    def test_now_factory(self):
+        state = SentinelState.now()
+        assert state.attempts == 0
+        assert state.version == 1
+        # Verify it's a valid ISO timestamp
+        dt = datetime.fromisoformat(state.stopped_at)
+        assert dt.tzinfo is not None  # tz-aware
+
+    def test_round_trip(self, log_dir):
+        """Write and read back should produce identical state."""
+        original = SentinelState(stopped_at="2026-05-13T15:30:00+08:00", attempts=2, version=1)
+        write_sentinel(log_dir, original)
+        restored = read_sentinel(log_dir)
+        assert restored.stopped_at == original.stopped_at
+        assert restored.attempts == original.attempts
+        assert restored.version == original.version
+
+
+class TestDumpState:
+    """dump_state is the single source of truth for the sentinel JSON shape;
+    admin-side code that overwrites a remote worker's sentinel via
+    runtime.write_file() reuses it to avoid schema drift."""
+
+    def test_returns_json_string_with_all_fields(self):
+        s = SentinelState(stopped_at="2026-05-13T10:00:00+08:00", attempts=2, version=1)
+        result = json.loads(dump_state(s))
+        assert result == {"stopped_at": "2026-05-13T10:00:00+08:00", "attempts": 2, "version": 1}
+
+    def test_dump_then_load_round_trip(self, log_dir):
+        original = SentinelState(stopped_at="2026-05-13T10:00:00+08:00", attempts=3, version=1)
+        sentinel_path(log_dir).write_text(dump_state(original))
+        restored = read_sentinel(log_dir)
+        assert restored.stopped_at == original.stopped_at
+        assert restored.attempts == original.attempts
+
+
+class TestAtomicWrite:
+    def test_no_partial_file_left_on_disk_after_write(self, log_dir):
+        """After a successful write, only the sentinel exists; no .tmp leftover."""
+        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-13T10:00:00+08:00"))
+        leftovers = [p.name for p in log_dir.iterdir() if p.name.endswith(".tmp")]
+        assert leftovers == []


### PR DESCRIPTION
## Summary
  - 新增 `SandboxLogArchiveTask`：每日扫描 worker 上含 sentinel 的日志目录，对 stopped >
  `keep_days` 的目录执行 `tar | ossutil cp && rm -rf`
  - 全部动作复用既有 RPC（`/execute`、`/read_file`、`/write_file`），**不在 `local_api.py`
   新增 endpoint**
  - AK/SK 通过 `SandboxCommand.env` 注入 ossutil 子进程，**不进命令字符串**
  - 指标从 6 个精简到 1 个：仅保留 `sandbox.log.archive.failed_persist`

  ## Files (6, ≤8)
  - `rock/admin/scheduler/tasks/sandbox_log_archive_task.py` (NEW)
  - `rock/admin/scheduler/tasks/__init__.py` (export)
  - `rock/admin/metrics/constants.py` (-5 +1 metric)
  - `rock/admin/metrics/monitor.py` (-5 register calls)
  - `tests/unit/admin/scheduler/__init__.py` (NEW, empty)
  - `tests/unit/admin/scheduler/test_sandbox_log_archive_task.py` (NEW)

  ## Test plan
  - [ ] `uv run pytest tests/unit/admin/scheduler/test_sandbox_log_archive_task.py -v`
  - [ ] `uv run ruff check rock/admin/scheduler/tasks/sandbox_log_archive_task.py
  rock/admin/metrics/`
  - [ ] 关键断言：AK/SK 不在 command 字符串中

  refs #959