### PR TITLE
feature(scheduler): add BuildCacheCleanupTask for uv/pip cache pruning

### DIFF
--- a/rock/admin/scheduler/tasks/__init__.py
+++ b/rock/admin/scheduler/tasks/__init__.py
@@ -1,4 +1,5 @@
 # rock/admin/scheduler/tasks/__init__.py
+from rock.admin.scheduler.tasks.build_cache_cleanup_task import BuildCacheCleanupTask
 from rock.admin.scheduler.tasks.container_cleanup_task import ContainerCleanupTask
 from rock.admin.scheduler.tasks.file_cleanup_task import FileCleanupTask
 from rock.admin.scheduler.tasks.image_cleanup_task import ImageCleanupTask
@@ -6,6 +7,7 @@ from rock.admin.scheduler.tasks.image_pull_task import ImagePullTask
 from rock.admin.scheduler.tasks.ray_log_cleanup_task import RayLogCleanupTask
 
 __all__ = [
+    "BuildCacheCleanupTask",
     "ContainerCleanupTask",
     "FileCleanupTask",
     "ImageCleanupTask",

--- a/rock/admin/scheduler/tasks/build_cache_cleanup_task.py
+++ b/rock/admin/scheduler/tasks/build_cache_cleanup_task.py
@@ -1,0 +1,86 @@
+"""Prune build/install caches (uv, pip) on each worker."""
+
+from rock.admin.proto.request import SandboxCommand as Command
+from rock.admin.scheduler.task_base import BaseTask, IdempotencyType, TaskStatusEnum
+from rock.common.constants import SCHEDULER_LOG_NAME
+from rock.logger import init_logger
+from rock.sandbox.remote_sandbox import RemoteSandboxRuntime
+
+logger = init_logger(name="build_cache_cleanup", file_name=SCHEDULER_LOG_NAME)
+
+# Map tool name -> shell snippet that prunes its cache. Each snippet uses an
+# explicit if/then/else so the "not installed" message is only emitted when
+# `command -v` actually fails — otherwise the legacy `a && b || c` form would
+# also fire `c` when `b` failed (permission/disk error), misleading operators
+# into thinking the tool was missing when in fact the prune itself errored.
+_TOOL_COMMANDS: dict[str, str] = {
+    "uv": (
+        "if command -v uv >/dev/null 2>&1; then "
+        '  uv cache prune 2>&1 || echo "uv: prune failed"; '
+        'else echo "uv: skipped (not installed)"; fi'
+    ),
+    "pip": (
+        "if command -v pip >/dev/null 2>&1; then "
+        '  pip cache purge 2>&1 || echo "pip: prune failed"; '
+        'else echo "pip: skipped (not installed)"; fi'
+    ),
+}
+
+
+class BuildCacheCleanupTask(BaseTask):
+    """Prune build/install caches for the configured tools.
+
+    Each tool runs in its own self-skipping shell snippet, so a worker that
+    lacks one of them won't fail the whole task. Default `tools` covers both
+    common tools used in the standard worker image; restrict via yml if you
+    want to skip one of them.
+    """
+
+    def __init__(
+        self,
+        interval_seconds: int = 86400,
+        tools: list[str] | None = None,
+    ):
+        """
+        Args:
+            interval_seconds: Execution interval, default 24 hours.
+            tools: Subset of {"uv", "pip"}; default both. Unknown names raise.
+        """
+        super().__init__(
+            type="build_cache_cleanup",
+            interval_seconds=interval_seconds,
+            idempotency=IdempotencyType.IDEMPOTENT,
+        )
+        tools = tools if tools is not None else ["uv", "pip"]
+        unknown = [t for t in tools if t not in _TOOL_COMMANDS]
+        if unknown:
+            raise ValueError(
+                f"Unsupported build cache tool(s): {unknown}. Supported: {sorted(_TOOL_COMMANDS)}"
+            )
+        self.tools = tools
+
+    @classmethod
+    def from_config(cls, task_config) -> "BuildCacheCleanupTask":
+        return cls(
+            interval_seconds=task_config.interval_seconds,
+            tools=task_config.params.get("tools"),
+        )
+
+    async def run_action(self, runtime: RemoteSandboxRuntime) -> dict:
+        # Sequential `; ` (not `&& `): each tool's snippet already converts
+        # "missing" to a soft echo, but `;` keeps any future tool that emits a
+        # non-zero exit from short-circuiting the rest.
+        snippets = [_TOOL_COMMANDS[t] for t in self.tools]
+        command = "; ".join(snippets) if snippets else "echo 'no tools configured'"
+        result = await runtime.execute(Command(command=command, shell=True, check=False))
+        output = (result.stdout or "").strip()
+        logger.info(
+            f"[{self.type}] [{runtime._config.host}] cache prune done: "
+            f"tools={self.tools}, exit={result.exit_code}, output_head={output[:200]}"
+        )
+        return {
+            "status": TaskStatusEnum.SUCCESS,
+            "tools": self.tools,
+            "exit_code": result.exit_code,
+            "output_head": output[:500],
+        }

--- a/rock/admin/scheduler/tasks/build_cache_cleanup_task.py
+++ b/rock/admin/scheduler/tasks/build_cache_cleanup_task.py
@@ -1,5 +1,7 @@
 """Prune build/install caches (uv, pip) on each worker."""
 
+import textwrap
+
 from rock.admin.proto.request import SandboxCommand as Command
 from rock.admin.scheduler.task_base import BaseTask, IdempotencyType, TaskStatusEnum
 from rock.common.constants import SCHEDULER_LOG_NAME
@@ -14,15 +16,21 @@ logger = init_logger(name="build_cache_cleanup", file_name=SCHEDULER_LOG_NAME)
 # also fire `c` when `b` failed (permission/disk error), misleading operators
 # into thinking the tool was missing when in fact the prune itself errored.
 _TOOL_COMMANDS: dict[str, str] = {
-    "uv": (
-        "if command -v uv >/dev/null 2>&1; then "
-        '  uv cache prune 2>&1 || echo "uv: prune failed"; '
-        'else echo "uv: skipped (not installed)"; fi'
+    "uv": textwrap.dedent(
+        """\
+        if command -v uv >/dev/null 2>&1; then
+          uv cache prune 2>&1 || echo "uv: prune failed"
+        else
+          echo "uv: skipped (not installed)"
+        fi"""
     ),
-    "pip": (
-        "if command -v pip >/dev/null 2>&1; then "
-        '  pip cache purge 2>&1 || echo "pip: prune failed"; '
-        'else echo "pip: skipped (not installed)"; fi'
+    "pip": textwrap.dedent(
+        """\
+        if command -v pip >/dev/null 2>&1; then
+          pip cache purge 2>&1 || echo "pip: prune failed"
+        else
+          echo "pip: skipped (not installed)"
+        fi"""
     ),
 }
 
@@ -54,9 +62,7 @@ class BuildCacheCleanupTask(BaseTask):
         tools = tools if tools is not None else ["uv", "pip"]
         unknown = [t for t in tools if t not in _TOOL_COMMANDS]
         if unknown:
-            raise ValueError(
-                f"Unsupported build cache tool(s): {unknown}. Supported: {sorted(_TOOL_COMMANDS)}"
-            )
+            raise ValueError(f"Unsupported build cache tool(s): {unknown}. Supported: {sorted(_TOOL_COMMANDS)}")
         self.tools = tools
 
     @classmethod

--- a/tests/unit/admin/scheduler/test_build_cache_cleanup_task.py
+++ b/tests/unit/admin/scheduler/test_build_cache_cleanup_task.py
@@ -1,0 +1,131 @@
+"""Tests for BuildCacheCleanupTask."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from rock.admin.scheduler.task_base import TaskStatusEnum
+from rock.admin.scheduler.tasks.build_cache_cleanup_task import BuildCacheCleanupTask
+
+
+class _FakeTaskConfig:
+    def __init__(self, params=None, interval_seconds=86400):
+        self.params = params or {}
+        self.interval_seconds = interval_seconds
+
+
+class _FakeExecResult:
+    def __init__(self, exit_code=0, stdout="Pruned 0 entries"):
+        self.exit_code = exit_code
+        self.stdout = stdout
+
+
+def _runtime(stdout="Pruned 0 entries", exit_code=0):
+    rt = AsyncMock()
+    rt._config = type("C", (), {"host": "10.0.0.1"})()
+    rt.execute = AsyncMock(return_value=_FakeExecResult(exit_code=exit_code, stdout=stdout))
+    return rt
+
+
+class TestInit:
+    def test_default_tools(self):
+        task = BuildCacheCleanupTask()
+        assert task.type == "build_cache_cleanup"
+        assert task.interval_seconds == 86400
+        assert task.tools == ["uv", "pip"]
+
+    def test_custom_tools_subset(self):
+        task = BuildCacheCleanupTask(tools=["uv"])
+        assert task.tools == ["uv"]
+
+    def test_empty_tools_list_is_allowed(self):
+        # Explicit empty list -> task no-ops (echo line). Different from None,
+        # which means "use default".
+        task = BuildCacheCleanupTask(tools=[])
+        assert task.tools == []
+
+    def test_unknown_tool_raises(self):
+        with pytest.raises(ValueError, match="Unsupported build cache tool"):
+            BuildCacheCleanupTask(tools=["uv", "npm"])
+
+
+class TestFromConfig:
+    def test_from_config_defaults(self):
+        task = BuildCacheCleanupTask.from_config(_FakeTaskConfig())
+        assert task.tools == ["uv", "pip"]
+
+    def test_from_config_custom_tools(self):
+        cfg = _FakeTaskConfig(params={"tools": ["pip"]}, interval_seconds=3600)
+        task = BuildCacheCleanupTask.from_config(cfg)
+        assert task.tools == ["pip"]
+        assert task.interval_seconds == 3600
+
+
+class TestRunAction:
+    @pytest.mark.asyncio
+    async def test_default_command_invokes_both_tools(self):
+        task = BuildCacheCleanupTask()
+        runtime = _runtime()
+
+        result = await task.run_action(runtime)
+        assert result["status"] == TaskStatusEnum.SUCCESS
+        assert result["tools"] == ["uv", "pip"]
+
+        cmd = runtime.execute.await_args.args[0].command
+        assert "uv cache prune" in cmd
+        assert "pip cache purge" in cmd
+        # Each step has its own command -v guard so missing tool != failure.
+        assert "command -v uv" in cmd
+        assert "command -v pip" in cmd
+
+    @pytest.mark.asyncio
+    async def test_command_skips_missing_tool_with_soft_echo(self):
+        # if/then/else structure emits "skipped (not installed)" only when
+        # `command -v` fails — distinct from the "prune failed" branch below.
+        task = BuildCacheCleanupTask()
+        runtime = _runtime(stdout="No cache entries to prune\npip: skipped (not installed)")
+
+        result = await task.run_action(runtime)
+        assert result["status"] == TaskStatusEnum.SUCCESS
+        assert "skipped" in result["output_head"]
+
+    @pytest.mark.asyncio
+    async def test_command_distinguishes_prune_failure_from_missing_tool(self):
+        # Regression: the old `a && b || c` form fired "skipped (not installed)"
+        # even when the tool was present but prune itself errored (permission,
+        # disk full, etc.). The if/then/else version must surface "prune failed"
+        # in that case so operators can tell the two apart in logs.
+        task = BuildCacheCleanupTask()
+        runtime = _runtime()
+        await task.run_action(runtime)
+        cmd = runtime.execute.await_args.args[0].command
+
+        # Both branches must be present in the generated command for both tools.
+        assert "uv: prune failed" in cmd
+        assert "uv: skipped (not installed)" in cmd
+        assert "pip: prune failed" in cmd
+        assert "pip: skipped (not installed)" in cmd
+        # The mutually-exclusive shape: if/then/else replaces `a && b || c`.
+        assert "if command -v uv" in cmd
+        assert "if command -v pip" in cmd
+        assert "else echo" in cmd
+
+    @pytest.mark.asyncio
+    async def test_subset_of_tools(self):
+        task = BuildCacheCleanupTask(tools=["uv"])
+        runtime = _runtime()
+
+        await task.run_action(runtime)
+        cmd = runtime.execute.await_args.args[0].command
+        assert "uv cache prune" in cmd
+        assert "pip cache purge" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_empty_tools_list_runs_noop(self):
+        task = BuildCacheCleanupTask(tools=[])
+        runtime = _runtime(stdout="no tools configured")
+
+        result = await task.run_action(runtime)
+        assert result["status"] == TaskStatusEnum.SUCCESS
+        cmd = runtime.execute.await_args.args[0].command
+        assert "no tools configured" in cmd

--- a/tests/unit/admin/scheduler/test_build_cache_cleanup_task.py
+++ b/tests/unit/admin/scheduler/test_build_cache_cleanup_task.py
@@ -108,7 +108,9 @@ class TestRunAction:
         # The mutually-exclusive shape: if/then/else replaces `a && b || c`.
         assert "if command -v uv" in cmd
         assert "if command -v pip" in cmd
-        assert "else echo" in cmd
+        # Triple-quote bash puts `else` and `echo` on separate lines (newline as
+        # statement separator); just check the keyword is present.
+        assert "else" in cmd
 
     @pytest.mark.asyncio
     async def test_subset_of_tools(self):


### PR DESCRIPTION
## Summary                                                                            

  新增 `BuildCacheCleanupTask`：在每个 worker 上定时清理 uv / pip 的缓存。                
  
  - 每个工具用独立的自跳过 shell snippet（`command -v` guard），缺失工具不影响其他工具    
  - **关键改动 vs naive 写法**：用 `if/then/else` 结构而不是 `a && b || c`，避免 `b`    
  失败时误报 "skipped (not installed)" 这种误导性日志                                     
  - `tools` 默认 `["uv", "pip"]`，yml 可子集化；未知工具名构造时即抛                    
  `ValueError`，配置错误快速失败                                                          
  - 幂等（uv/pip prune 只删未被引用的条目）                                             
  - 默认 24h 间隔                                                                         
                                                                                        
  ## yml usage                                                                            
                                                                                        
  ```yaml                                                                                 
  - task_class: rock.admin.scheduler.tasks.build_cache_cleanup_task.BuildCacheCleanupTask
    enabled: true                                                                         
    interval_seconds: 86400
    params:                                                                               
      tools: ["uv", "pip"]   # 可选；默认两个都开                                       
  ```                                                                                     
                                                                                        
  ## Files (4)                                                                            
                                                                                        
  - `rock/admin/scheduler/tasks/build_cache_cleanup_task.py` (NEW, 86 lines)              
  - `rock/admin/scheduler/tasks/__init__.py` (export)
  - `tests/unit/admin/scheduler/__init__.py` (NEW, empty)                                 
  - `tests/unit/admin/scheduler/test_build_cache_cleanup_task.py` (NEW, 11 tests including
   the prune-failure-vs-missing-tool regression)                                          
                                                                                          
  ## Test plan                                                                            
                                                                                        
  - [ ] `uv run pytest tests/unit/admin/scheduler/test_build_cache_cleanup_task.py -v`（11
   passed）
  - [ ] `uv run ruff check rock/admin/scheduler/tasks/build_cache_cleanup_task.py         
  tests/unit/admin/scheduler/test_build_cache_cleanup_task.py`                            
  - [ ] 灰度灰度 worker：`du -sh ~/.cache/uv ~/.cache/pip` 前后对比
                                                                                          
  refs #968 