### PR TITLE
feature(deployments): write sentinel on docker stop for deferred sandbox log   archival

### DIFF
--- a/rock/deployments/docker.py
+++ b/rock/deployments/docker.py
@@ -624,77 +624,106 @@ class DockerDeployment(AbstractDeployment):
         if self._runtime:
             await loop.run_in_executor(stop_executor, self._stop)
 
+    def _try_mark_sentinel(self, container_name: str | None) -> None:
+        """Best-effort: write .rock_stopped_at sentinel for deferred archival.
+
+        Caller MUST pass container_name (snapshotted at _stop() entry), since
+        self._container_name is reset mid-flow before this method is called.
+        Never raises — sentinel writing is housekeeping, must not break stop flow.
+        All branches log explicitly so root cause is traceable from worker logs.
+        """
+        try:
+            log_path = env_vars.ROCK_LOGGING_PATH
+            if not log_path:
+                logger.warning("[sentinel] skip: ROCK_LOGGING_PATH is empty")
+                return
+            if not container_name:
+                logger.warning("[sentinel] skip: container_name is empty (None at _stop entry)")
+                return
+            log_dir = Path(log_path) / container_name
+            logger.info(f"[sentinel] resolved log_dir={log_dir}")
+            if not log_dir.is_dir():
+                logger.warning(f"[sentinel] skip: log_dir does not exist: {log_dir}")
+                return
+            if sentinel_path(log_dir).exists():
+                logger.info(f"[sentinel] skip: sentinel already exists at {sentinel_path(log_dir)}")
+                return
+            write_sentinel(log_dir)
+            logger.info(f"[sentinel] WRITE_OK at {sentinel_path(log_dir)}")
+        except Exception as e:
+            logger.exception(f"[sentinel] _try_mark_sentinel unexpected error: {e}")
+
+
     def _stop(self):
         """Stops the runtime."""
-        if self._container_name in ENV_POOL:
-            del ENV_POOL[self._container_name]
-        if self._runtime is not None:
-            try:
-                with timeout(5):
-                    self._runtime.close()
-            except TimeoutError as e:
-                logger.error("close timeout", exc_info=e)
-            except Exception as e:
-                logger.error("close failed", exc_info=e)
-            self._runtime = None
+        container_name_for_sentinel = self._container_name
 
-        if self._container_process is not None:
-            try:
-                subprocess.check_call(
-                    ["docker", "kill", self._container_name],  # type: ignore
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    timeout=10,
-                )
-            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-                logger.warning(
-                    f"Failed to kill container {self._container_name}: {e}. Will try harder.", exc_info=False
-                )
-            for _ in range(3):
-                self._container_process.kill()
+        try:
+            if self._container_name in ENV_POOL:
+                del ENV_POOL[self._container_name]
+            if self._runtime is not None:
                 try:
-                    self._container_process.wait(timeout=5)
-                    break
-                except subprocess.TimeoutExpired:
-                    continue
-            else:
-                logger.warning(f"Failed to kill container {self._container_name} with SIGKILL")
+                    with timeout(5):
+                        self._runtime.close()
+                except TimeoutError as e:
+                    logger.error("close timeout", exc_info=e)
+                except Exception as e:
+                    logger.error("close failed", exc_info=e)
+                self._runtime = None
 
-            self._container_process = None
-            self._cleanup_kata_disk()
-            self._cleanup_log_dir_xfs_quota()
-            self._container_name = None
+            if self._container_process is not None:
+                try:
+                    subprocess.check_call(
+                        ["docker", "kill", self._container_name],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        timeout=10,
+                    )
+                except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+                    logger.warning(
+                        f"Failed to kill container {self._container_name}: {e}. Will try harder.", exc_info=False
+                    )
+                for _ in range(3):
+                    self._container_process.kill()
+                    try:
+                        self._container_process.wait(timeout=5)
+                        break
+                    except subprocess.TimeoutExpired:
+                        continue
+                else:
+                    logger.warning(f"Failed to kill container {self._container_name} with SIGKILL")
 
-        if self._config and self._config.remove_images and DockerUtil.is_image_available(self._config.image):
-            logger.info(f"Removing image {self._config.image}")
+                self._container_process = None
+                self._cleanup_kata_disk()
+                self._cleanup_log_dir_xfs_quota()
+                self._container_name = None
+
+            if self._config and self._config.remove_images and DockerUtil.is_image_available(self._config.image):
+                logger.info(f"Removing image {self._config.image}")
+                try:
+                    DockerUtil.remove_image(self._config.image)
+                except subprocess.CalledProcessError:
+                    logger.error(f"Failed to remove image {self._config.image}", exc_info=True)
+
+            if self._check_stop_task is not None:
+                logger.info("Stopping check task")
+                self._check_stop_task.cancel()
+                self._check_stop_task = None
+
+            # service_status / port release 失败不影响 sentinel
             try:
