### PR TITLE
feature(cli): add `rock storage get` to download archived sandbox logs from OSS

### DIFF
--- a/rock/cli/command/storage.py
+++ b/rock/cli/command/storage.py
@@ -1,0 +1,109 @@
+"""`rock storage get <sandbox_id>` — download an archived sandbox log tarball.
+
+Thin CLI wrapper around :class:`rock.sdk.sandbox.storage_client.StorageClient`.
+This file only handles argparse + user-facing output; all OSS/STS logic lives
+in the SDK so it can be reused programmatically.
+"""
+
+import argparse
+import os
+
+from rock.cli.command.command import Command
+from rock.logger import init_logger
+from rock.sdk.sandbox.storage_client import ArchiveNotFoundError, StorageClient
+
+logger = init_logger("rock.cli.storage")
+
+
+class StorageCommand(Command):
+    """rock storage get <sandbox_id> [-o PATH]"""
+
+    name = "storage"
+
+    async def arun(self, args: argparse.Namespace):
+        action = getattr(args, "storage_action", None)
+        if action == "get":
+            await self._get(args)
+            return
+        # argparse with required=True surfaces missing-action errors itself,
+        # but guard explicitly so subclasses/tests get a clear message.
+        raise ValueError(f"Unknown storage action: {action!r}")
+
+    async def _get(self, args: argparse.Namespace):
+        client = StorageClient(
+            base_url=args.base_url,
+            auth_token=getattr(args, "auth_token", None),
+            extra_headers=getattr(args, "extra_headers", None),
+        )
+        out_path = self._resolve_output_path(args.output, args.sandbox_id)
+
+        try:
+            written = await client.download_archived_log(
+                sandbox_id=args.sandbox_id,
+                output_path=out_path,
+                archive_prefix=args.archive_prefix or "",
+                bucket=args.bucket,
+                endpoint=args.endpoint,
+            )
+        except ArchiveNotFoundError as e:
+            print(f"NOT FOUND: {e}")
+            logger.error(f"Archive not found for sandbox {args.sandbox_id}: {e}")
+            return
+        except RuntimeError:
+            # Pre-flight errors (STS fetch, OSS config missing) — let them
+            # propagate so the user sees the configuration explanation.
+            raise
+        except Exception as e:
+            # OSS connectivity / unexpected oss2 errors — print + swallow.
+            print(f"FAILED: {e}")
+            logger.exception(f"Failed to download archive for {args.sandbox_id}: {e}")
+            return
+
+        print(f"OK: {written}")
+        print(f"To extract: tar -xzf {written}")
+
+    @staticmethod
+    def _resolve_output_path(output: str | None, sandbox_id: str) -> str:
+        if not output:
+            return f"./{sandbox_id}.tar.gz"
+        # If caller passed a directory (existing or with trailing /), drop the file inside.
+        if output.endswith("/") or os.path.isdir(output):
+            return os.path.join(output.rstrip("/"), f"{sandbox_id}.tar.gz")
+        return output
+
+    @staticmethod
+    async def add_parser_to(subparsers: argparse._SubParsersAction):
+        storage = subparsers.add_parser(
+            "storage",
+            help="Manage sandbox archive storage on OSS",
+            description="Download archived sandbox log tarballs from OSS.",
+        )
+        storage_sub = storage.add_subparsers(dest="storage_action", required=True)
+
+        get_p = storage_sub.add_parser("get", help="Download an archived sandbox log tarball")
+        get_p.add_argument("sandbox_id", help="Sandbox id (matches the directory name under ROCK_LOGGING_PATH)")
+        get_p.add_argument(
+            "-o",
+            "--output",
+            default=None,
+            help="Output file path or directory (default: ./<sandbox_id>.tar.gz)",
+        )
+        get_p.add_argument(
+            "--archive-prefix",
+            dest="archive_prefix",
+            default="",
+            help=(
+                "OSS key prefix used at archive time (must match admin's "
+                "sandbox_config.log.archive_prefix, e.g. 'rock-archives/')."
+            ),
+        )
+        get_p.add_argument(
+            "--bucket",
+            default=None,
+            help="Override the OSS bucket returned by admin /get_token",
+        )
+        get_p.add_argument(
+            "--endpoint",
+            default=None,
+            help="Override the OSS endpoint returned by admin /get_token",
+        )

