### PR TITLE
feature(scheduler): feature(scheduler): merge dangling/BuildKit prune into ImageCleanupTask

### DIFF
--- a/rock/admin/scheduler/tasks/image_cleanup_task.py
+++ b/rock/admin/scheduler/tasks/image_cleanup_task.py
@@ -11,21 +11,37 @@ logger = init_logger(name="image_clean", file_name=SCHEDULER_LOG_NAME)
 
 
 class ImageCleanupTask(BaseTask):
-    """Docker image cleanup task using docuum."""
+    """Docker image cleanup: docuum LRU + dangling/BuildKit prune.
+
+    Two complementary cleanups in one task:
+    - docuum: long-running daemon, LRU eviction of whole image:tag entries.
+      Honors ``image_whitelist``.
+    - ``docker image prune --filter dangling=true`` + ``docker builder prune
+      --keep-storage <X>``: one-shot synchronous sweep of dangling layers
+      (``<none>:<none>``) and BuildKit cache, which docuum never touches.
+      Whitelist is intentionally NOT plumbed through here — dangling layers
+      and BuildKit cache entries have no image:tag, so a whitelist would be
+      misleading on both subcommands.
+
+    Set ``keep_build_storage`` to a falsy value to disable the prune step.
+    """
 
     def __init__(
         self,
         interval_seconds: int = 3600,
         disk_threshold: str = "1T",
         image_whitelist: list[str] | None = None,
+        keep_build_storage: str | None = "20GB",
     ):
         """
-        Initialize image cleanup task.
-
         Args:
             interval_seconds: Execution interval, default 1 hour
-            disk_threshold: Disk threshold to trigger cleanup, default 1T
-            image_whitelist: List of regex patterns for images to keep (matched against repository:tag)
+            disk_threshold: Disk threshold to trigger docuum cleanup, default 1T
+            image_whitelist: Regex patterns of images to keep (matched against
+                repository:tag). Applies to docuum only.
+            keep_build_storage: Lower bound for BuildKit cache retention,
+                passed to ``docker builder prune --keep-storage``. Default
+                "20GB". Set to None / empty to skip the prune step.
         """
         super().__init__(
             type="image_cleanup",
@@ -34,21 +50,21 @@ class ImageCleanupTask(BaseTask):
         )
         self.disk_threshold = disk_threshold
         self.image_whitelist = image_whitelist or []
+        self.keep_build_storage = keep_build_storage
 
     @classmethod
     def from_config(cls, task_config) -> "ImageCleanupTask":
         """Create task instance from config."""
-        disk_threshold = task_config.params.get("disk_threshold", "1T")
-        image_whitelist = task_config.params.get("image_whitelist", [])
         return cls(
             interval_seconds=task_config.interval_seconds,
-            disk_threshold=disk_threshold,
-            image_whitelist=image_whitelist,
+            disk_threshold=task_config.params.get("disk_threshold", "1T"),
+            image_whitelist=task_config.params.get("image_whitelist", []),
+            keep_build_storage=task_config.params.get("keep_build_storage", "20GB"),
         )
 
     async def run_action(self, runtime: RemoteSandboxRuntime) -> dict:
-        """Run docuum image cleanup action."""
-        # Check if docuum exists, install if not
+        """Start docuum daemon, then synchronously prune dangling/build cache."""
+        # 1) docuum: LRU image eviction (long-running, nohup &)
         check_and_install_cmd = (
             f"command -v docuum > /dev/null 2>&1 || curl {env_vars.ROCK_DOCUUM_INSTALL_URL} -LSfs | sh"
         )
@@ -67,9 +83,31 @@ class ImageCleanupTask(BaseTask):
         pid = extract_nohup_pid(result.stdout)
         logger.info(f"image cleanup task [{pid}] run successfully on worker[{runtime._config.host}]")
 