-                DockerUtil.remove_image(self._config.image)
-            except subprocess.CalledProcessError:
-                logger.error(f"Failed to remove image {self._config.image}", exc_info=True)
-
-        if self._check_stop_task is not None:
-            logger.info("Stopping check task")
-            self._check_stop_task.cancel()
-            self._check_stop_task = None
-
-        service_status = self.get_status()
-        for _, port in service_status.get_port_mapping().items():
-            release_port(port)
-
-        # Mark per-sandbox host log dir for deferred archive. Only touches
-        # ${ROCK_LOGGING_PATH}/<container_name>/, not host-side
-        # /data/logs/*.log (managed by logrotate). The sentinel drives
-        # SandboxLogArchiveTask, which tar+uploads + rms after
-        # `oss.keep_days_before_archive` days.
-        if env_vars.ROCK_LOGGING_PATH and self._container_name:
-            log_dir = Path(env_vars.ROCK_LOGGING_PATH) / self._container_name
-            if log_dir.is_dir() and not sentinel_path(log_dir).exists():
-                # _stop() may be called twice (e.g. ray actor restart);
-                # do not bump stopped_at on the second call.
-                write_sentinel(log_dir)
-                logger.info(f"Marked sandbox log dir for deferred archive: {log_dir}")
-
-        self._config = None
+                service_status = self.get_status()
+                for _, port in service_status.get_port_mapping().items():
+                    release_port(port)
+            except Exception as e:
+                logger.warning(
+                    f"[sentinel] pre-stop service_status/port_release failed (non-fatal): {e}",
+                    exc_info=True,
+                )
+        finally:
+            # 用 snapshot 的 container_name,绕开 self._container_name 已被清空的问题
+            self._try_mark_sentinel(container_name_for_sentinel)
+            self._config = None
 
     @property
     def runtime(self) -> RemoteSandboxRuntime:

--- a/rock/deployments/docker.py
+++ b/rock/deployments/docker.py
@@ -21,7 +21,7 @@ from rock.deployments.config import DockerDeploymentConfig
 from rock.deployments.constants import Port, Status
 from rock.deployments.docker_client import TempAuthDockerClient, TempAuthDockerClientError
 from rock.deployments.hooks.abstract import CombinedDeploymentHook, DeploymentHook
-from rock.deployments.log_cleanup_sentinel import sentinel_path, write_sentinel
+from rock.deployments.log_cleanup_sentinel import Sentinel
 from rock.deployments.runtime_env import DockerRuntimeEnv, LocalRuntimeEnv, PipRuntimeEnv, UvRuntimeEnv
 from rock.deployments.sandbox_validator import DockerSandboxValidator
 from rock.deployments.status import PersistedServiceStatus, ServiceStatus