--- a/rock/sdk/sandbox/storage_client.py
+++ b/rock/sdk/sandbox/storage_client.py
@@ -1,0 +1,159 @@
+"""StorageClient — download archived sandbox log tarballs from OSS.
+
+Separate from :class:`rock.sdk.sandbox.oss_client.OssClient` because they serve
+different OSS prefixes and lifecycles:
+  - OssClient        — sandbox <-> host file transfer (rock-transfer/), alive sandbox
+  - StorageClient    — stopped sandbox log archives (rock-archives/), historical
+
+Recovery flow:
+  1. Call admin ``/get_token?account=primary`` to obtain a short-lived STS
+     for the primary OSS account.
+  2. Use oss2 + STS auth to download
+     ``oss://<bucket>/<archive_prefix>sandbox-logs/<sandbox_id>.tar.gz``.
+
+The CLI (``rock storage get``) is a thin wrapper around this client.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+
+import oss2
+
+from rock.logger import init_logger
+from rock.utils.archive_command import ArchiveCommand
+from rock.utils.http import HttpUtils
+
+logger = init_logger(__name__)
+
+
+class ArchiveNotFoundError(FileNotFoundError):
+    """Raised when the requested sandbox's archive does not exist in OSS."""
+
+
+class StorageClient:
+    """SDK client for downloading archived sandbox log tarballs from OSS.
+
+    Args:
+        base_url: admin base URL. May be the bare host (``https://admin/``) or
+            include the ``/apis/envs/sandbox/v1`` prefix; both are accepted.
+        auth_token: optional ``xrl-authorization`` token for admin requests.
+        extra_headers: optional extra HTTP headers attached to every admin call.
+    """
+
+    _API_PREFIX = "/apis/envs/sandbox/v1"
+
+    def __init__(
+        self,
+        base_url: str,
+        auth_token: str | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ):
+        self._base_url = base_url
+        self._auth_token = auth_token
+        self._extra_headers = dict(extra_headers or {})
+
+    async def download_archived_log(
+        self,
+        sandbox_id: str,
+        output_path: str,
+        archive_prefix: str = "",
+        bucket: str | None = None,
+        endpoint: str | None = None,
+    ) -> str:
+        """Download ``sandbox_id``'s archived log tarball to ``output_path``.
+
+        Args:
+            sandbox_id: target sandbox id (matches the log directory name).
+            output_path: local file path to write the downloaded tarball.
+            archive_prefix: OSS key prefix used at archive time. Must match
+                admin's ``sandbox_config.log.archive_prefix``.
+            bucket: optional OSS bucket override (defaults to value returned
+                by admin ``/get_token``).
+            endpoint: optional OSS endpoint override (same default rule).
+
+        Returns:
+            The local path the tarball was written to (== ``output_path``).
+
+        Raises:
+            ArchiveNotFoundError: archive object does not exist in OSS.
+            RuntimeError: STS fetch failed or admin response missing fields.
+        """
+        sts = await self._fetch_primary_sts()
+        bucket_name, endpoint_url, region = self._extract_oss_target(sts, bucket, endpoint)
+        oss_key = ArchiveCommand.build_key(sandbox_id, archive_prefix)
+
+        oss_bucket = oss2.Bucket(
+            auth=oss2.StsAuth(sts["AccessKeyId"], sts["AccessKeySecret"], sts["SecurityToken"]),
+            endpoint=endpoint_url,
+            bucket_name=bucket_name,
+            region=region,
+        )
+
+        os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+        try:
+            await asyncio.to_thread(oss_bucket.get_object_to_file, oss_key, output_path)
+        except oss2.exceptions.NoSuchKey as e:
+            raise ArchiveNotFoundError(f"oss://{bucket_name}/{oss_key}") from e
+
+        return output_path
+
+    async def _fetch_primary_sts(self) -> dict[str, Any]:
+        url = self._build_get_token_url()
+        headers = self._build_headers()
+        try:
+            response = await HttpUtils.get(url, headers)
+        except Exception as e:
+            # Most common 404 cause: caller passed admin-write URL but /get_token only
+            # lives on the proxy/read role. Augment the error so the user knows what to flip.
+            if "404" in str(e):
+                raise RuntimeError(
+                    f"admin /get_token returned 404 at {url}. "
+                    "/get_token is only mounted on the proxy/read admin role, not the write admin. "
+                    "If you used the write URL, switch base_url to the proxy/read URL."
+                ) from e
+            raise
+        if response.get("status") != "Success":
+            raise RuntimeError(f"admin /get_token returned: {response.get('message') or response}")
+        result = response.get("result")
+        if not result:
+            raise RuntimeError("admin /get_token returned an empty result; check OssConfig.primary on admin")
+        return result
+
+    def _build_get_token_url(self) -> str:
+        """Normalize ``base_url`` and append ``/get_token?account=primary``.
+
+        Accepts either the bare admin host or a base that already contains
+        the API prefix; in either case the result hits the right route.
+        """
+        clean = self._base_url.rstrip("/")
+        if not clean.endswith(self._API_PREFIX):
+            clean = f"{clean}{self._API_PREFIX}"
+        return f"{clean}/get_token?account=primary"
+
+    def _build_headers(self) -> dict[str, str]:
+        headers = dict(self._extra_headers)
+        if self._auth_token:
+            headers["xrl-authorization"] = self._auth_token
+        return headers
+
+    @staticmethod
+    def _extract_oss_target(
+        sts: dict[str, Any],
+        bucket_override: str | None,
+        endpoint_override: str | None,
+    ) -> tuple[str, str, str | None]:
+        # The /get_token response from a recent admin includes Endpoint/Bucket/Region
+        # for the primary account. Caller overrides win (useful when testing against
+        # a non-default bucket without redeploying admin).
+        bucket = bucket_override or sts.get("Bucket")
+        endpoint = endpoint_override or sts.get("Endpoint")
+        region = sts.get("Region")
+        if not bucket or not endpoint:
+            raise RuntimeError(
+                "OSS bucket/endpoint missing — pass bucket/endpoint explicitly or configure "
+                "OssConfig.primary.bucket/endpoint on admin"
+            )
+        return bucket, endpoint, region