+        # 2) Dangling/BuildKit prune (sync, fail-soft so an old/missing docker
+        #    subcommand on one worker doesn't abort the rest of the pipeline).
+        prune_exit = None
+        prune_output = ""
+        if self.keep_build_storage:
+            prune_steps = [
+                "docker image prune -f --filter dangling=true",
+                f"docker builder prune -f --keep-storage {self.keep_build_storage}",
+            ]
+            prune_cmd = "; ".join(f"({s}) 2>&1 || true" for s in prune_steps)
+            prune_result = await runtime.execute(Command(command=prune_cmd, shell=True, check=False))
+            prune_output = (prune_result.stdout or "").strip()[:1000]
+            prune_exit = prune_result.exit_code
+            logger.info(
+                f"docker prune done on worker[{runtime._config.host}]: "
+                f"keep_build_storage={self.keep_build_storage}, exit={prune_exit}, "
+                f"output_head={prune_output[:300]}"
+            )
+
         return {
             "pid": pid,
             "disk_threshold": self.disk_threshold,
             "image_whitelist": self.image_whitelist,
+            "keep_build_storage": self.keep_build_storage,
+            "prune_exit_code": prune_exit,
+            "prune_output_head": prune_output,
             "status": TaskStatusEnum.RUNNING,
         }