@@ -44,8 +44,8 @@ from rock.utils import (
 
 __all__ = ["DockerDeployment", "DockerDeploymentConfig"]
 CHECK_CLEAR_INTERVAL_SECONDS = 300
-XFS_PRJID_MIN = (1 << 31)                      # low project IDs are reserved for Docker
-XFS_PRJID_RANGE = (1 << 32) - XFS_PRJID_MIN   # use remaining 32-bit space: [XFS_PRJID_MIN, 2^32)
+XFS_PRJID_MIN = 1 << 31  # low project IDs are reserved for Docker
+XFS_PRJID_RANGE = (1 << 32) - XFS_PRJID_MIN  # use remaining 32-bit space: [XFS_PRJID_MIN, 2^32)
 
 
 logger = init_logger(__name__)
@@ -425,7 +425,9 @@ class DockerDeployment(AbstractDeployment):
             return
 
         # Derive a deterministic project id from container name; reserve low ids.
-        project_id = (int(hashlib.sha1(self.container_name.encode("utf-8")).hexdigest()[:8], 16) % XFS_PRJID_RANGE) + XFS_PRJID_MIN
+        project_id = (
+            int(hashlib.sha1(self.container_name.encode("utf-8")).hexdigest()[:8], 16) % XFS_PRJID_RANGE
+        ) + XFS_PRJID_MIN
         try:
             findmnt_result = subprocess.run(
                 ["findmnt", "-T", log_file_path, "-o", "TARGET", "--noheadings"],
@@ -645,14 +647,13 @@ class DockerDeployment(AbstractDeployment):
             if not log_dir.is_dir():
                 logger.warning(f"[sentinel] skip: log_dir does not exist: {log_dir}")
                 return
-            if sentinel_path(log_dir).exists():
-                logger.info(f"[sentinel] skip: sentinel already exists at {sentinel_path(log_dir)}")
+            if Sentinel.path(log_dir).exists():
+                logger.info(f"[sentinel] skip: sentinel already exists at {Sentinel.path(log_dir)}")
                 return
-            write_sentinel(log_dir)
-            logger.info(f"[sentinel] WRITE_OK at {sentinel_path(log_dir)}")
+            Sentinel.write(log_dir)
+            logger.info(f"[sentinel] WRITE_OK at {Sentinel.path(log_dir)}")
         except Exception as e:
             logger.exception(f"[sentinel] _try_mark_sentinel unexpected error: {e}")
-
 
     def _stop(self):
         """Stops the runtime."""

--- a/rock/deployments/docker.py
+++ b/rock/deployments/docker.py
@@ -21,6 +21,7 @@ from rock.deployments.config import DockerDeploymentConfig
 from rock.deployments.constants import Port, Status
 from rock.deployments.docker_client import TempAuthDockerClient, TempAuthDockerClientError
 from rock.deployments.hooks.abstract import CombinedDeploymentHook, DeploymentHook
+from rock.deployments.log_cleanup_sentinel import sentinel_path, write_sentinel
 from rock.deployments.runtime_env import DockerRuntimeEnv, LocalRuntimeEnv, PipRuntimeEnv, UvRuntimeEnv
 from rock.deployments.sandbox_validator import DockerSandboxValidator
 from rock.deployments.status import PersistedServiceStatus, ServiceStatus
@@ -679,6 +680,19 @@ class DockerDeployment(AbstractDeployment):
         service_status = self.get_status()
         for _, port in service_status.get_port_mapping().items():
             release_port(port)
+
+        # Mark per-sandbox host log dir for deferred archive. Only touches
+        # ${ROCK_LOGGING_PATH}/<container_name>/, not host-side
+        # /data/logs/*.log (managed by logrotate). The sentinel drives
+        # SandboxLogArchiveTask, which tar+uploads + rms after
+        # `oss.keep_days_before_archive` days.
+        if env_vars.ROCK_LOGGING_PATH and self._container_name:
+            log_dir = Path(env_vars.ROCK_LOGGING_PATH) / self._container_name
+            if log_dir.is_dir() and not sentinel_path(log_dir).exists():
+                # _stop() may be called twice (e.g. ray actor restart);
+                # do not bump stopped_at on the second call.
+                write_sentinel(log_dir)
+                logger.info(f"Marked sandbox log dir for deferred archive: {log_dir}")
 
         self._config = None
 

--- a/rock/deployments/log_cleanup_sentinel.py
+++ b/rock/deployments/log_cleanup_sentinel.py
@@ -2,7 +2,7 @@
 
 The sentinel is a small JSON file dropped into a stopped sandbox's log
 directory by DockerDeployment._stop(); SandboxLogArchiveTask later picks
-up dirs whose sentinel is older than `oss.keep_days_before_archive` and
+up dirs whose sentinel is older than `sandbox_config.log.keep_days_before_archive` and
 ships them to OSS.
 
 Sentinel JSON shape (versioned for future evolution):

--- a/rock/deployments/log_cleanup_sentinel.py
+++ b/rock/deployments/log_cleanup_sentinel.py
@@ -39,67 +39,80 @@ class SentinelState:
         return cls(stopped_at=datetime.now().astimezone().isoformat(), attempts=0)
 
 
-def sentinel_path(log_dir: Path) -> Path:
-    return log_dir / LOG_STOPPED_SENTINEL
+class Sentinel:
+    """Namespace for sentinel file read/write operations.
 
+    Stateless: all methods are `@staticmethod`. Grouped under a class so
+    deployment / scheduler / test sides go through one explicit entry point
+    (``Sentinel.path``, ``Sentinel.read``, ``Sentinel.write``, etc.) and
+    cannot drift on path / serialization conventions.
 
-def dump_state(state: SentinelState) -> str:
-    """Serialize a SentinelState to its on-disk JSON form.
-
-    Single source of truth for the schema — admin-side code that needs to
-    overwrite a remote worker's sentinel via runtime.write_file() reuses
-    this so the JSON layout stays consistent with local writes.
+    The on-disk JSON shape lives on `SentinelState` (a separate dataclass);
+    this class only handles I/O.
     """
-    return json.dumps(asdict(state), ensure_ascii=False)
 
+    @staticmethod
+    def path(log_dir: Path) -> Path:
+        return log_dir / LOG_STOPPED_SENTINEL
 
-def _atomic_write(target: Path, content: str) -> None:
-    # tempfile + rename inside the same directory: rename is POSIX atomic,
-    # so a crashed write never leaves a half-written sentinel on disk.
-    target.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_name = tempfile.mkstemp(prefix=target.name + ".", suffix=".tmp", dir=str(target.parent))
-    try:
-        with os.fdopen(fd, "w") as f:
-            f.write(content)
-        os.replace(tmp_name, target)
-    except Exception as e:
-        logger.warning(f"[sentinel] _atomic_write failed for {target}: {e}", exc_info=True)
+    @staticmethod
+    def dump(state: SentinelState) -> str:
+        """Serialize a SentinelState to its on-disk JSON form.
+
+        Single source of truth for the schema — admin-side code that needs to
+        overwrite a remote worker's sentinel via runtime.write_file() reuses
+        this so the JSON layout stays consistent with local writes.
+        """
+        return json.dumps(asdict(state), ensure_ascii=False)
+
+    @staticmethod
+    def _atomic_write(target: Path, content: str) -> None:
+        # tempfile + rename inside the same directory: rename is POSIX atomic,
+        # so a crashed write never leaves a half-written sentinel on disk.
+        target.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(prefix=target.name + ".", suffix=".tmp", dir=str(target.parent))
         try:
-            os.unlink(tmp_name)
-        except OSError:
-            pass
-        raise
+            with os.fdopen(fd, "w") as f:
+                f.write(content)
+            os.replace(tmp_name, target)
+        except Exception as e:
+            logger.warning(f"[sentinel] _atomic_write failed for {target}: {e}", exc_info=True)
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+            raise
 
+    @staticmethod
+    def write(log_dir: Path, state: SentinelState | None = None) -> None:
+        target = Sentinel.path(log_dir)
+        if state is None:
+            state = SentinelState.now()
+        Sentinel._atomic_write(target, Sentinel.dump(state))
 
-def write_sentinel(log_dir: Path, state: SentinelState | None = None) -> None:
-    target = sentinel_path(log_dir)
-    if state is None:
-        state = SentinelState.now()
-    _atomic_write(target, dump_state(state))
+    @staticmethod
+    def read(log_dir: Path) -> SentinelState | None:
+        """Returns None when sentinel missing or unreadable. Caller treats
+        None as "not yet stopped" (i.e. skip archive)."""
+        target = Sentinel.path(log_dir)
+        if not target.is_file():
+            return None
+        try:
+            data = json.loads(target.read_text())
+            return SentinelState(
+                stopped_at=data["stopped_at"],
+                attempts=int(data.get("attempts", 0)),
+                version=int(data.get("version", _SENTINEL_VERSION)),
+            )
+        except Exception as e:
+            logger.warning(f"sentinel read failed for {target}: {e}")
+            return None
 
-
-def read_sentinel(log_dir: Path) -> SentinelState | None:
-    """Returns None when sentinel missing or unreadable. Caller treats
-    None as "not yet stopped" (i.e. skip archive)."""
-    target = sentinel_path(log_dir)
-    if not target.is_file():
-        return None
-    try:
-        data = json.loads(target.read_text())
-        return SentinelState(
-            stopped_at=data["stopped_at"],
-            attempts=int(data.get("attempts", 0)),
-            version=int(data.get("version", _SENTINEL_VERSION)),
-        )
-    except Exception as e:
-        logger.warning(f"sentinel read failed for {target}: {e}")
-        return None
-
-
-def bump_attempts(log_dir: Path) -> int:
-    """Increment attempts on the sentinel; returns new value.
-    If sentinel is missing, recreate with attempts=1 (best-effort)."""
-    state = read_sentinel(log_dir) or SentinelState.now()
-    state.attempts += 1
-    write_sentinel(log_dir, state)
-    return state.attempts
+    @staticmethod
+    def bump_attempts(log_dir: Path) -> int:
+        """Increment attempts on the sentinel; returns new value.
+        If sentinel is missing, recreate with attempts=1 (best-effort)."""
+        state = Sentinel.read(log_dir) or SentinelState.now()
+        state.attempts += 1
+        Sentinel.write(log_dir, state)
+        return state.attempts

--- a/rock/deployments/log_cleanup_sentinel.py
+++ b/rock/deployments/log_cleanup_sentinel.py
@@ -62,7 +62,8 @@ def _atomic_write(target: Path, content: str) -> None:
         with os.fdopen(fd, "w") as f:
             f.write(content)
         os.replace(tmp_name, target)
-    except Exception:
+    except Exception as e:
+        logger.warning(f"[sentinel] _atomic_write failed for {target}: {e}", exc_info=True)
         try:
             os.unlink(tmp_name)
         except OSError:

--- a/rock/deployments/log_cleanup_sentinel.py
+++ b/rock/deployments/log_cleanup_sentinel.py
@@ -1,0 +1,104 @@
+"""Sentinel file read/write helpers for deferred sandbox log archival.
+
+The sentinel is a small JSON file dropped into a stopped sandbox's log
+directory by DockerDeployment._stop(); SandboxLogArchiveTask later picks
+up dirs whose sentinel is older than `oss.keep_days_before_archive` and
+ships them to OSS.
+
+Sentinel JSON shape (versioned for future evolution):
+    {
+        "version": 1,
+        "stopped_at": "2026-05-13T10:30:00+08:00",  // ISO 8601, tz-aware
+        "attempts": 0                                // archive retry count
+    }
+"""
+
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+
+from rock.logger import init_logger
+
+logger = init_logger(__name__)
+
+LOG_STOPPED_SENTINEL = ".rock_stopped_at"
+_SENTINEL_VERSION = 1
+
+
+@dataclass
+class SentinelState:
+    stopped_at: str
+    attempts: int = 0
+    version: int = _SENTINEL_VERSION
+
+    @classmethod
+    def now(cls) -> "SentinelState":
+        return cls(stopped_at=datetime.now().astimezone().isoformat(), attempts=0)
+
+
+def sentinel_path(log_dir: Path) -> Path:
+    return log_dir / LOG_STOPPED_SENTINEL
+
+
+def dump_state(state: SentinelState) -> str:
+    """Serialize a SentinelState to its on-disk JSON form.
+
+    Single source of truth for the schema — admin-side code that needs to
+    overwrite a remote worker's sentinel via runtime.write_file() reuses
+    this so the JSON layout stays consistent with local writes.
+    """
+    return json.dumps(asdict(state), ensure_ascii=False)
+
+
+def _atomic_write(target: Path, content: str) -> None:
+    # tempfile + rename inside the same directory: rename is POSIX atomic,
+    # so a crashed write never leaves a half-written sentinel on disk.
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=target.name + ".", suffix=".tmp", dir=str(target.parent))
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        os.replace(tmp_name, target)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def write_sentinel(log_dir: Path, state: SentinelState | None = None) -> None:
+    target = sentinel_path(log_dir)
+    if state is None:
+        state = SentinelState.now()
+    _atomic_write(target, dump_state(state))
+
+
+def read_sentinel(log_dir: Path) -> SentinelState | None:
+    """Returns None when sentinel missing or unreadable. Caller treats
+    None as "not yet stopped" (i.e. skip archive)."""
+    target = sentinel_path(log_dir)
+    if not target.is_file():
+        return None
+    try:
+        data = json.loads(target.read_text())
+        return SentinelState(
+            stopped_at=data["stopped_at"],
+            attempts=int(data.get("attempts", 0)),
+            version=int(data.get("version", _SENTINEL_VERSION)),
+        )
+    except Exception as e:
+        logger.warning(f"sentinel read failed for {target}: {e}")
+        return None
+
+
+def bump_attempts(log_dir: Path) -> int:
+    """Increment attempts on the sentinel; returns new value.
+    If sentinel is missing, recreate with attempts=1 (best-effort)."""
+    state = read_sentinel(log_dir) or SentinelState.now()
+    state.attempts += 1
+    write_sentinel(log_dir, state)
+    return state.attempts

--- a/tests/unit/deployments/test_log_cleanup_sentinel.py
+++ b/tests/unit/deployments/test_log_cleanup_sentinel.py
@@ -7,12 +7,8 @@ import pytest
 
 from rock.deployments.log_cleanup_sentinel import (
     LOG_STOPPED_SENTINEL,
+    Sentinel,
     SentinelState,
-    bump_attempts,
-    dump_state,
-    read_sentinel,
-    sentinel_path,
-    write_sentinel,
 )
 
 
@@ -26,14 +22,14 @@ def log_dir(tmp_path):
 
 class TestSentinelPath:
     def test_returns_correct_path(self, log_dir):
-        result = sentinel_path(log_dir)
+        result = Sentinel.path(log_dir)
         assert result == log_dir / LOG_STOPPED_SENTINEL
 
 
 class TestWriteSentinel:
     def test_writes_default_state(self, log_dir):
-        write_sentinel(log_dir)
-        target = sentinel_path(log_dir)
+        Sentinel.write(log_dir)
+        target = Sentinel.path(log_dir)
         assert target.is_file()
         data = json.loads(target.read_text())
         assert data["version"] == 1
@@ -44,67 +40,67 @@ class TestWriteSentinel:
 
     def test_writes_custom_state(self, log_dir):
         state = SentinelState(stopped_at="2026-05-10T10:00:00+08:00", attempts=2, version=1)
-        write_sentinel(log_dir, state)
-        data = json.loads(sentinel_path(log_dir).read_text())
+        Sentinel.write(log_dir, state)
+        data = json.loads(Sentinel.path(log_dir).read_text())
         assert data["stopped_at"] == "2026-05-10T10:00:00+08:00"
         assert data["attempts"] == 2
         assert data["version"] == 1
 
     def test_overwrites_existing_sentinel(self, log_dir):
-        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-01T00:00:00+08:00", attempts=0))
-        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-02T00:00:00+08:00", attempts=1))
-        data = json.loads(sentinel_path(log_dir).read_text())
+        Sentinel.write(log_dir, SentinelState(stopped_at="2026-05-01T00:00:00+08:00", attempts=0))
+        Sentinel.write(log_dir, SentinelState(stopped_at="2026-05-02T00:00:00+08:00", attempts=1))
+        data = json.loads(Sentinel.path(log_dir).read_text())
         assert data["stopped_at"] == "2026-05-02T00:00:00+08:00"
         assert data["attempts"] == 1
 
 
 class TestReadSentinel:
     def test_reads_valid_sentinel(self, log_dir):
-        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-10T12:00:00+08:00", attempts=1))
-        state = read_sentinel(log_dir)
+        Sentinel.write(log_dir, SentinelState(stopped_at="2026-05-10T12:00:00+08:00", attempts=1))
+        state = Sentinel.read(log_dir)
         assert state is not None
         assert state.stopped_at == "2026-05-10T12:00:00+08:00"
         assert state.attempts == 1
         assert state.version == 1
 
     def test_returns_none_when_missing(self, log_dir):
-        assert read_sentinel(log_dir) is None
+        assert Sentinel.read(log_dir) is None
 
     def test_returns_none_on_corrupt_json(self, log_dir):
-        sentinel_path(log_dir).write_text("not valid json {{{")
-        assert read_sentinel(log_dir) is None
+        Sentinel.path(log_dir).write_text("not valid json {{{")
+        assert Sentinel.read(log_dir) is None
 
     def test_returns_none_on_missing_stopped_at_key(self, log_dir):
-        sentinel_path(log_dir).write_text(json.dumps({"version": 1, "attempts": 0}))
-        assert read_sentinel(log_dir) is None
+        Sentinel.path(log_dir).write_text(json.dumps({"version": 1, "attempts": 0}))
+        assert Sentinel.read(log_dir) is None
 
     def test_defaults_attempts_to_zero(self, log_dir):
-        sentinel_path(log_dir).write_text(json.dumps({"stopped_at": "2026-05-10T00:00:00Z"}))
-        state = read_sentinel(log_dir)
+        Sentinel.path(log_dir).write_text(json.dumps({"stopped_at": "2026-05-10T00:00:00Z"}))
+        state = Sentinel.read(log_dir)
         assert state is not None
         assert state.attempts == 0
 
 
 class TestBumpAttempts:
     def test_increments_existing_sentinel(self, log_dir):
-        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-10T00:00:00+08:00", attempts=0))
-        result = bump_attempts(log_dir)
+        Sentinel.write(log_dir, SentinelState(stopped_at="2026-05-10T00:00:00+08:00", attempts=0))
+        result = Sentinel.bump_attempts(log_dir)
         assert result == 1
-        state = read_sentinel(log_dir)
+        state = Sentinel.read(log_dir)
         assert state.attempts == 1
 
     def test_increments_multiple_times(self, log_dir):
-        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-10T00:00:00+08:00", attempts=0))
-        bump_attempts(log_dir)
-        bump_attempts(log_dir)
-        result = bump_attempts(log_dir)
+        Sentinel.write(log_dir, SentinelState(stopped_at="2026-05-10T00:00:00+08:00", attempts=0))
+        Sentinel.bump_attempts(log_dir)
+        Sentinel.bump_attempts(log_dir)
+        result = Sentinel.bump_attempts(log_dir)
         assert result == 3
 
     def test_creates_sentinel_if_missing(self, log_dir):
         """If sentinel is missing, bump_attempts recreates with attempts=1."""
-        result = bump_attempts(log_dir)
+        result = Sentinel.bump_attempts(log_dir)
         assert result == 1
-        state = read_sentinel(log_dir)
+        state = Sentinel.read(log_dir)
         assert state is not None
         assert state.attempts == 1
 
@@ -121,27 +117,27 @@ class TestSentinelState:
     def test_round_trip(self, log_dir):
         """Write and read back should produce identical state."""
         original = SentinelState(stopped_at="2026-05-13T15:30:00+08:00", attempts=2, version=1)
-        write_sentinel(log_dir, original)
-        restored = read_sentinel(log_dir)
+        Sentinel.write(log_dir, original)
+        restored = Sentinel.read(log_dir)
         assert restored.stopped_at == original.stopped_at
         assert restored.attempts == original.attempts
         assert restored.version == original.version
 
 
-class TestDumpState:
-    """dump_state is the single source of truth for the sentinel JSON shape;
+class TestSentinelDump:
+    """Sentinel.dump is the single source of truth for the sentinel JSON shape;
     admin-side code that overwrites a remote worker's sentinel via
     runtime.write_file() reuses it to avoid schema drift."""
 
     def test_returns_json_string_with_all_fields(self):
         s = SentinelState(stopped_at="2026-05-13T10:00:00+08:00", attempts=2, version=1)
-        result = json.loads(dump_state(s))
+        result = json.loads(Sentinel.dump(s))
         assert result == {"stopped_at": "2026-05-13T10:00:00+08:00", "attempts": 2, "version": 1}
 
     def test_dump_then_load_round_trip(self, log_dir):
         original = SentinelState(stopped_at="2026-05-13T10:00:00+08:00", attempts=3, version=1)
-        sentinel_path(log_dir).write_text(dump_state(original))
-        restored = read_sentinel(log_dir)
+        Sentinel.path(log_dir).write_text(Sentinel.dump(original))
+        restored = Sentinel.read(log_dir)
         assert restored.stopped_at == original.stopped_at
         assert restored.attempts == original.attempts
 
@@ -149,6 +145,6 @@ class TestDumpState:
 class TestAtomicWrite:
     def test_no_partial_file_left_on_disk_after_write(self, log_dir):
         """After a successful write, only the sentinel exists; no .tmp leftover."""
-        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-13T10:00:00+08:00"))
+        Sentinel.write(log_dir, SentinelState(stopped_at="2026-05-13T10:00:00+08:00"))
         leftovers = [p.name for p in log_dir.iterdir() if p.name.endswith(".tmp")]
         assert leftovers == []

--- a/tests/unit/deployments/test_log_cleanup_sentinel.py
+++ b/tests/unit/deployments/test_log_cleanup_sentinel.py
@@ -1,0 +1,154 @@
+"""Tests for rock.deployments.log_cleanup_sentinel — sentinel read/write/bump helpers."""
+
+import json
+from datetime import datetime
+
+import pytest
+
+from rock.deployments.log_cleanup_sentinel import (
+    LOG_STOPPED_SENTINEL,
+    SentinelState,
+    bump_attempts,
+    dump_state,
+    read_sentinel,
+    sentinel_path,
+    write_sentinel,
+)
+
+
+@pytest.fixture
+def log_dir(tmp_path):
+    """Create a temporary directory simulating a sandbox log directory."""
+    d = tmp_path / "sandbox-abc123"
+    d.mkdir()
+    return d
+
+
+class TestSentinelPath:
+    def test_returns_correct_path(self, log_dir):
+        result = sentinel_path(log_dir)
+        assert result == log_dir / LOG_STOPPED_SENTINEL
+
+
+class TestWriteSentinel:
+    def test_writes_default_state(self, log_dir):
+        write_sentinel(log_dir)
+        target = sentinel_path(log_dir)
+        assert target.is_file()
+        data = json.loads(target.read_text())
+        assert data["version"] == 1
+        assert data["attempts"] == 0
+        assert "stopped_at" in data
+        # stopped_at should be a valid ISO 8601 timestamp
+        datetime.fromisoformat(data["stopped_at"])
+
+    def test_writes_custom_state(self, log_dir):
+        state = SentinelState(stopped_at="2026-05-10T10:00:00+08:00", attempts=2, version=1)
+        write_sentinel(log_dir, state)
+        data = json.loads(sentinel_path(log_dir).read_text())
+        assert data["stopped_at"] == "2026-05-10T10:00:00+08:00"
+        assert data["attempts"] == 2
+        assert data["version"] == 1
+
+    def test_overwrites_existing_sentinel(self, log_dir):
+        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-01T00:00:00+08:00", attempts=0))
+        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-02T00:00:00+08:00", attempts=1))
+        data = json.loads(sentinel_path(log_dir).read_text())
+        assert data["stopped_at"] == "2026-05-02T00:00:00+08:00"
+        assert data["attempts"] == 1
+
+
+class TestReadSentinel:
+    def test_reads_valid_sentinel(self, log_dir):
+        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-10T12:00:00+08:00", attempts=1))
+        state = read_sentinel(log_dir)
+        assert state is not None
+        assert state.stopped_at == "2026-05-10T12:00:00+08:00"
+        assert state.attempts == 1
+        assert state.version == 1
+
+    def test_returns_none_when_missing(self, log_dir):
+        assert read_sentinel(log_dir) is None
+
+    def test_returns_none_on_corrupt_json(self, log_dir):
+        sentinel_path(log_dir).write_text("not valid json {{{")
+        assert read_sentinel(log_dir) is None
+
+    def test_returns_none_on_missing_stopped_at_key(self, log_dir):
+        sentinel_path(log_dir).write_text(json.dumps({"version": 1, "attempts": 0}))
+        assert read_sentinel(log_dir) is None
+
+    def test_defaults_attempts_to_zero(self, log_dir):
+        sentinel_path(log_dir).write_text(json.dumps({"stopped_at": "2026-05-10T00:00:00Z"}))
+        state = read_sentinel(log_dir)
+        assert state is not None
+        assert state.attempts == 0
+
+
+class TestBumpAttempts:
+    def test_increments_existing_sentinel(self, log_dir):
+        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-10T00:00:00+08:00", attempts=0))
+        result = bump_attempts(log_dir)
+        assert result == 1
+        state = read_sentinel(log_dir)
+        assert state.attempts == 1
+
+    def test_increments_multiple_times(self, log_dir):
+        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-10T00:00:00+08:00", attempts=0))
+        bump_attempts(log_dir)
+        bump_attempts(log_dir)
+        result = bump_attempts(log_dir)
+        assert result == 3
+
+    def test_creates_sentinel_if_missing(self, log_dir):
+        """If sentinel is missing, bump_attempts recreates with attempts=1."""
+        result = bump_attempts(log_dir)
+        assert result == 1
+        state = read_sentinel(log_dir)
+        assert state is not None
+        assert state.attempts == 1
+
+
+class TestSentinelState:
+    def test_now_factory(self):
+        state = SentinelState.now()
+        assert state.attempts == 0
+        assert state.version == 1
+        # Verify it's a valid ISO timestamp
+        dt = datetime.fromisoformat(state.stopped_at)
+        assert dt.tzinfo is not None  # tz-aware
+
+    def test_round_trip(self, log_dir):
+        """Write and read back should produce identical state."""
+        original = SentinelState(stopped_at="2026-05-13T15:30:00+08:00", attempts=2, version=1)
+        write_sentinel(log_dir, original)
+        restored = read_sentinel(log_dir)
+        assert restored.stopped_at == original.stopped_at
+        assert restored.attempts == original.attempts
+        assert restored.version == original.version
+
+
+class TestDumpState:
+    """dump_state is the single source of truth for the sentinel JSON shape;
+    admin-side code that overwrites a remote worker's sentinel via
+    runtime.write_file() reuses it to avoid schema drift."""
+
+    def test_returns_json_string_with_all_fields(self):
+        s = SentinelState(stopped_at="2026-05-13T10:00:00+08:00", attempts=2, version=1)
+        result = json.loads(dump_state(s))
+        assert result == {"stopped_at": "2026-05-13T10:00:00+08:00", "attempts": 2, "version": 1}
+
+    def test_dump_then_load_round_trip(self, log_dir):
+        original = SentinelState(stopped_at="2026-05-13T10:00:00+08:00", attempts=3, version=1)
+        sentinel_path(log_dir).write_text(dump_state(original))
+        restored = read_sentinel(log_dir)
+        assert restored.stopped_at == original.stopped_at
+        assert restored.attempts == original.attempts
+
+
+class TestAtomicWrite:
+    def test_no_partial_file_left_on_disk_after_write(self, log_dir):
+        """After a successful write, only the sentinel exists; no .tmp leftover."""
+        write_sentinel(log_dir, SentinelState(stopped_at="2026-05-13T10:00:00+08:00"))
+        leftovers = [p.name for p in log_dir.iterdir() if p.name.endswith(".tmp")]
+        assert leftovers == []


### PR DESCRIPTION

  ## Summary
  - 新增 `rock/deployments/log_cleanup_sentinel.py`：`SentinelState` + 原子
  `write_sentinel` / `read_sentinel` / `bump_attempts`
  - `DockerDeployment._stop()` 末尾在已挂载的 log_dir 落
  `.rock_stopped_at`（文件已存在则跳过）
  - `LOG_STOPPED_SENTINEL` 常量与 `dump_state()` 同模块导出，admin 侧
  `SandboxLogArchiveTask` 直接复用

  ## Files
  - `rock/deployments/log_cleanup_sentinel.py` (NEW)
  - `rock/deployments/docker.py` (`_stop()` 尾部新增写 sentinel)
  - `tests/unit/deployments/test_log_cleanup_sentinel.py` (NEW)

  ## Test plan
  - [ ] `uv run pytest tests/unit/deployments/test_log_cleanup_sentinel.py -v`
  - [ ] `uv run ruff check rock/deployments/log_cleanup_sentinel.py
  rock/deployments/docker.py`

  refs #958