### PR TITLE
feature(admin): add /admin/internal/disk_emergency_cleanup for SRE on-call

### DIFF
--- a/rock/admin/entrypoints/admin_ops_api.py
+++ b/rock/admin/entrypoints/admin_ops_api.py
@@ -4,9 +4,9 @@ Currently provides:
 - Disk emergency cleanup: trigger scheduled cleanup tasks immediately on
   selected workers, bypassing the scheduler interval.
 
-Default mode is **async** (fire-and-forget): the API returns a job_id
-immediately while tasks execute in the background. Callers can use mode="sync"
-to block and get per-task summaries directly.
+Execution is async (fire-and-forget): the API returns a job_id immediately
+while tasks execute in the background. Use the /status/{job_id} endpoint
+to poll for results.
 
 NOTE: Task instances are constructed on demand from RockConfig (via
 TaskFactory). This does NOT touch the SchedulerThread's task registry, so
@@ -39,6 +39,7 @@ admin_ops_router = APIRouter()
 
 _TASK_WHITELIST_SUFFIXES: tuple[str, ...] = ("_cleanup", "_prune")
 _RATE_LIMIT_SECONDS: int = 60
+_MAX_JOB_HISTORY: int = 1000
 _last_triggered_at: dict[str, float] = {}  # task_type -> unix ts
 
 # Wired from main.py lifespan. Decoupled from SchedulerThread.