--- a/tests/unit/admin/scheduler/test_image_cleanup_task.py
+++ b/tests/unit/admin/scheduler/test_image_cleanup_task.py
@@ -1,0 +1,171 @@
+"""Tests for ImageCleanupTask (docuum LRU + dangling/BuildKit prune)."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from rock.admin.scheduler.task_base import TaskStatusEnum
+from rock.admin.scheduler.tasks.image_cleanup_task import ImageCleanupTask
+
+
+class _FakeTaskConfig:
+    def __init__(self, params=None, interval_seconds=3600):
+        self.params = params or {}
+        self.interval_seconds = interval_seconds
+
+
+class _FakeExecResult:
+    def __init__(self, exit_code=0, stdout=""):
+        self.exit_code = exit_code
+        self.stdout = stdout
+
+
+def _runtime(side_effects):
+    """Build a runtime whose execute() returns successive results from side_effects."""
+    rt = AsyncMock()
+    rt._config = type("C", (), {"host": "10.0.0.1"})()
+    rt.execute = AsyncMock(side_effect=side_effects)
+    return rt
+
+
+# Fixed call sequence for run_action when keep_build_storage is set:
+#   1) docuum install check
+#   2) docuum start (returns PID-tagged stdout)
+#   3) docker image prune + docker builder prune (one combined cmd)
+def _default_results(pid=12345, prune_stdout="Total reclaimed space: 1.2GB"):
+    return [
+        _FakeExecResult(),
+        _FakeExecResult(stdout=f"PIDSTART{pid}PIDEND"),
+        _FakeExecResult(stdout=prune_stdout),
+    ]
+
+
+class TestInit:
+    def test_default(self):
+        task = ImageCleanupTask()
+        assert task.type == "image_cleanup"
+        assert task.interval_seconds == 3600
+        assert task.disk_threshold == "1T"
+        assert task.image_whitelist == []
+        assert task.keep_build_storage == "20GB"
+
+    def test_custom(self):
+        task = ImageCleanupTask(
+            interval_seconds=600,
+            disk_threshold="500G",
+            image_whitelist=[r"^rock-base.*$"],
+            keep_build_storage="5GB",
+        )
+        assert task.interval_seconds == 600
+        assert task.disk_threshold == "500G"
+        assert task.image_whitelist == [r"^rock-base.*$"]
+        assert task.keep_build_storage == "5GB"
+
+    def test_disable_prune(self):
+        task = ImageCleanupTask(keep_build_storage=None)
+        assert task.keep_build_storage is None
+
+
+class TestFromConfig:
+    def test_from_config_defaults(self):
+        task = ImageCleanupTask.from_config(_FakeTaskConfig())
+        assert task.disk_threshold == "1T"
+        assert task.image_whitelist == []
+        assert task.keep_build_storage == "20GB"
+
+    def test_from_config_custom(self):
+        cfg = _FakeTaskConfig(
+            params={
+                "disk_threshold": "200G",
+                "image_whitelist": [r"^pinned:.*$"],
+                "keep_build_storage": "10GB",
+            },
+            interval_seconds=7200,
+        )
+        task = ImageCleanupTask.from_config(cfg)
+        assert task.interval_seconds == 7200
+        assert task.disk_threshold == "200G"
+        assert task.image_whitelist == [r"^pinned:.*$"]
+        assert task.keep_build_storage == "10GB"
+
+
+class TestRunAction:
+    @pytest.mark.asyncio
+    async def test_docuum_command_includes_threshold(self):
+        task = ImageCleanupTask(disk_threshold="500G")
+        runtime = _runtime(_default_results())
+
+        await task.run_action(runtime)
+        docuum_cmd = runtime.execute.await_args_list[1].args[0].command
+        assert "docuum --threshold 500G" in docuum_cmd
+
+    @pytest.mark.asyncio
+    async def test_docuum_command_passes_whitelist(self):
+        task = ImageCleanupTask(image_whitelist=[r"^rock-base.*$", r"^pinned:.*$"])
+        runtime = _runtime(_default_results())
+
+        await task.run_action(runtime)
+        docuum_cmd = runtime.execute.await_args_list[1].args[0].command
+        assert "--keep '^rock-base.*$'" in docuum_cmd
+        assert "--keep '^pinned:.*$'" in docuum_cmd
+
+    @pytest.mark.asyncio
+    async def test_prune_command_includes_image_and_builder_prune(self):
+        task = ImageCleanupTask(keep_build_storage="10GB")
+        runtime = _runtime(_default_results())
+
+        await task.run_action(runtime)
+        prune_cmd = runtime.execute.await_args_list[2].args[0].command
+        assert "docker image prune -f --filter dangling=true" in prune_cmd
+        assert "docker builder prune -f --keep-storage 10GB" in prune_cmd
+
+    @pytest.mark.asyncio
+    async def test_prune_command_does_not_invoke_volume_prune(self):
+        # Long-running sandboxes may attach named volumes; we don't want to
+        # drop them on schedule.
+        task = ImageCleanupTask()
+        runtime = _runtime(_default_results())
+
+        await task.run_action(runtime)
+        prune_cmd = runtime.execute.await_args_list[2].args[0].command
+        assert "docker volume prune" not in prune_cmd
+
+    @pytest.mark.asyncio
+    async def test_prune_step_is_fail_soft(self):
+        task = ImageCleanupTask()
+        runtime = _runtime(_default_results())
+
+        await task.run_action(runtime)
+        prune_cmd = runtime.execute.await_args_list[2].args[0].command
+        # `(...) 2>&1 || true` makes a missing/old docker subcommand non-fatal.
+        assert "|| true" in prune_cmd
+
+    @pytest.mark.asyncio
+    async def test_prune_skipped_when_keep_build_storage_falsy(self):
+        task = ImageCleanupTask(keep_build_storage=None)
+        # Only 2 execute calls expected: install check + docuum start.
+        runtime = _runtime(_default_results()[:2])
+
+        result = await task.run_action(runtime)
+        assert runtime.execute.await_count == 2
+        assert result["prune_exit_code"] is None
+        assert result["prune_output_head"] == ""
+
+    @pytest.mark.asyncio
+    async def test_run_action_returns_pid_and_status(self):
+        task = ImageCleanupTask()
+        runtime = _runtime(_default_results(pid=98765))
+
+        result = await task.run_action(runtime)
+        assert result["status"] == TaskStatusEnum.RUNNING
+        assert result["pid"] == 98765
+        assert result["disk_threshold"] == "1T"
+        assert result["keep_build_storage"] == "20GB"
+
+    @pytest.mark.asyncio
+    async def test_run_action_records_prune_output(self):
+        task = ImageCleanupTask()
+        runtime = _runtime(_default_results(prune_stdout="Total reclaimed space: 3.5GB\n(more)"))
+
+        result = await task.run_action(runtime)
+        assert "Total reclaimed space" in result["prune_output_head"]


### PR DESCRIPTION
## Summary                                                                              
                                                                                        
  新增 `DockerImagePruneTask`：在每个 worker 上定时清理 docker dangling 层 + BuildKit     
  cache。
                                                                                          
  - 与 `ImageCleanupTask`（docuum, 按 image:tag LRU）**正交**：docuum 看不到              
  `<none>:<none>` 层和 BuildKit cache，本 task 补这个空隙
  - 按 review 反馈合并到 ImageCleanupTask
  - keep_build_storage 默认 "20GB",可设 None/"" 关闭                                                                                                                                                               
  - 不调用 volume prune(防止误删 named volumes)             
  - whitelist 不下传到 prune 步骤(dangling/BuildKit 没有 image:tag)
  refs #968 