### PR TITLE
feature(scheduler): add RayLogCleanupTask and disable worker-to-driver log forwarding

### DIFF
--- a/rock/admin/core/ray_service.py
+++ b/rock/admin/core/ray_service.py
@@ -40,6 +40,7 @@ class RayService:
             namespace=self._config.namespace,
             resources=self._config.resources,
             _temp_dir=self._config.temp_dir,
+            log_to_driver=False,
         )
         if self._config.ray_reconnect_enabled:
             self._setup_ray_reconnect_scheduler()
@@ -94,6 +95,7 @@ class RayService:
                             namespace=self._config.namespace,
                             resources=self._config.resources,
                             _temp_dir=self._config.temp_dir,
+                            log_to_driver=False,
                         )
                     except Exception as e:
                         last_exc = e

--- a/rock/admin/scheduler/tasks/__init__.py
+++ b/rock/admin/scheduler/tasks/__init__.py
@@ -3,5 +3,12 @@ from rock.admin.scheduler.tasks.container_cleanup_task import ContainerCleanupTa
 from rock.admin.scheduler.tasks.file_cleanup_task import FileCleanupTask
 from rock.admin.scheduler.tasks.image_cleanup_task import ImageCleanupTask
 from rock.admin.scheduler.tasks.image_pull_task import ImagePullTask
+from rock.admin.scheduler.tasks.ray_log_cleanup_task import RayLogCleanupTask
 
-__all__ = ["ContainerCleanupTask", "FileCleanupTask", "ImageCleanupTask", "ImagePullTask"]
+__all__ = [
+    "ContainerCleanupTask",
+    "FileCleanupTask",
+    "ImageCleanupTask",
+    "ImagePullTask",
+    "RayLogCleanupTask",
+]

--- a/rock/admin/scheduler/tasks/ray_log_cleanup_task.py
+++ b/rock/admin/scheduler/tasks/ray_log_cleanup_task.py
@@ -1,5 +1,7 @@
 """Drop stale /data/tmp/ray/session_* dirs on each worker."""
 
+import textwrap
+
 from rock.admin.proto.request import SandboxCommand as Command
 from rock.admin.scheduler.task_base import BaseTask, IdempotencyType, TaskStatusEnum
 from rock.common.constants import SCHEDULER_LOG_NAME
@@ -60,20 +62,25 @@ class RayLogCleanupTask(BaseTask):
         max_age_min = self.min_age_hours * 60
         # Resolve session_latest -> live basename, then list session_* dirs
         # older than threshold and rm -rf those that are not the live one.