--- a/tests/unit/cli/command/test_storage.py
+++ b/tests/unit/cli/command/test_storage.py
@@ -1,0 +1,248 @@
+"""Tests for `rock storage get` — download archived sandbox log tarball."""
+
+import argparse
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from rock.cli.command.storage import StorageCommand
+
+
+def _args(**overrides):
+    base = dict(
+        storage_action="get",
+        sandbox_id="sb-abc",
+        output=None,
+        archive_prefix="rock-archives/",
+        bucket=None,
+        endpoint=None,
+        base_url="http://admin.local:8080",
+        auth_token="tok-1",
+        extra_headers={"cluster": "default"},
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+def _sts_payload(**extra):
+    payload = {
+        "AccessKeyId": "AK",
+        "AccessKeySecret": "SK",
+        "SecurityToken": "ST",
+        "Endpoint": "oss-cn-hangzhou.aliyuncs.com",
+        "Bucket": "chatos-rock",
+        "Region": "cn-hangzhou",
+    }
+    payload.update(extra)
+    return payload
+
+
+class TestStorageGet:
+    @pytest.mark.asyncio
+    async def test_success_downloads_to_default_path_and_uses_correct_key(self, tmp_path, capsys):
+        cmd = StorageCommand()
+        args = _args(output=str(tmp_path / "out.tar.gz"))
+
+        bucket_mock = MagicMock()
+        bucket_mock.get_object_to_file = MagicMock()
+        with (
+            patch(
+                "rock.sdk.sandbox.storage_client.HttpUtils.get",
+                AsyncMock(return_value={"status": "Success", "result": _sts_payload()}),
+            ),
+            patch("rock.sdk.sandbox.storage_client.oss2") as oss2_mod,
+        ):
+            oss2_mod.Bucket.return_value = bucket_mock
+            oss2_mod.StsAuth.return_value = "stsauth"
+            # NoSuchKey lookup path is exercised separately; here the call succeeds.
+            oss2_mod.exceptions.NoSuchKey = type("NoSuchKey", (Exception,), {})
+
+            await cmd.arun(args)
+
+        # Asserts on what we sent to oss2:
+        oss2_mod.StsAuth.assert_called_once_with("AK", "SK", "ST")
+        oss2_mod.Bucket.assert_called_once()
+        kwargs = oss2_mod.Bucket.call_args.kwargs
+        assert kwargs["bucket_name"] == "chatos-rock"
+        assert kwargs["endpoint"] == "oss-cn-hangzhou.aliyuncs.com"
+        assert kwargs["region"] == "cn-hangzhou"
+
+        # Key is built via shared helper, must match archive-side layout exactly.
+        bucket_mock.get_object_to_file.assert_called_once()
+        oss_key, local_path = bucket_mock.get_object_to_file.call_args.args
+        assert oss_key == "rock-archives/sandbox-logs/sb-abc.tar.gz"
+        assert local_path == str(tmp_path / "out.tar.gz")
+
+        out = capsys.readouterr().out
+        assert "OK:" in out
+        assert "tar -xzf" in out
+
+    @pytest.mark.asyncio
+    async def test_default_output_when_no_flag(self, capsys):
+        cmd = StorageCommand()
+        args = _args(output=None)
+
+        bucket_mock = MagicMock()
+        with (
+            patch(
+                "rock.sdk.sandbox.storage_client.HttpUtils.get",
+                AsyncMock(return_value={"status": "Success", "result": _sts_payload()}),
+            ),
+            patch("rock.sdk.sandbox.storage_client.oss2") as oss2_mod,
+            patch("rock.sdk.sandbox.storage_client.os.makedirs"),
+        ):
+            oss2_mod.Bucket.return_value = bucket_mock
+            oss2_mod.exceptions.NoSuchKey = type("NoSuchKey", (Exception,), {})
+
+            await cmd.arun(args)
+
+        _, local_path = bucket_mock.get_object_to_file.call_args.args
+        assert local_path == "./sb-abc.tar.gz"
+
+    @pytest.mark.asyncio
+    async def test_directory_output_appends_filename(self, capsys):
+        cmd = StorageCommand()
+        args = _args(output="/tmp/recover/")  # trailing slash → directory semantics
+
+        bucket_mock = MagicMock()
+        with (
+            patch(
+                "rock.sdk.sandbox.storage_client.HttpUtils.get",
+                AsyncMock(return_value={"status": "Success", "result": _sts_payload()}),
+            ),
+            patch("rock.sdk.sandbox.storage_client.oss2") as oss2_mod,
+            patch("rock.sdk.sandbox.storage_client.os.makedirs"),
+        ):
+            oss2_mod.Bucket.return_value = bucket_mock
+            oss2_mod.exceptions.NoSuchKey = type("NoSuchKey", (Exception,), {})
+
+            await cmd.arun(args)
+
+        _, local_path = bucket_mock.get_object_to_file.call_args.args
+        assert local_path == "/tmp/recover/sb-abc.tar.gz"
+
+    @pytest.mark.asyncio
+    async def test_no_such_key_prints_not_found(self, capsys):
+        cmd = StorageCommand()
+        args = _args()
+
+        # Build the NoSuchKey class first so storage.py can raise it via the patched module.
+        no_such_key = type("NoSuchKey", (Exception,), {})
+        bucket_mock = MagicMock()
+        bucket_mock.get_object_to_file = MagicMock(side_effect=no_such_key("missing"))
+
+        with (
+            patch(
+                "rock.sdk.sandbox.storage_client.HttpUtils.get",
+                AsyncMock(return_value={"status": "Success", "result": _sts_payload()}),
+            ),
+            patch("rock.sdk.sandbox.storage_client.oss2") as oss2_mod,
+            patch("rock.sdk.sandbox.storage_client.os.makedirs"),
+        ):
+            oss2_mod.Bucket.return_value = bucket_mock
+            oss2_mod.exceptions.NoSuchKey = no_such_key
+
+            await cmd.arun(args)
+
+        out = capsys.readouterr().out
+        assert "NOT FOUND" in out
+        assert "rock-archives/sandbox-logs/sb-abc.tar.gz" in out
+
+    @pytest.mark.asyncio
+    async def test_generic_oss_exception_prints_failed(self, capsys):
+        cmd = StorageCommand()
+        args = _args()
+
+        bucket_mock = MagicMock()
+        # Use IOError (subclass of OSError, not RuntimeError) — real oss2 errors
+        # surface as oss2.exceptions.OssError/ServerError, which inherit from
+        # Exception (not RuntimeError). CLI swallows these and prints FAILED;
+        # RuntimeError is reserved for pre-flight (STS/config) errors and bubbles.
+        bucket_mock.get_object_to_file = MagicMock(side_effect=IOError("network exploded"))
+
+        with (
+            patch(
+                "rock.sdk.sandbox.storage_client.HttpUtils.get",
+                AsyncMock(return_value={"status": "Success", "result": _sts_payload()}),
+            ),
+            patch("rock.sdk.sandbox.storage_client.oss2") as oss2_mod,
+            patch("rock.sdk.sandbox.storage_client.os.makedirs"),
+        ):
+            oss2_mod.Bucket.return_value = bucket_mock
+            oss2_mod.exceptions.NoSuchKey = type("NoSuchKey", (Exception,), {})
+
+            await cmd.arun(args)
+
+        out = capsys.readouterr().out
+        assert "FAILED" in out
+        assert "network exploded" in out
+
+    @pytest.mark.asyncio
+    async def test_admin_get_token_failure_raises(self):
+        cmd = StorageCommand()
+        args = _args()
+        with patch(
+            "rock.sdk.sandbox.storage_client.HttpUtils.get",
+            AsyncMock(return_value={"status": "Failed", "message": "no primary configured"}),
+        ):
+            with pytest.raises(RuntimeError, match="no primary configured"):
+                await cmd.arun(args)
+
+    @pytest.mark.asyncio
+    async def test_missing_oss_target_raises(self):
+        """If admin returns STS without Endpoint/Bucket and no CLI override, fail loud."""
+        cmd = StorageCommand()
+        args = _args(bucket=None, endpoint=None)
+
+        bare = _sts_payload()
+        bare.pop("Endpoint")
+        bare.pop("Bucket")
+        with patch(
+            "rock.sdk.sandbox.storage_client.HttpUtils.get",
+            AsyncMock(return_value={"status": "Success", "result": bare}),
+        ):
+            with pytest.raises(RuntimeError, match="bucket/endpoint missing"):
+                await cmd.arun(args)
+
+    @pytest.mark.asyncio
+    async def test_cli_overrides_take_precedence_over_get_token_response(self):
+        cmd = StorageCommand()
+        args = _args(bucket="my-bucket", endpoint="my-endpoint")
+
+        bucket_mock = MagicMock()
+        with (
+            patch(
+                "rock.sdk.sandbox.storage_client.HttpUtils.get",
+                AsyncMock(return_value={"status": "Success", "result": _sts_payload()}),
+            ),
+            patch("rock.sdk.sandbox.storage_client.oss2") as oss2_mod,
+            patch("rock.sdk.sandbox.storage_client.os.makedirs"),
+        ):
+            oss2_mod.Bucket.return_value = bucket_mock
+            oss2_mod.exceptions.NoSuchKey = type("NoSuchKey", (Exception,), {})
+
+            await cmd.arun(args)
+
+        kwargs = oss2_mod.Bucket.call_args.kwargs
+        assert kwargs["bucket_name"] == "my-bucket"
+        assert kwargs["endpoint"] == "my-endpoint"
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_raises(self):
+        cmd = StorageCommand()
+        with pytest.raises(ValueError, match="Unknown storage action"):
+            await cmd.arun(argparse.Namespace(storage_action="delete"))
+
+    @pytest.mark.asyncio
+    async def test_404_error_message_explains_proxy_role(self):
+        # A 404 on /get_token nearly always means the user pointed at the write-admin URL
+        # by mistake; surface that explicitly instead of bubbling a raw HTTPStatusError.
+        # Integration-level: CLI → SDK → patched HttpUtils → RuntimeError surfaces.
+        cmd = StorageCommand()
+        args = _args()
+        with patch(
+            "rock.sdk.sandbox.storage_client.HttpUtils.get",
+            AsyncMock(side_effect=Exception("Client error '404 Not Found' for url ...")),
+        ):
+            with pytest.raises(RuntimeError, match="proxy/read admin role"):
+                await cmd.arun(args)

--- a/tests/unit/sdk/sandbox/test_storage_client.py
+++ b/tests/unit/sdk/sandbox/test_storage_client.py
@@ -1,0 +1,81 @@
+"""SDK-level tests for StorageClient (URL/headers/STS extraction pure logic).
+
+Integration-level oss2/HttpUtils mocking is exercised end-to-end via
+tests/unit/cli/command/test_storage.py (CLI -> SDK -> mocked oss2 path).
+This file focuses on the pure helpers + auth header logic that don't need
+the full download path.
+"""
+
+import pytest
+
+from rock.sdk.sandbox.storage_client import StorageClient
+
+
+class TestBuildGetTokenUrl:
+    def test_appends_api_prefix_when_base_url_is_bare_host(self):
+        client = StorageClient(base_url="https://admin.local")
+        assert client._build_get_token_url() == "https://admin.local/apis/envs/sandbox/v1/get_token?account=primary"
+
+    def test_does_not_double_append_when_base_url_already_has_prefix(self):
+        client = StorageClient(base_url="https://admin.local/apis/envs/sandbox/v1")
+        assert client._build_get_token_url() == "https://admin.local/apis/envs/sandbox/v1/get_token?account=primary"
+
+    def test_strips_trailing_slash(self):
+        client = StorageClient(base_url="https://admin.local/")
+        assert client._build_get_token_url() == "https://admin.local/apis/envs/sandbox/v1/get_token?account=primary"
+
+
+class TestBuildHeaders:
+    def test_auth_token_lifts_to_xrl_authorization_header(self):
+        client = StorageClient(base_url="https://x", auth_token="tok-2", extra_headers={"cluster": "c1"})
+        headers = client._build_headers()
+        assert headers["xrl-authorization"] == "tok-2"
+        assert headers["cluster"] == "c1"
+
+    def test_no_auth_token_keeps_extra_headers_only(self):
+        client = StorageClient(base_url="https://x", auth_token=None, extra_headers={"cluster": "c1"})
+        headers = client._build_headers()
+        assert "xrl-authorization" not in headers
+        assert headers["cluster"] == "c1"
+
+    def test_extra_headers_isolated_from_caller_mutation(self):
+        # Defensive copy: caller mutating their dict after construction must not
+        # leak into subsequent client requests.
+        original = {"cluster": "c1"}
+        client = StorageClient(base_url="https://x", extra_headers=original)
+        original["leaked"] = "yes"
+        assert "leaked" not in client._build_headers()
+
+
+class TestExtractOssTarget:
+    _STS_FULL = {
+        "AccessKeyId": "AK",
+        "AccessKeySecret": "SK",
+        "SecurityToken": "ST",
+        "Endpoint": "oss-cn-hangzhou.aliyuncs.com",
+        "Bucket": "chatos-rock",
+        "Region": "cn-hangzhou",
+    }
+
+    def test_caller_bucket_override_wins(self):
+        bucket, endpoint, region = StorageClient._extract_oss_target(self._STS_FULL, "override-bucket", None)
+        assert bucket == "override-bucket"
+        assert endpoint == self._STS_FULL["Endpoint"]
+        assert region == "cn-hangzhou"
+
+    def test_caller_endpoint_override_wins(self):
+        bucket, endpoint, region = StorageClient._extract_oss_target(self._STS_FULL, None, "override-endpoint")
+        assert bucket == self._STS_FULL["Bucket"]
+        assert endpoint == "override-endpoint"
+
+    def test_missing_bucket_raises(self):
+        sts = dict(self._STS_FULL)
+        del sts["Bucket"]
+        with pytest.raises(RuntimeError, match="bucket/endpoint missing"):
+            StorageClient._extract_oss_target(sts, None, None)
+
+    def test_missing_endpoint_raises(self):
+        sts = dict(self._STS_FULL)
+        del sts["Endpoint"]
+        with pytest.raises(RuntimeError, match="bucket/endpoint missing"):
+            StorageClient._extract_oss_target(sts, None, None)


### PR DESCRIPTION
## Summary
  - 新增 `rock storage get <sandbox_id> [-o PATH] [--archive-prefix ...] [--bucket ...]
  [--endpoint ...]`
  - 通过 admin 既有 `/get_token?account=primary` 拿 STS；CLI 永不持长期 AK/SK
  - OSS key 直接复用 PR-A 的 `build_sandbox_log_key`，避免归档侧 / 恢复侧逻辑漂移
  - 自动发现机制下不需要改 `cli/main.py`；不在 `local_api.py` 新增 endpoint

  ## Files (2)
  - `rock/cli/command/storage.py` (NEW, 147 lines)
  - `tests/unit/cli/command/test_storage.py` (NEW, 244 lines)

  ## Test plan
  - [ ] `uv run pytest tests/unit/cli/command/test_storage.py -v`
  - [ ] `uv run ruff check rock/cli/command/storage.py
  tests/unit/cli/command/test_storage.py`
  - [ ] 覆盖矩阵：默认/自定义/目录输出、NoSuchKey、通用异常、admin 失败、缺 endpoint、CLI
  覆盖、未知 action、headers

  refs #961