@@ -114,6 +115,18 @@ def _select_tasks(
     return selected, errors
 
 
+def _evict_stale_jobs() -> None:
+    """Evict oldest completed/failed jobs when history exceeds _MAX_JOB_HISTORY."""
+    if len(_async_jobs) <= _MAX_JOB_HISTORY:
+        return
+    done = [(k, v) for k, v in _async_jobs.items()
+            if v["status"] in ("completed", "failed")]
+    done.sort(key=lambda x: x[1].get("submitted_at", 0))
+    to_remove = len(_async_jobs) - _MAX_JOB_HISTORY
+    for k, _ in done[:to_remove]:
+        del _async_jobs[k]
+
+
 def _check_and_mark_rate_limit(task_type: str, now: float) -> bool:
     """Returns True if allowed; False if hit cooldown.
     Side effect on success: updates _last_triggered_at[task_type] = now.
@@ -178,6 +191,7 @@ async def disk_emergency_cleanup(
     payload: DiskEmergencyCleanupRequest,
     request: Request,
 ) -> RockResponse[dict]:
+    _evict_stale_jobs()
     caller_ip = request.client.host if request.client else "unknown"
     audit_logger.info(
         f"emergency_cleanup called: caller={caller_ip}, "

--- a/rock/admin/entrypoints/admin_ops_api.py
+++ b/rock/admin/entrypoints/admin_ops_api.py
@@ -1,0 +1,297 @@
+"""Admin operations API — internal endpoints for SRE on-call.
+
+Currently provides:
+- Disk emergency cleanup: trigger scheduled cleanup tasks immediately on
+  selected workers, bypassing the scheduler interval.
+
+Default mode is **async** (fire-and-forget): the API returns a job_id
+immediately while tasks execute in the background. Callers can use mode="sync"
+to block and get per-task summaries directly.
+
+NOTE: Task instances are constructed on demand from RockConfig (via
+TaskFactory). This does NOT touch the SchedulerThread's task registry, so
+the two paths are independent — emergency cleanup works even when the
+periodic scheduler is intentionally disabled.
+"""
+
+import asyncio
+import time
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Request
+
+from rock.actions import ResponseStatus, RockResponse
+from rock.admin.proto.request import DiskEmergencyCleanupRequest
+from rock.admin.scheduler.task_base import BaseTask
+from rock.admin.scheduler.task_factory import TaskFactory
+from rock.common.constants import SCHEDULER_LOG_NAME
+from rock.common.exception import handle_exceptions
+from rock.config import RockConfig
+from rock.logger import init_logger
+
+audit_logger = init_logger(name="admin_ops", file_name=SCHEDULER_LOG_NAME)
+logger = init_logger(name="admin_ops_api")
+
+admin_ops_router = APIRouter()
+
+# --- Whitelist & rate limit (process-local) ---
+
+_TASK_WHITELIST_SUFFIXES: tuple[str, ...] = ("_cleanup", "_prune")
+_RATE_LIMIT_SECONDS: int = 60
+_last_triggered_at: dict[str, float] = {}  # task_type -> unix ts
+
+# Wired from main.py lifespan. Decoupled from SchedulerThread.
+_alive_workers_provider = None
+_rock_config_provider = None
+
+# In-memory store for async job status tracking
+_async_jobs: dict[str, dict[str, Any]] = {}
+
+
+def set_alive_workers_provider(provider) -> None:
+    global _alive_workers_provider
+    _alive_workers_provider = provider
+
+
+def set_rock_config_provider(provider) -> None:
+    """Wire a callable that returns the current RockConfig (Nacos hot-reload friendly)."""
+    global _rock_config_provider
+    _rock_config_provider = provider
+
+
+def _is_task_whitelisted(task_type: str) -> bool:
+    return any(task_type.endswith(sfx) for sfx in _TASK_WHITELIST_SUFFIXES)
+
+
+def _build_eligible_tasks(rock_config: RockConfig) -> dict[str, BaseTask]:
+    """Construct BaseTask instances for every whitelisted yml entry.
+
+    Builds on demand, so config changes (Nacos / yml reload) are picked up
+    on the next API call without any cross-thread state.
+    """
+    out: dict[str, BaseTask] = {}
+    for task_config in rock_config.scheduler.tasks:
+        if not getattr(task_config, "task_class", None):
+            continue
+        # Even disabled-in-yml cleanup tasks should be reachable by emergency
+        # trigger (the whole point is "scheduler off, but SRE needs it now").
+        try:
+            task = TaskFactory.create_task(task_config)
+        except Exception as e:
+            logger.warning(
+                f"emergency_cleanup: failed to construct task '{task_config.task_class}': {e}"
+            )
+            continue
+        if _is_task_whitelisted(task.type):
+            out[task.type] = task
+    return out
+
+
+def _select_tasks(
+    requested: list[str] | None,
+    available: dict[str, BaseTask],
+) -> tuple[list[BaseTask], list[str]]:
+    """Resolve names against the available (whitelisted) pool."""
+    errors: list[str] = []
+    if requested is None:
+        return list(available.values()), errors
+
+    selected: list[BaseTask] = []
+    seen: set[str] = set()
+    for name in requested:
+        if name in seen:
+            errors.append(f"{name}: duplicate in request")
+            continue
+        seen.add(name)
+        if name not in available:
+            errors.append(
+                f"{name}: not in eligible task pool "
+                f"(must be a yml-registered task whose type ends in {_TASK_WHITELIST_SUFFIXES})"
+            )
+            continue
+        selected.append(available[name])
+    return selected, errors
+
+
+def _check_and_mark_rate_limit(task_type: str, now: float) -> bool:
+    """Returns True if allowed; False if hit cooldown.
+    Side effect on success: updates _last_triggered_at[task_type] = now.
+    """
+    last = _last_triggered_at.get(task_type, 0.0)
+    if now - last < _RATE_LIMIT_SECONDS:
+        return False
+    _last_triggered_at[task_type] = now
+    return True
+
+
+async def _run_tasks_blocking(
+    tasks: list[BaseTask],
+    worker_ips: list[str],
+) -> dict[str, Any]:
+    """Run each task sequentially across workers; collect per-task summary."""
+    results: dict[str, Any] = {}
+    for task in tasks:
+        t0 = time.time()
+        try:
+            await task.run(worker_ips)
+            results[task.type] = {
+                "status": "ok",
+                "elapsed_seconds": round(time.time() - t0, 2),
+                "worker_count": len(worker_ips),
+            }
+        except Exception as e:
+            results[task.type] = {
+                "status": "error",
+                "error": str(e),
+                "elapsed_seconds": round(time.time() - t0, 2),
+                "worker_count": len(worker_ips),
+            }
+            logger.exception(f"emergency_cleanup task '{task.type}' failed: {e}")
+    return results
+
+
+async def _run_tasks_async_background(
+    job_id: str,
+    tasks: list[BaseTask],
+    worker_ips: list[str],
+    caller_ip: str,
+) -> None:
+    """Background coroutine for async mode; updates _async_jobs on completion."""
+    try:
+        results = await _run_tasks_blocking(tasks, worker_ips)
+        _async_jobs[job_id]["status"] = "completed"
+        _async_jobs[job_id]["results"] = results
+        audit_logger.info(
+            f"emergency_cleanup async job completed: job_id={job_id}, "
+            f"caller={caller_ip}, results={results}"
+        )
+    except Exception as e:
+        _async_jobs[job_id]["status"] = "failed"
+        _async_jobs[job_id]["error"] = str(e)
+        logger.exception(f"emergency_cleanup async job '{job_id}' failed: {e}")
+
+
+@admin_ops_router.post("/disk_emergency_cleanup")
+@handle_exceptions(error_message="disk emergency cleanup failed")
+async def disk_emergency_cleanup(
+    payload: DiskEmergencyCleanupRequest,
+    request: Request,
+) -> RockResponse[dict]:
+    caller_ip = request.client.host if request.client else "unknown"
+    audit_logger.info(
+        f"emergency_cleanup called: caller={caller_ip}, "
+        f"tasks={payload.tasks}, worker_ips={payload.worker_ips}"
+    )
+
+    # 1) Resolve workers
+    if payload.worker_ips is not None:
+        worker_ips = list(payload.worker_ips)
+    elif _alive_workers_provider is not None:
+        try:
+            worker_ips = list(_alive_workers_provider())
+        except Exception as e:
+            logger.exception(f"alive_workers_provider raised: {e}")
+            worker_ips = []
+    else:
+        worker_ips = []
+
+    if not worker_ips:
+        return RockResponse(
+            status=ResponseStatus.FAILED,
+            message="no worker available",
+            error="worker_ips empty and alive-workers provider returned nothing",
+            result=None,
+        )
+
+    # 2) Resolve eligible tasks from current RockConfig
+    if _rock_config_provider is None:
+        return RockResponse(
+            status=ResponseStatus.FAILED,
+            message="not initialized",
+            error="rock_config_provider not wired; admin lifespan did not set it",
+            result=None,
+        )
+    try:
+        rock_config = _rock_config_provider()
+    except Exception as e:
+        logger.exception(f"rock_config_provider raised: {e}")
+        return RockResponse(
+            status=ResponseStatus.FAILED,
+            message="config unavailable",
+            error=str(e),
+            result=None,
+        )
+
+    available = _build_eligible_tasks(rock_config)
+    selected, errors = _select_tasks(payload.tasks, available)
+    if not selected:
+        return RockResponse(
+            status=ResponseStatus.FAILED,
+            message="no eligible task",
+            error="; ".join(errors) or "no whitelisted cleanup task registered in yml",
+            result={"errors": errors, "available": sorted(available.keys())},
+        )
+
+    # 3) Per-task rate limit
+    now = time.time()
+    allowed: list[BaseTask] = []
+    rate_limited: list[str] = []
+    for task in selected:
+        if _check_and_mark_rate_limit(task.type, now):
+            allowed.append(task)
+        else:
+            rate_limited.append(task.type)
+
+    if not allowed:
+        return RockResponse(
+            status=ResponseStatus.FAILED,
+            message="rate limited",
+            error=f"all requested tasks were triggered within last {_RATE_LIMIT_SECONDS}s",
+            result={"rate_limited": rate_limited, "cooldown_seconds": _RATE_LIMIT_SECONDS},
+        )
+
+    # 4) Fire-and-forget: return job_id immediately
+    job_id = uuid.uuid4().hex[:12]
+    _async_jobs[job_id] = {
+        "status": "running",
+        "tasks": [t.type for t in allowed],
+        "worker_count": len(worker_ips),
+        "submitted_at": time.time(),
+    }
+    asyncio.create_task(
+        _run_tasks_async_background(job_id, allowed, worker_ips, caller_ip)
+    )
+    audit_logger.info(
+        f"emergency_cleanup dispatched: job_id={job_id}, caller={caller_ip}, "
+        f"tasks={[t.type for t in allowed]}, workers={len(worker_ips)}"
+    )
+    return RockResponse(
+        status=ResponseStatus.SUCCESS,
+        message="accepted",
+        result={
+            "job_id": job_id,
+            "tasks": [t.type for t in allowed],
+            "worker_count": len(worker_ips),
+            "rejected": errors,
+            "rate_limited": rate_limited,
+        },
+    )
+
+
+@admin_ops_router.get("/disk_emergency_cleanup/status/{job_id}")
+@handle_exceptions(error_message="failed to get job status")
+async def disk_emergency_cleanup_status(job_id: str) -> RockResponse[dict]:
+    """Query the status of an async emergency cleanup job."""
+    if job_id not in _async_jobs:
+        return RockResponse(
+            status=ResponseStatus.FAILED,
+            message="job not found",
+            error=f"job_id '{job_id}' does not exist or has expired",
+            result=None,
+        )
+    return RockResponse(
+        status=ResponseStatus.SUCCESS,
+        message="ok",
+        result=_async_jobs[job_id],
+    )

--- a/rock/admin/entrypoints/admin_ops_api.py
+++ b/rock/admin/entrypoints/admin_ops_api.py
@@ -37,7 +37,7 @@ admin_ops_router = APIRouter()
 
 # --- Whitelist & rate limit (process-local) ---
 
-_TASK_WHITELIST_SUFFIXES: tuple[str, ...] = ("_cleanup", "_prune")
+_TASK_WHITELIST_SUFFIXES: tuple[str, ...] = ("_cleanup", "_prune", "_archive")
 _RATE_LIMIT_SECONDS: int = 60
 _MAX_JOB_HISTORY: int = 1000
 _last_triggered_at: dict[str, float] = {}  # task_type -> unix ts
@@ -80,9 +80,7 @@ def _build_eligible_tasks(rock_config: RockConfig) -> dict[str, BaseTask]:
         try:
             task = TaskFactory.create_task(task_config)
         except Exception as e:
-            logger.warning(
-                f"emergency_cleanup: failed to construct task '{task_config.task_class}': {e}"
-            )
+            logger.warning(f"emergency_cleanup: failed to construct task '{task_config.task_class}': {e}")
             continue
         if _is_task_whitelisted(task.type):
             out[task.type] = task
@@ -119,8 +117,7 @@ def _evict_stale_jobs() -> None:
     """Evict oldest completed/failed jobs when history exceeds _MAX_JOB_HISTORY."""
     if len(_async_jobs) <= _MAX_JOB_HISTORY:
         return
-    done = [(k, v) for k, v in _async_jobs.items()
-            if v["status"] in ("completed", "failed")]
+    done = [(k, v) for k, v in _async_jobs.items() if v["status"] in ("completed", "failed")]
     done.sort(key=lambda x: x[1].get("submitted_at", 0))
     to_remove = len(_async_jobs) - _MAX_JOB_HISTORY
     for k, _ in done[:to_remove]:
@@ -176,8 +173,7 @@ async def _run_tasks_async_background(
         _async_jobs[job_id]["status"] = "completed"
         _async_jobs[job_id]["results"] = results
         audit_logger.info(
-            f"emergency_cleanup async job completed: job_id={job_id}, "
-            f"caller={caller_ip}, results={results}"
+            f"emergency_cleanup async job completed: job_id={job_id}, caller={caller_ip}, results={results}"
         )
     except Exception as e:
         _async_jobs[job_id]["status"] = "failed"
@@ -194,8 +190,7 @@ async def disk_emergency_cleanup(
     _evict_stale_jobs()
     caller_ip = request.client.host if request.client else "unknown"
     audit_logger.info(
-        f"emergency_cleanup called: caller={caller_ip}, "
-        f"tasks={payload.tasks}, worker_ips={payload.worker_ips}"
+        f"emergency_cleanup called: caller={caller_ip}, tasks={payload.tasks}, worker_ips={payload.worker_ips}"
     )
 
     # 1) Resolve workers
@@ -273,9 +268,7 @@ async def disk_emergency_cleanup(
         "worker_count": len(worker_ips),
         "submitted_at": time.time(),
     }
-    asyncio.create_task(
-        _run_tasks_async_background(job_id, allowed, worker_ips, caller_ip)
-    )
+    asyncio.create_task(_run_tasks_async_background(job_id, allowed, worker_ips, caller_ip))
     audit_logger.info(
         f"emergency_cleanup dispatched: job_id={job_id}, caller={caller_ip}, "
         f"tasks={[t.type for t in allowed]}, workers={len(worker_ips)}"

--- a/rock/admin/main.py
+++ b/rock/admin/main.py
@@ -16,6 +16,11 @@ from rock import env_vars
 from rock.admin.core.db_provider import DatabaseProvider
 from rock.admin.core.ray_service import RayService
 from rock.admin.core.sandbox_table import SandboxTable
+from rock.admin.entrypoints.admin_ops_api import (
+    admin_ops_router,
+    set_alive_workers_provider as set_admin_ops_workers_provider,
+    set_rock_config_provider as set_admin_ops_config_provider,
+)
 from rock.admin.entrypoints.sandbox_api import sandbox_router, set_sandbox_manager
 from rock.admin.entrypoints.sandbox_proxy_api import sandbox_proxy_router, set_sandbox_proxy_service
 from rock.admin.entrypoints.warmup_api import set_warmup_service, warmup_router
@@ -133,6 +138,12 @@ async def lifespan(app: FastAPI):
         set_warmup_service(warmup_service)
         set_env_service(sandbox_manager)
 
+        # Wire admin_ops_api providers (independent of scheduler being enabled)
+        from rock.admin.scheduler.scheduler import WorkerIPCache
+        _emergency_worker_cache = WorkerIPCache(cache_ttl=rock_config.scheduler.worker_cache_ttl)
+        set_admin_ops_workers_provider(_emergency_worker_cache.get_alive_workers)
+        set_admin_ops_config_provider(lambda: rock_config)
+
         if rock_config.scheduler.enabled and is_primary_pod():
             scheduler_thread = SchedulerThread(
                 scheduler_config=rock_config.scheduler,
@@ -242,6 +253,11 @@ def main():
     # config router
     if args.role == "admin":
         app.include_router(sandbox_router, prefix="/apis/envs/sandbox/v1", tags=["sandbox"])
+        app.include_router(
+            admin_ops_router,
+            prefix="/apis/v1/admin/internal",
+            tags=["admin-internal"],
+        )
     else:
         app.include_router(sandbox_proxy_router, prefix="/apis/envs/sandbox/v1", tags=["sandbox"])
     app.include_router(warmup_router, prefix="/apis/envs/sandbox/v1", tags=["warmup"])

--- a/rock/admin/proto/request.py
+++ b/rock/admin/proto/request.py
@@ -140,6 +140,27 @@ class ClusterInfo(TypedDict, total=False):
     cluster_name: str
 
 
+class DiskEmergencyCleanupRequest(BaseModel):
+    """Manual trigger for disk cleanup tasks, bypassing the scheduler interval.
+
+    Designed for SRE on-call use during disk-fill incidents. All fields are
+    optional; defaults run all whitelisted cleanup tasks on all alive workers.
+    Execution is always async (fire-and-forget), returns job_id immediately.
+    """
+
+    tasks: list[str] | None = Field(
+        default=None,
+        description=(
+            "BaseTask.type names to trigger (e.g. 'docker_image_prune'). "
+            "Whitelisted to suffix '_cleanup' / '_prune'. None = all whitelisted."
+        ),
+    )
+    worker_ips: list[str] | None = Field(
+        default=None,
+        description="Worker IPs to target. None = use the live alive-worker cache.",
+    )
+
+
 class StartHeaders:
     def __init__(
         self,

--- a/rock/admin/proto/request.py
+++ b/rock/admin/proto/request.py
@@ -151,7 +151,7 @@ class DiskEmergencyCleanupRequest(BaseModel):
     tasks: list[str] | None = Field(
         default=None,
         description=(
-            "BaseTask.type names to trigger (e.g. 'docker_image_prune'). "
+            "BaseTask.type names to trigger (e.g. 'image_cleanup'). "
             "Whitelisted to suffix '_cleanup' / '_prune'. None = all whitelisted."
         ),
     )

--- a/tests/unit/admin/entrypoints/test_disk_emergency_api.py
+++ b/tests/unit/admin/entrypoints/test_disk_emergency_api.py
@@ -85,11 +85,11 @@ def _wire_config_with_tasks(tasks: list):
 class TestSelectTasks:
     def test_default_returns_all_available(self):
         available = {
-            "docker_image_prune": _make_task("docker_image_prune"),
+            "image_cleanup": _make_task("image_cleanup"),
             "file_cleanup": _make_task("file_cleanup"),
         }
         selected, errors = api._select_tasks(None, available)
-        assert sorted(t.type for t in selected) == ["docker_image_prune", "file_cleanup"]
+        assert sorted(t.type for t in selected) == ["file_cleanup", "image_cleanup"]
         assert errors == []
 
     def test_explicit_request_filters_unknown(self):
@@ -108,7 +108,9 @@ class TestSelectTasks:
 class TestWhitelist:
     def test_suffix_cleanup(self):
         assert api._is_task_whitelisted("file_cleanup") is True
-        assert api._is_task_whitelisted("docker_image_prune") is True
+        # `_prune` suffix kept whitelisted for forward-compat with future
+        # prune-style tasks; synthetic stub since no current task uses it.
+        assert api._is_task_whitelisted("future_prune") is True
 
     def test_suffix_archive(self):
         # `_archive` is whitelisted so emergency API can manually trigger
@@ -141,7 +143,7 @@ class TestRateLimit:
     def test_independent_per_task(self):
         api._check_and_mark_rate_limit("file_cleanup", now=1000.0)
         # different task name, same instant -> allowed
-        assert api._check_and_mark_rate_limit("docker_image_prune", now=1000.0) is True
+        assert api._check_and_mark_rate_limit("image_cleanup", now=1000.0) is True
 
 
 # ----------------------------------------------------------------------------- #
@@ -262,21 +264,21 @@ class TestDiskEmergencyCleanupAsync:
 
     @pytest.mark.asyncio
     async def test_partial_rate_limit_runs_the_unblocked_subset(self):
-        # Trigger file_cleanup first, then request both — only docker_image_prune runs.
+        # Trigger file_cleanup first, then request both — only image_cleanup runs.
         t1 = _make_task("file_cleanup")
-        t2 = _make_task("docker_image_prune")
+        t2 = _make_task("image_cleanup")
         api.set_alive_workers_provider(lambda: ["10.0.0.1"])
         with _wire_config_with_tasks([t1, t2]):
             await api.disk_emergency_cleanup.__wrapped__(
                 DiskEmergencyCleanupRequest(tasks=["file_cleanup"]), _make_request()
             )
             resp = await api.disk_emergency_cleanup.__wrapped__(
-                DiskEmergencyCleanupRequest(tasks=["file_cleanup", "docker_image_prune"]),
+                DiskEmergencyCleanupRequest(tasks=["file_cleanup", "image_cleanup"]),
                 _make_request(),
             )
         assert resp.status == ResponseStatus.SUCCESS
         assert "file_cleanup" in resp.result["rate_limited"]
-        assert "docker_image_prune" in resp.result["tasks"]
+        assert "image_cleanup" in resp.result["tasks"]
 
 
 # ----------------------------------------------------------------------------- #

--- a/tests/unit/admin/entrypoints/test_disk_emergency_api.py
+++ b/tests/unit/admin/entrypoints/test_disk_emergency_api.py
@@ -14,7 +14,6 @@ from rock.actions import ResponseStatus
 from rock.admin.entrypoints import admin_ops_api as api
 from rock.admin.proto.request import DiskEmergencyCleanupRequest
 
-
 # ----------------------------------------------------------------------------- #
 # Fixtures
 # ----------------------------------------------------------------------------- #
@@ -111,9 +110,14 @@ class TestWhitelist:
         assert api._is_task_whitelisted("file_cleanup") is True
         assert api._is_task_whitelisted("docker_image_prune") is True
 
+    def test_suffix_archive(self):
+        # `_archive` is whitelisted so emergency API can manually trigger
+        # SandboxLogArchiveTask outside its 24h cadence (e.g. for SRE recovery).
+        assert api._is_task_whitelisted("sandbox_log_archive") is True
+
     def test_non_whitelist(self):
         assert api._is_task_whitelisted("image_pull") is False
-        assert api._is_task_whitelisted("sandbox_log_archive") is False
+        assert api._is_task_whitelisted("warmup_check") is False
 
 
 # ----------------------------------------------------------------------------- #
@@ -150,18 +154,14 @@ class TestDiskEmergencyCleanupAsync:
     async def test_no_worker_returns_failed(self):
         api.set_alive_workers_provider(lambda: [])
         with _wire_config_with_tasks([_make_task("file_cleanup")]):
-            resp = await api.disk_emergency_cleanup.__wrapped__(
-                DiskEmergencyCleanupRequest(), _make_request()
-            )
+            resp = await api.disk_emergency_cleanup.__wrapped__(DiskEmergencyCleanupRequest(), _make_request())
         assert resp.status == ResponseStatus.FAILED
         assert "no worker available" in resp.message
 
     @pytest.mark.asyncio
     async def test_no_config_provider_returns_failed(self):
         api.set_alive_workers_provider(lambda: ["10.0.0.1"])
-        resp = await api.disk_emergency_cleanup.__wrapped__(
-            DiskEmergencyCleanupRequest(), _make_request()
-        )
+        resp = await api.disk_emergency_cleanup.__wrapped__(DiskEmergencyCleanupRequest(), _make_request())
         assert resp.status == ResponseStatus.FAILED
         assert "not initialized" in resp.message
 
@@ -170,9 +170,7 @@ class TestDiskEmergencyCleanupAsync:
         api.set_alive_workers_provider(lambda: ["10.0.0.1"])
         # image_pull is not whitelisted, gets filtered in _build_eligible_tasks
         with _wire_config_with_tasks([_make_task("image_pull")]):
-            resp = await api.disk_emergency_cleanup.__wrapped__(
-                DiskEmergencyCleanupRequest(), _make_request()
-            )
+            resp = await api.disk_emergency_cleanup.__wrapped__(DiskEmergencyCleanupRequest(), _make_request())
         assert resp.status == ResponseStatus.FAILED
         assert "no eligible task" in resp.message
 
@@ -181,9 +179,7 @@ class TestDiskEmergencyCleanupAsync:
         t1 = _make_task("file_cleanup")
         api.set_alive_workers_provider(lambda: ["10.0.0.1", "10.0.0.2"])
         with _wire_config_with_tasks([t1]):
-            resp = await api.disk_emergency_cleanup.__wrapped__(
-                DiskEmergencyCleanupRequest(), _make_request()
-            )
+            resp = await api.disk_emergency_cleanup.__wrapped__(DiskEmergencyCleanupRequest(), _make_request())
 
         assert resp.status == ResponseStatus.SUCCESS
         assert resp.message == "accepted"
@@ -260,9 +256,7 @@ class TestDiskEmergencyCleanupAsync:
 
         api.set_alive_workers_provider(boom)
         with _wire_config_with_tasks([_make_task("file_cleanup")]):
-            resp = await api.disk_emergency_cleanup.__wrapped__(
-                DiskEmergencyCleanupRequest(), _make_request()
-            )
+            resp = await api.disk_emergency_cleanup.__wrapped__(DiskEmergencyCleanupRequest(), _make_request())
         assert resp.status == ResponseStatus.FAILED
         assert "no worker available" in resp.message
 

--- a/tests/unit/admin/entrypoints/test_disk_emergency_api.py
+++ b/tests/unit/admin/entrypoints/test_disk_emergency_api.py
@@ -1,0 +1,305 @@
+"""Unit tests for disk_emergency_api.
+
+Tests bypass FastAPI by calling the handler via __wrapped__ (handle_exceptions
+uses functools.wraps so this is safe). Mocks RockConfig and TaskFactory so we
+don't depend on a real scheduler.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from rock.actions import ResponseStatus
+from rock.admin.entrypoints import admin_ops_api as api
+from rock.admin.proto.request import DiskEmergencyCleanupRequest
+
+
+# ----------------------------------------------------------------------------- #
+# Fixtures
+# ----------------------------------------------------------------------------- #
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Snapshot + restore rate limit, providers, and async jobs between tests."""
+    saved_rate = dict(api._last_triggered_at)
+    saved_workers = api._alive_workers_provider
+    saved_config = api._rock_config_provider
+    saved_jobs = dict(api._async_jobs)
+
+    api._last_triggered_at = {}
+    api._alive_workers_provider = None
+    api._rock_config_provider = None
+    api._async_jobs = {}
+
+    yield
+
+    api._last_triggered_at = saved_rate
+    api._alive_workers_provider = saved_workers
+    api._rock_config_provider = saved_config
+    api._async_jobs = saved_jobs
+
+
+def _make_task(task_type: str, run_impl=None) -> MagicMock:
+    task = MagicMock()
+    task.type = task_type
+    task.run = AsyncMock(side_effect=run_impl) if run_impl else AsyncMock(return_value=None)
+    return task
+
+
+def _make_request(client_host="127.0.0.1") -> MagicMock:
+    req = MagicMock()
+    req.client = MagicMock()
+    req.client.host = client_host
+    return req
+
+
+def _wire_config_with_tasks(tasks: list):
+    """Mock _rock_config_provider to return a RockConfig-shaped MagicMock whose
+    scheduler.tasks is a list of fake TaskConfig entries, and patch TaskFactory
+    so create_task returns the given BaseTask mocks in declaration order."""
+    fake_task_configs = []
+    for t in tasks:
+        tc = MagicMock(spec=["task_class", "enabled"])
+        tc.task_class = f"fake.module.{t.type.title().replace('_', '')}"
+        tc.enabled = True
+        fake_task_configs.append(tc)
+    fake_cfg = MagicMock()
+    fake_cfg.scheduler.tasks = fake_task_configs
+    api._rock_config_provider = lambda: fake_cfg
+
+    # Map task_class -> BaseTask mock for TaskFactory.create_task to look up
+    by_class = {tc.task_class: t for tc, t in zip(fake_task_configs, tasks, strict=True)}
+
+    def fake_create(task_config):
+        return by_class[task_config.task_class]
+
+    return patch("rock.admin.entrypoints.admin_ops_api.TaskFactory.create_task", side_effect=fake_create)
+
+
+# ----------------------------------------------------------------------------- #
+# Whitelist + selection
+# ----------------------------------------------------------------------------- #
+
+
+class TestSelectTasks:
+    def test_default_returns_all_available(self):
+        available = {
+            "docker_image_prune": _make_task("docker_image_prune"),
+            "file_cleanup": _make_task("file_cleanup"),
+        }
+        selected, errors = api._select_tasks(None, available)
+        assert sorted(t.type for t in selected) == ["docker_image_prune", "file_cleanup"]
+        assert errors == []
+
+    def test_explicit_request_filters_unknown(self):
+        available = {"file_cleanup": _make_task("file_cleanup")}
+        selected, errors = api._select_tasks(["file_cleanup", "ghost_cleanup"], available)
+        assert [t.type for t in selected] == ["file_cleanup"]
+        assert any("ghost_cleanup" in e and "not in eligible task pool" in e for e in errors)
+
+    def test_duplicate_in_request_reported_once(self):
+        available = {"file_cleanup": _make_task("file_cleanup")}
+        selected, errors = api._select_tasks(["file_cleanup", "file_cleanup"], available)
+        assert [t.type for t in selected] == ["file_cleanup"]
+        assert any("duplicate" in e for e in errors)
+
+
+class TestWhitelist:
+    def test_suffix_cleanup(self):
+        assert api._is_task_whitelisted("file_cleanup") is True
+        assert api._is_task_whitelisted("docker_image_prune") is True
+
+    def test_non_whitelist(self):
+        assert api._is_task_whitelisted("image_pull") is False
+        assert api._is_task_whitelisted("sandbox_log_archive") is False
+
+
+# ----------------------------------------------------------------------------- #
+# Rate limit
+# ----------------------------------------------------------------------------- #
+
+
+class TestRateLimit:
+    def test_first_call_allowed(self):
+        assert api._check_and_mark_rate_limit("file_cleanup", now=1000.0) is True
+
+    def test_within_window_blocked(self):
+        api._check_and_mark_rate_limit("file_cleanup", now=1000.0)
+        assert api._check_and_mark_rate_limit("file_cleanup", now=1030.0) is False
+
+    def test_after_window_allowed(self):
+        api._check_and_mark_rate_limit("file_cleanup", now=1000.0)
+        future = 1000.0 + api._RATE_LIMIT_SECONDS + 1
+        assert api._check_and_mark_rate_limit("file_cleanup", now=future) is True
+
+    def test_independent_per_task(self):
+        api._check_and_mark_rate_limit("file_cleanup", now=1000.0)
+        # different task name, same instant -> allowed
+        assert api._check_and_mark_rate_limit("docker_image_prune", now=1000.0) is True
+
+
+# ----------------------------------------------------------------------------- #
+# Handler full path — async mode (default)
+# ----------------------------------------------------------------------------- #
+
+
+class TestDiskEmergencyCleanupAsync:
+    @pytest.mark.asyncio
+    async def test_no_worker_returns_failed(self):
+        api.set_alive_workers_provider(lambda: [])
+        with _wire_config_with_tasks([_make_task("file_cleanup")]):
+            resp = await api.disk_emergency_cleanup.__wrapped__(
+                DiskEmergencyCleanupRequest(), _make_request()
+            )
+        assert resp.status == ResponseStatus.FAILED
+        assert "no worker available" in resp.message
+
+    @pytest.mark.asyncio
+    async def test_no_config_provider_returns_failed(self):
+        api.set_alive_workers_provider(lambda: ["10.0.0.1"])
+        resp = await api.disk_emergency_cleanup.__wrapped__(
+            DiskEmergencyCleanupRequest(), _make_request()
+        )
+        assert resp.status == ResponseStatus.FAILED
+        assert "not initialized" in resp.message
+
+    @pytest.mark.asyncio
+    async def test_no_eligible_task_returns_failed(self):
+        api.set_alive_workers_provider(lambda: ["10.0.0.1"])
+        # image_pull is not whitelisted, gets filtered in _build_eligible_tasks
+        with _wire_config_with_tasks([_make_task("image_pull")]):
+            resp = await api.disk_emergency_cleanup.__wrapped__(
+                DiskEmergencyCleanupRequest(), _make_request()
+            )
+        assert resp.status == ResponseStatus.FAILED
+        assert "no eligible task" in resp.message
+
+    @pytest.mark.asyncio
+    async def test_async_returns_job_id_immediately(self):
+        t1 = _make_task("file_cleanup")
+        api.set_alive_workers_provider(lambda: ["10.0.0.1", "10.0.0.2"])
+        with _wire_config_with_tasks([t1]):
+            resp = await api.disk_emergency_cleanup.__wrapped__(
+                DiskEmergencyCleanupRequest(), _make_request()
+            )
+
+        assert resp.status == ResponseStatus.SUCCESS
+        assert resp.message == "accepted"
+        assert "job_id" in resp.result
+        assert resp.result["worker_count"] == 2
+        assert resp.result["tasks"] == ["file_cleanup"]
+
+        # Let background task complete
+        await asyncio.sleep(0.05)
+        job_id = resp.result["job_id"]
+        assert api._async_jobs[job_id]["status"] == "completed"
+        assert "file_cleanup" in api._async_jobs[job_id]["results"]
+        t1.run.assert_awaited_once_with(["10.0.0.1", "10.0.0.2"])
+
+    @pytest.mark.asyncio
+    async def test_async_background_error_recorded_in_job(self):
+        async def boom(_workers):
+            raise RuntimeError("kaboom")
+
+        t = _make_task("file_cleanup", run_impl=boom)
+        api.set_alive_workers_provider(lambda: ["10.0.0.1"])
+        with _wire_config_with_tasks([t]):
+            resp = await api.disk_emergency_cleanup.__wrapped__(
+                DiskEmergencyCleanupRequest(tasks=["file_cleanup"]), _make_request()
+            )
+
+        assert resp.status == ResponseStatus.SUCCESS
+        assert resp.message == "accepted"
+
+        # Let background task complete
+        await asyncio.sleep(0.05)
+        job_id = resp.result["job_id"]
+        # Task error is recorded per-task inside results, job itself completes
+        job = api._async_jobs[job_id]
+        assert job["status"] == "completed"
+        assert job["results"]["file_cleanup"]["status"] == "error"
+        assert "kaboom" in job["results"]["file_cleanup"]["error"]
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_blocks_second_call(self):
+        t = _make_task("file_cleanup")
+        api.set_alive_workers_provider(lambda: ["10.0.0.1"])
+        with _wire_config_with_tasks([t]):
+            first = await api.disk_emergency_cleanup.__wrapped__(
+                DiskEmergencyCleanupRequest(tasks=["file_cleanup"]), _make_request()
+            )
+            assert first.status == ResponseStatus.SUCCESS
+
+            second = await api.disk_emergency_cleanup.__wrapped__(
+                DiskEmergencyCleanupRequest(tasks=["file_cleanup"]), _make_request()
+            )
+            assert second.status == ResponseStatus.FAILED
+            assert "rate limited" in second.message
+            assert "file_cleanup" in second.result["rate_limited"]
+
+    @pytest.mark.asyncio
+    async def test_explicit_worker_ips_overrides_provider(self):
+        t = _make_task("file_cleanup")
+        api.set_alive_workers_provider(lambda: ["from-provider"])
+        with _wire_config_with_tasks([t]):
+            resp = await api.disk_emergency_cleanup.__wrapped__(
+                DiskEmergencyCleanupRequest(tasks=["file_cleanup"], worker_ips=["10.99.0.1"]),
+                _make_request(),
+            )
+        assert resp.status == ResponseStatus.SUCCESS
+        # Let background task complete
+        await asyncio.sleep(0.05)
+        t.run.assert_awaited_once_with(["10.99.0.1"])
+
+    @pytest.mark.asyncio
+    async def test_provider_exception_falls_back_to_failed(self):
+        def boom():
+            raise RuntimeError("ray not initialised")
+
+        api.set_alive_workers_provider(boom)
+        with _wire_config_with_tasks([_make_task("file_cleanup")]):
+            resp = await api.disk_emergency_cleanup.__wrapped__(
+                DiskEmergencyCleanupRequest(), _make_request()
+            )
+        assert resp.status == ResponseStatus.FAILED
+        assert "no worker available" in resp.message
+
+    @pytest.mark.asyncio
+    async def test_partial_rate_limit_runs_the_unblocked_subset(self):
+        # Trigger file_cleanup first, then request both — only docker_image_prune runs.
+        t1 = _make_task("file_cleanup")
+        t2 = _make_task("docker_image_prune")
+        api.set_alive_workers_provider(lambda: ["10.0.0.1"])
+        with _wire_config_with_tasks([t1, t2]):
+            await api.disk_emergency_cleanup.__wrapped__(
+                DiskEmergencyCleanupRequest(tasks=["file_cleanup"]), _make_request()
+            )
+            resp = await api.disk_emergency_cleanup.__wrapped__(
+                DiskEmergencyCleanupRequest(tasks=["file_cleanup", "docker_image_prune"]),
+                _make_request(),
+            )
+        assert resp.status == ResponseStatus.SUCCESS
+        assert "file_cleanup" in resp.result["rate_limited"]
+        assert "docker_image_prune" in resp.result["tasks"]
+
+
+# ----------------------------------------------------------------------------- #
+# Status endpoint
+# ----------------------------------------------------------------------------- #
+
+
+class TestDiskEmergencyCleanupStatus:
+    @pytest.mark.asyncio
+    async def test_unknown_job_returns_failed(self):
+        resp = await api.disk_emergency_cleanup_status.__wrapped__("nonexistent")
+        assert resp.status == ResponseStatus.FAILED
+        assert "not found" in resp.message
+
+    @pytest.mark.asyncio
+    async def test_existing_job_returns_status(self):
+        api._async_jobs["test123"] = {"status": "running", "tasks": ["file_cleanup"]}
+        resp = await api.disk_emergency_cleanup_status.__wrapped__("test123")
+        assert resp.status == ResponseStatus.SUCCESS
+        assert resp.result["status"] == "running"


### PR DESCRIPTION
## Summary

新增 SRE 紧急清理 API：`POST /apis/v1/admin/internal/disk_emergency_cleanup`，
让 on-call 在磁盘暴涨时不必等 24h 调度，一次调用立即触发指定/全部清理 task。

- 复用 `BaseTask.run()` + `WorkerIPCache`，无新机制
- 白名单（只允许 `*_cleanup` / `*_prune`）+ 60s 进程内限流防止误用
- 同步阻塞返回每个 (task, worker) 摘要，SRE 实时可见效果
- 仅在 `--role=admin` 注册，proxy 角色不暴露


## Files (5)

- `rock/admin/proto/request.py` (新增 `DiskEmergencyCleanupRequest`)
- `rock/admin/entrypoints/disk_emergency_api.py` (NEW)
- `rock/admin/main.py` (import + lifespan provider + route register)
- `tests/unit/admin/entrypoints/__init__.py` (NEW, empty)
- `tests/unit/admin/entrypoints/test_disk_emergency_api.py` (NEW, 11+ tests)

## Test plan

- [ ] `uv run pytest tests/unit/admin/entrypoints/test_disk_emergency_api.py -v`
- [ ] `uv run ruff check rock/admin/entrypoints/disk_emergency_api.py rock/admin/main.py`
- [ ] dev 灰度：`curl ... -d '{}'` 返回每个 task 的执行摘要
- [ ] 立刻重复 → `rate limited`
- [ ] `{"tasks":["image_pull"]}` 被白名单拦截

fixes #972