-        command = (
-            f'if [ -d "{ray_dir}" ]; then '
-            f'  LIVE=$(readlink "{ray_dir}/session_latest" 2>/dev/null | xargs -I{{}} basename {{}} 2>/dev/null); '
-            f'  echo "live_session=${{LIVE:-<none>}}"; '
-            f'  find "{ray_dir}" -maxdepth 1 -type d -name "session_*" '
-            f'    ! -name "session_latest" -mmin +{max_age_min} '
-            f'  | while read -r d; do '
-            f'      bn=$(basename "$d"); '
-            f'      if [ "$bn" != "$LIVE" ]; then '
-            f'        rm -rf "$d" && echo "removed=$bn"; '
-            f'      fi; '
-            f'    done; '
-            f'  echo "ray_log_cleanup_done"; '
-            f'else echo "ray_temp_dir_not_found"; fi'
+        # textwrap.dedent strips common leading whitespace so source can be
+        # indented for readability without polluting the emitted shell.
+        command = textwrap.dedent(
+            f"""\
+            if [ -d "{ray_dir}" ]; then
+              LIVE=$(readlink "{ray_dir}/session_latest" 2>/dev/null | xargs -I{{}} basename {{}} 2>/dev/null)
+              echo "live_session=${{LIVE:-<none>}}"
+              find "{ray_dir}" -maxdepth 1 -type d -name "session_*" \\
+                ! -name "session_latest" -mmin +{max_age_min} \\
+              | while read -r d; do
+                  bn=$(basename "$d")
+                  if [ "$bn" != "$LIVE" ]; then
+                    rm -rf "$d" && echo "removed=$bn"
+                  fi
+                done
+              echo "ray_log_cleanup_done"
+            else
+              echo "ray_temp_dir_not_found"
+            fi"""
         )
         result = await runtime.execute(Command(command=command, shell=True, check=False))
         output = (result.stdout or "").strip()

--- a/rock/admin/scheduler/tasks/ray_log_cleanup_task.py
+++ b/rock/admin/scheduler/tasks/ray_log_cleanup_task.py
@@ -1,0 +1,91 @@
+"""Drop stale /data/tmp/ray/session_* dirs on each worker."""
+
+from rock.admin.proto.request import SandboxCommand as Command
+from rock.admin.scheduler.task_base import BaseTask, IdempotencyType, TaskStatusEnum
+from rock.common.constants import SCHEDULER_LOG_NAME
+from rock.logger import init_logger
+from rock.sandbox.remote_sandbox import RemoteSandboxRuntime
+
+logger = init_logger(name="ray_log_cleanup", file_name=SCHEDULER_LOG_NAME)
+
+
+class RayLogCleanupTask(BaseTask):
+    """Drop /data/tmp/ray/session_* dirs that are NOT the live session.
+
+    Ray restarts (cluster up/down, head failover) leave dozens of
+    session_<timestamp>_<pid> dirs behind. The currently active one is
+    symlinked as `session_latest`; we resolve that link and skip its target.
+    Sessions younger than `min_age_hours` are also kept as a buffer against
+    a stale symlink.
+
+    NOTE: This is the WORKER side. The ray-head's /data/tmp/ray is cleaned
+    by a daily cron baked into the head Dockerfile (rock-internal repo);
+    rocklet is not deployed on the head and the worker scheduler does not
+    reach it.
+    """
+
+    def __init__(
+        self,
+        interval_seconds: int = 86400,
+        ray_temp_dir: str = "/data/tmp/ray",
+        min_age_hours: int = 24,
+    ):
+        """
+        Args:
+            interval_seconds: Execution interval, default 24 hours.
+            ray_temp_dir: Ray's --temp-dir, default /data/tmp/ray.
+            min_age_hours: Only delete session dirs whose mtime is older than
+                this AND that are not session_latest. Default 24h.
+        """
+        super().__init__(
+            type="ray_log_cleanup",
+            interval_seconds=interval_seconds,
+            idempotency=IdempotencyType.IDEMPOTENT,
+        )
+        if min_age_hours < 1:
+            raise ValueError(f"ray_log_cleanup.min_age_hours must be >= 1, got {min_age_hours}")
+        self.ray_temp_dir = ray_temp_dir.rstrip("/")
+        self.min_age_hours = min_age_hours
+
+    @classmethod
+    def from_config(cls, task_config) -> "RayLogCleanupTask":
+        return cls(
+            interval_seconds=task_config.interval_seconds,
+            ray_temp_dir=task_config.params.get("ray_temp_dir", "/data/tmp/ray"),
+            min_age_hours=task_config.params.get("min_age_hours", 24),
+        )
+
+    async def run_action(self, runtime: RemoteSandboxRuntime) -> dict:
+        ray_dir = self.ray_temp_dir
+        max_age_min = self.min_age_hours * 60
+        # Resolve session_latest -> live basename, then list session_* dirs
+        # older than threshold and rm -rf those that are not the live one.
+        command = (
+            f'if [ -d "{ray_dir}" ]; then '
+            f'  LIVE=$(readlink "{ray_dir}/session_latest" 2>/dev/null | xargs -I{{}} basename {{}} 2>/dev/null); '
+            f'  echo "live_session=${{LIVE:-<none>}}"; '
+            f'  find "{ray_dir}" -maxdepth 1 -type d -name "session_*" '
+            f'    ! -name "session_latest" -mmin +{max_age_min} '
+            f'  | while read -r d; do '
+            f'      bn=$(basename "$d"); '
+            f'      if [ "$bn" != "$LIVE" ]; then '
+            f'        rm -rf "$d" && echo "removed=$bn"; '
+            f'      fi; '
+            f'    done; '
+            f'  echo "ray_log_cleanup_done"; '
+            f'else echo "ray_temp_dir_not_found"; fi'
+        )
+        result = await runtime.execute(Command(command=command, shell=True, check=False))
+        output = (result.stdout or "").strip()
+        removed = [line.split("=", 1)[1] for line in output.splitlines() if line.startswith("removed=")]
+        logger.info(
+            f"[{self.type}] [{runtime._config.host}] ray_log_cleanup done: "
+            f"removed={len(removed)} sessions, output_head={output[:300]}"
+        )
+        return {
+            "status": TaskStatusEnum.SUCCESS,
+            "exit_code": result.exit_code,
+            "removed_count": len(removed),
+            "removed_sessions": removed,
+            "output_head": output[:1000],
+        }

--- a/tests/unit/admin/core/test_ray_service.py
+++ b/tests/unit/admin/core/test_ray_service.py
@@ -160,6 +160,7 @@ async def test_reconnect_ray_calls_ray_shutdown_and_init_and_reset_counters(ray_
             namespace=ray_service._config.namespace,
             resources=ray_service._config.resources,
             _temp_dir=ray_service._config.temp_dir,
+            log_to_driver=False,
         )
 
         assert service._ray_request_count == 0

--- a/tests/unit/admin/scheduler/test_ray_log_cleanup_task.py
+++ b/tests/unit/admin/scheduler/test_ray_log_cleanup_task.py
@@ -1,0 +1,120 @@
+"""Tests for RayLogCleanupTask."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from rock.admin.scheduler.task_base import TaskStatusEnum
+from rock.admin.scheduler.tasks.ray_log_cleanup_task import RayLogCleanupTask
+
+
+class _FakeTaskConfig:
+    def __init__(self, params=None, interval_seconds=86400):
+        self.params = params or {}
+        self.interval_seconds = interval_seconds
+
+
+class _FakeExecResult:
+    def __init__(self, exit_code=0, stdout="ray_log_cleanup_done"):
+        self.exit_code = exit_code
+        self.stdout = stdout
+
+
+def _runtime(stdout="ray_log_cleanup_done", exit_code=0):
+    rt = AsyncMock()
+    rt._config = type("C", (), {"host": "10.0.0.1"})()
+    rt.execute = AsyncMock(return_value=_FakeExecResult(exit_code=exit_code, stdout=stdout))
+    return rt
+
+
+class TestInit:
+    def test_default(self):
+        task = RayLogCleanupTask()
+        assert task.type == "ray_log_cleanup"
+        assert task.ray_temp_dir == "/data/tmp/ray"
+        assert task.min_age_hours == 24
+
+    def test_strips_trailing_slash(self):
+        task = RayLogCleanupTask(ray_temp_dir="/data/ray/")
+        assert task.ray_temp_dir == "/data/ray"
+
+    def test_rejects_min_age_below_one(self):
+        with pytest.raises(ValueError, match="min_age_hours must be >= 1"):
+            RayLogCleanupTask(min_age_hours=0)
+
+
+class TestFromConfig:
+    def test_from_config_defaults(self):
+        task = RayLogCleanupTask.from_config(_FakeTaskConfig())
+        assert task.ray_temp_dir == "/data/tmp/ray"
+        assert task.min_age_hours == 24
+
+    def test_from_config_custom(self):
+        cfg = _FakeTaskConfig(
+            params={"ray_temp_dir": "/data/ray", "min_age_hours": 48},
+            interval_seconds=3600,
+        )
+        task = RayLogCleanupTask.from_config(cfg)
+        assert task.ray_temp_dir == "/data/ray"
+        assert task.min_age_hours == 48
+        assert task.interval_seconds == 3600
+
+
+class TestRunAction:
+    @pytest.mark.asyncio
+    async def test_command_skips_session_latest(self):
+        task = RayLogCleanupTask()
+        runtime = _runtime()
+        await task.run_action(runtime)
+
+        cmd = runtime.execute.await_args.args[0].command
+        # `! -name "session_latest"` skips the symlink itself; readlink resolves
+        # the target so we also skip whichever real session it points at.
+        assert '! -name "session_latest"' in cmd
+        assert "readlink" in cmd
+        assert 'name "session_*"' in cmd
+
+    @pytest.mark.asyncio
+    async def test_command_uses_min_age_in_minutes(self):
+        task = RayLogCleanupTask(min_age_hours=48)
+        runtime = _runtime()
+        await task.run_action(runtime)
+
+        cmd = runtime.execute.await_args.args[0].command
+        # 48h * 60 = 2880
+        assert "-mmin +2880" in cmd
+
+    @pytest.mark.asyncio
+    async def test_command_respects_custom_temp_dir(self):
+        task = RayLogCleanupTask(ray_temp_dir="/data/ray")
+        runtime = _runtime()
+        await task.run_action(runtime)
+
+        cmd = runtime.execute.await_args.args[0].command
+        assert '"/data/ray"' in cmd
+
+    @pytest.mark.asyncio
+    async def test_extracts_removed_count_from_output(self):
+        stdout = (
+            "live_session=session_2026_03_01_xyz_111\n"
+            "removed=session_2026_02_15_aaa_222\n"
+            "removed=session_2026_02_20_bbb_333\n"
+            "ray_log_cleanup_done"
+        )
+        task = RayLogCleanupTask()
+        runtime = _runtime(stdout=stdout)
+
+        result = await task.run_action(runtime)
+        assert result["status"] == TaskStatusEnum.SUCCESS
+        assert result["removed_count"] == 2
+        assert "session_2026_02_15_aaa_222" in result["removed_sessions"]
+        assert "session_2026_02_20_bbb_333" in result["removed_sessions"]
+
+    @pytest.mark.asyncio
+    async def test_handles_missing_ray_dir(self):
+        task = RayLogCleanupTask()
+        runtime = _runtime(stdout="ray_temp_dir_not_found")
+
+        result = await task.run_action(runtime)
+        assert result["status"] == TaskStatusEnum.SUCCESS
+        assert result["removed_count"] == 0


### PR DESCRIPTION
## Summary                                                                            

  两件相关但独立的事，合一个 PR 因为都触及 ray 日志路径：                                 
  
  ### 1. RayLogCleanupTask（新 scheduler task）                                           
                                                                                        
  每个 worker 上定时清理 `/data/tmp/ray/session_*` 老目录：                               
  
  - 解析 `session_latest` symlink 拿到真实活 session basename，skip 之                    
  - `find -mmin +N` 守护：默认 24h 以内的 session 一律不删，给 symlink lag 留 buffer    
  - 单次 `rm -rf` 是 idempotent；中断后下次跑会继续，符合 mtime 仍然满足                  
  - 默认 `ray_temp_dir = "/data/tmp/ray"`，`min_age_hours = 24`                           
  - 构造时 `min_age_hours < 1` 抛 `ValueError`，避免人工误配把活的 session 删掉           
                                                                                          
  ### 2. `log_to_driver=False`（rock/admin/core/ray_service.py）                          
                                                                                          
  `ray.init()` 两个调用点（首次 init + reconnect）都加上 `log_to_driver=False`：          
                                                                                          
  - 关掉 worker actor stdout/stderr 经 GRPC 转发到 driver（admin 进程）
  - worker 自己写到 `/data/tmp/ray/...` 的日志文件**不受影响**，正好让 RayLogCleanupTask  
  来管                                                                                    
  - **副作用**：以后 admin 进程 stdout 看不到 actor print/exception；要排查 actor 异常需登
   worker 看 `worker-*.out`                                                               
                                                                                        
  ## ray-head 不在范围                                                                    
                                                                                          
  ray-head 的 `/data/tmp/ray` 同样需要清理，但 head 不部署 rocklet，scheduler 
  不触达。临时方案：rock-internal 仓的 ray-head Dockerfile 加 cron +                      
  shell（独立改动，不在本 PR）。                                                        
                                                                                          
  ## yml usage                                                                          

  ```yaml
  - task_class: rock.admin.scheduler.tasks.ray_log_cleanup_task.RayLogCleanupTask
    enabled: true                                                                         
    interval_seconds: 86400
    params:                                                                               
      ray_temp_dir: "/data/tmp/ray"                                                     
      min_age_hours: 24                                                                   
  ```
                                                                                          
  ## Files (5)                                                                          
                                                                                          
  - `rock/admin/scheduler/tasks/ray_log_cleanup_task.py` (NEW, 91 lines)                  
  - `rock/admin/scheduler/tasks/__init__.py` (export)                                     
  - `rock/admin/core/ray_service.py` (`log_to_driver=False` on both `ray.init()` sites)   
  - `tests/unit/admin/scheduler/__init__.py` (NEW, empty)                                 
  - `tests/unit/admin/scheduler/test_ray_log_cleanup_task.py` (NEW, 10 tests)
                                                                                          
   worker 看 `worker-*.out`

  ## ray-head 不在范围

  ray-head 的 `/data/tmp/ray` 同样需要清理，但 head 不部署 rocklet，scheduler
  不触达。临时方案：rock-internal 仓的 ray-head Dockerfile 加 cron +
                                
  - [ ] `uv run pytest tests/unit/admin/scheduler/test_docker_image_prune_task.py -v`（8
  passed）    
  - [ ] `uv run ruff check rock/admin/scheduler/tasks/docker_image_prune_task.py
  tests/unit/admin/scheduler/test_docker_image_prune_task.py`
  - [ ] 灰度灰度 worker：`docker system df` 前后对比 Build Cache 和 dangling images 项
                 
  refs #968 