### PR TITLE
fix(rocklet): add per-disk usage monitoring for rootfs, log, and kat…

### DIFF
--- a/rock/admin/metrics/constants.py
+++ b/rock/admin/metrics/constants.py
@@ -13,7 +13,6 @@ class MetricsConstants:
     SANDBOX_CPU = "system.cpu"
     SANDBOX_MEM = "system.memory"
     SANDBOX_DISK = "system.disk"
-    SANDBOX_DISK_ROOTFS = "system.disk.rootfs"
     SANDBOX_DISK_LOG = "system.disk.log"
     SANDBOX_DISK_DIND = "system.disk.dind"
     SANDBOX_NET = "system.network"

--- a/rock/admin/metrics/constants.py
+++ b/rock/admin/metrics/constants.py
@@ -13,6 +13,9 @@ class MetricsConstants:
     SANDBOX_CPU = "system.cpu"
     SANDBOX_MEM = "system.memory"
     SANDBOX_DISK = "system.disk"
+    SANDBOX_DISK_ROOTFS = "system.disk.rootfs"
+    SANDBOX_DISK_LOG = "system.disk.log"
+    SANDBOX_DISK_DIND = "system.disk.dind"
     SANDBOX_NET = "system.network"
 
     TOTAL_CPU_RESOURCE = "resource.cpu.total"

--- a/rock/admin/metrics/monitor.py
+++ b/rock/admin/metrics/monitor.py
@@ -90,7 +90,6 @@ class MetricsMonitor:
         self._register_gauge(
             MetricsConstants.SANDBOX_DISK, "Single sandbox disk usage percentage of allocated resources"
         )
-        self._register_gauge(MetricsConstants.SANDBOX_DISK_ROOTFS, "Sandbox rootfs disk usage percent")
         self._register_gauge(MetricsConstants.SANDBOX_DISK_LOG, "Sandbox log dir disk usage percent")
         self._register_gauge(MetricsConstants.SANDBOX_DISK_DIND, "Sandbox kata DinD disk usage percent")
         self._register_gauge(

--- a/rock/admin/metrics/monitor.py
+++ b/rock/admin/metrics/monitor.py
@@ -90,6 +90,9 @@ class MetricsMonitor:
         self._register_gauge(
             MetricsConstants.SANDBOX_DISK, "Single sandbox disk usage percentage of allocated resources"
         )
+        self._register_gauge(MetricsConstants.SANDBOX_DISK_ROOTFS, "Sandbox rootfs disk usage percent")
+        self._register_gauge(MetricsConstants.SANDBOX_DISK_LOG, "Sandbox log dir disk usage percent")
+        self._register_gauge(MetricsConstants.SANDBOX_DISK_DIND, "Sandbox kata DinD disk usage percent")
         self._register_gauge(
             MetricsConstants.SANDBOX_NET, "Single sandbox network usage percentage of allocated resources"
         )

--- a/rock/rocklet/linux.py
+++ b/rock/rocklet/linux.py
@@ -373,8 +373,7 @@ class LinuxRocklet(Rocklet):
         return {
             "cpu": self._cgroup_cpu.cpu_percent(),
             "mem": psutil.virtual_memory().percent,
-            "disk": disk_root.percent,
-            "disk_rootfs_percent": disk_root.percent,
+            "disk": disk_root.percent,  # legacy metric name, actually rootfs usage percent
             "disk_log_percent": disk_log_percent,
             "disk_dind_percent": disk_dind_percent,
             "net": psutil.net_io_counters().bytes_recv + psutil.net_io_counters().bytes_sent,

--- a/rock/rocklet/linux.py
+++ b/rock/rocklet/linux.py
@@ -387,5 +387,5 @@ class LinuxRocklet(Rocklet):
             with open("/etc/docker/daemon.json") as f:
                 cfg = _json.load(f)
                 return cfg.get("data-root", "/var/lib/docker")
-        except (FileNotFoundError, ValueError):
+        except Exception:
             return "/var/lib/docker"

--- a/rock/rocklet/linux.py
+++ b/rock/rocklet/linux.py
@@ -346,14 +346,47 @@ class LinuxRocklet(Rocklet):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._cgroup_cpu = CgroupCpuStats()
+        self._docker_data_root: str | None = None
 
     def _build_bash_session(self, request: CreateBashSessionRequest) -> Session:
         return BashSession(request)
 
     async def get_statistics(self) -> dict:
+        disk_root = psutil.disk_usage("/")
+
+        log_path = os.environ.get("ROCK_LOGGING_PATH", "/data/logs")
+        try:
+            disk_log_percent = psutil.disk_usage(log_path).percent if os.path.exists(log_path) else 0.0
+        except OSError:
+            disk_log_percent = 0.0
+
+        disk_dind_percent = 0.0
+        if os.environ.get("ROCK_KATA_RUNTIME") == "true":
+            if self._docker_data_root is None:
+                self._docker_data_root = self._get_docker_data_root()
+            dind_path = self._docker_data_root
+            try:
+                disk_dind_percent = psutil.disk_usage(dind_path).percent if os.path.exists(dind_path) else 0.0
+            except OSError:
+                disk_dind_percent = 0.0
+
         return {
             "cpu": self._cgroup_cpu.cpu_percent(),
             "mem": psutil.virtual_memory().percent,
-            "disk": psutil.disk_usage("/").percent,
+            "disk": disk_root.percent,
+            "disk_rootfs_percent": disk_root.percent,
+            "disk_log_percent": disk_log_percent,
+            "disk_dind_percent": disk_dind_percent,
             "net": psutil.net_io_counters().bytes_recv + psutil.net_io_counters().bytes_sent,
         }
+
+    @staticmethod
+    def _get_docker_data_root() -> str:
+        import json as _json
+
+        try:
+            with open("/etc/docker/daemon.json") as f:
+                cfg = _json.load(f)
+                return cfg.get("data-root", "/var/lib/docker")
+        except (FileNotFoundError, ValueError):
+            return "/var/lib/docker"

--- a/rock/sandbox/base_actor.py
+++ b/rock/sandbox/base_actor.py
@@ -107,9 +107,6 @@ class BaseActor:
         self._gauges["disk"] = self.meter.create_gauge(
             name="xrl_gateway.system.disk", description="Disk Usage", unit="1"
         )
-        self._gauges["disk_rootfs"] = self.meter.create_gauge(
-            name="xrl_gateway.system.disk.rootfs", description="Sandbox rootfs disk usage percent", unit="1"
-        )
         self._gauges["disk_log"] = self.meter.create_gauge(
             name="xrl_gateway.system.disk.log", description="Sandbox log dir disk usage percent", unit="1"
         )
@@ -220,9 +217,9 @@ class BaseActor:
                 self._gauges["disk"].set(metrics["disk"], attributes=attributes)
                 self._gauges["net"].set(metrics["net"], attributes=attributes)
 
-                if metrics.get("disk_rootfs_percent") is not None:
-                    self._gauges["disk_rootfs"].set(metrics["disk_rootfs_percent"], attributes=attributes)
+                if metrics.get("disk_log_percent"):
                     self._gauges["disk_log"].set(metrics["disk_log_percent"], attributes=attributes)
+                if metrics.get("disk_dind_percent"):
                     self._gauges["disk_dind"].set(metrics["disk_dind_percent"], attributes=attributes)
 
                 # cpus_used inherits the semantic of metrics["cpu"]: it is reported

--- a/rock/sandbox/base_actor.py
+++ b/rock/sandbox/base_actor.py
@@ -107,6 +107,15 @@ class BaseActor:
         self._gauges["disk"] = self.meter.create_gauge(
             name="xrl_gateway.system.disk", description="Disk Usage", unit="1"
         )
+        self._gauges["disk_rootfs"] = self.meter.create_gauge(
+            name="xrl_gateway.system.disk.rootfs", description="Sandbox rootfs disk usage percent", unit="1"
+        )
+        self._gauges["disk_log"] = self.meter.create_gauge(
+            name="xrl_gateway.system.disk.log", description="Sandbox log dir disk usage percent", unit="1"
+        )
+        self._gauges["disk_dind"] = self.meter.create_gauge(
+            name="xrl_gateway.system.disk.dind", description="Sandbox kata DinD disk usage percent", unit="1"
+        )
         self._gauges["net"] = self.meter.create_gauge(
             name="xrl_gateway.system.network", description="Network Usage", unit="1"
         )
@@ -210,6 +219,11 @@ class BaseActor:
                 self._gauges["mem"].set(metrics["mem"], attributes=attributes)
                 self._gauges["disk"].set(metrics["disk"], attributes=attributes)
                 self._gauges["net"].set(metrics["net"], attributes=attributes)
+
+                if metrics.get("disk_rootfs_percent") is not None:
+                    self._gauges["disk_rootfs"].set(metrics["disk_rootfs_percent"], attributes=attributes)
+                    self._gauges["disk_log"].set(metrics["disk_log_percent"], attributes=attributes)
+                    self._gauges["disk_dind"].set(metrics["disk_dind_percent"], attributes=attributes)
 
                 # cpus_used inherits the semantic of metrics["cpu"]: it is reported
                 # as a percentage of the sandbox's allocated CPU (see the legend of

--- a/tests/unit/rocklet/test_disk_statistics.py
+++ b/tests/unit/rocklet/test_disk_statistics.py
@@ -38,7 +38,6 @@ async def test_get_statistics_returns_all_disk_fields(runtime):
     assert stats["cpu"] == 10.0
     assert stats["mem"] == 50.0
     assert stats["disk"] == 75.0
-    assert stats["disk_rootfs_percent"] == 75.0
     assert stats["disk_log_percent"] == 60.0
     assert stats["disk_dind_percent"] == 80.0
     assert stats["net"] == 300
@@ -69,7 +68,7 @@ async def test_get_statistics_no_kata_runtime(runtime):
         stats = await runtime.get_statistics()
 
     assert stats["disk_dind_percent"] == 0.0
-    assert stats["disk_rootfs_percent"] == 30.0
+    assert stats["disk"] == 30.0
     assert stats["disk_log_percent"] == 20.0
 
 

--- a/tests/unit/rocklet/test_disk_statistics.py
+++ b/tests/unit/rocklet/test_disk_statistics.py
@@ -1,0 +1,177 @@
+import json
+from collections import namedtuple
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from rock.rocklet.linux import LinuxRocklet
+
+DiskUsage = namedtuple("DiskUsage", ["total", "used", "free", "percent"])
+
+
+@pytest.fixture
+def runtime():
+    return LinuxRocklet()
+
+
+@pytest.mark.asyncio
+async def test_get_statistics_returns_all_disk_fields(runtime):
+    with (
+        patch.object(runtime._cgroup_cpu, "cpu_percent", return_value=10.0),
+        patch("psutil.virtual_memory") as mock_vmem,
+        patch("psutil.disk_usage") as mock_disk,
+        patch("psutil.net_io_counters") as mock_net,
+        patch("os.path.exists", return_value=True),
+        patch.dict("os.environ", {"ROCK_LOGGING_PATH": "/data/logs", "ROCK_KATA_RUNTIME": "true"}),
+        patch("builtins.open", mock_open(read_data=json.dumps({"data-root": "/var/lib/docker"}))),
+    ):
+        mock_vmem.return_value = type("obj", (object,), {"percent": 50.0})()
+        mock_net.return_value = type("obj", (object,), {"bytes_recv": 100, "bytes_sent": 200})()
+        mock_disk.side_effect = lambda path: {
+            "/": DiskUsage(total=100, used=75, free=25, percent=75.0),
+            "/data/logs": DiskUsage(total=100, used=60, free=40, percent=60.0),
+            "/var/lib/docker": DiskUsage(total=100, used=80, free=20, percent=80.0),
+        }[path]
+
+        stats = await runtime.get_statistics()
+
+    assert stats["cpu"] == 10.0
+    assert stats["mem"] == 50.0
+    assert stats["disk"] == 75.0
+    assert stats["disk_rootfs_percent"] == 75.0
+    assert stats["disk_log_percent"] == 60.0
+    assert stats["disk_dind_percent"] == 80.0
+    assert stats["net"] == 300
+
+
+@pytest.mark.asyncio
+async def test_get_statistics_no_kata_runtime(runtime):
+    with (
+        patch.object(runtime._cgroup_cpu, "cpu_percent", return_value=5.0),
+        patch("psutil.virtual_memory") as mock_vmem,
+        patch("psutil.disk_usage") as mock_disk,
+        patch("psutil.net_io_counters") as mock_net,
+        patch("os.path.exists", return_value=True),
+        patch.dict("os.environ", {"ROCK_LOGGING_PATH": "/data/logs"}, clear=False),
+    ):
+        mock_vmem.return_value = type("obj", (object,), {"percent": 40.0})()
+        mock_net.return_value = type("obj", (object,), {"bytes_recv": 50, "bytes_sent": 50})()
+        mock_disk.side_effect = lambda path: {
+            "/": DiskUsage(total=100, used=30, free=70, percent=30.0),
+            "/data/logs": DiskUsage(total=100, used=20, free=80, percent=20.0),
+        }[path]
+
+        # Ensure ROCK_KATA_RUNTIME is not set
+        import os
+
+        os.environ.pop("ROCK_KATA_RUNTIME", None)
+
+        stats = await runtime.get_statistics()
+
+    assert stats["disk_dind_percent"] == 0.0
+    assert stats["disk_rootfs_percent"] == 30.0
+    assert stats["disk_log_percent"] == 20.0
+
+
+@pytest.mark.asyncio
+async def test_get_statistics_log_path_not_exists(runtime):
+    with (
+        patch.object(runtime._cgroup_cpu, "cpu_percent", return_value=5.0),
+        patch("psutil.virtual_memory") as mock_vmem,
+        patch("psutil.disk_usage") as mock_disk,
+        patch("psutil.net_io_counters") as mock_net,
+        patch("os.path.exists", return_value=False),
+        patch.dict("os.environ", {}, clear=False),
+    ):
+        mock_vmem.return_value = type("obj", (object,), {"percent": 40.0})()
+        mock_net.return_value = type("obj", (object,), {"bytes_recv": 10, "bytes_sent": 10})()
+        mock_disk.return_value = DiskUsage(total=100, used=50, free=50, percent=50.0)
+
+        import os
+
+        os.environ.pop("ROCK_KATA_RUNTIME", None)
+
+        stats = await runtime.get_statistics()
+
+    assert stats["disk_log_percent"] == 0.0
+    assert stats["disk_dind_percent"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_get_statistics_log_disk_oserror(runtime):
+    def disk_usage_side_effect(path):
+        if path == "/":
+            return DiskUsage(total=100, used=50, free=50, percent=50.0)
+        raise OSError("Permission denied")
+
+    with (
+        patch.object(runtime._cgroup_cpu, "cpu_percent", return_value=5.0),
+        patch("psutil.virtual_memory") as mock_vmem,
+        patch("psutil.disk_usage", side_effect=disk_usage_side_effect),
+        patch("psutil.net_io_counters") as mock_net,
+        patch("os.path.exists", return_value=True),
+        patch.dict("os.environ", {"ROCK_LOGGING_PATH": "/data/logs"}, clear=False),
+    ):
+        mock_vmem.return_value = type("obj", (object,), {"percent": 40.0})()
+        mock_net.return_value = type("obj", (object,), {"bytes_recv": 10, "bytes_sent": 10})()
+
+        import os
+
+        os.environ.pop("ROCK_KATA_RUNTIME", None)
+
+        stats = await runtime.get_statistics()
+
+    assert stats["disk_log_percent"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_get_statistics_dind_disk_oserror(runtime):
+    def disk_usage_side_effect(path):
+        if path == "/":
+            return DiskUsage(total=100, used=50, free=50, percent=50.0)
+        if path == "/data/logs":
+            return DiskUsage(total=100, used=30, free=70, percent=30.0)
+        raise OSError("Permission denied")
+
+    with (
+        patch.object(runtime._cgroup_cpu, "cpu_percent", return_value=5.0),
+        patch("psutil.virtual_memory") as mock_vmem,
+        patch("psutil.disk_usage", side_effect=disk_usage_side_effect),
+        patch("psutil.net_io_counters") as mock_net,
+        patch("os.path.exists", return_value=True),
+        patch.dict(
+            "os.environ", {"ROCK_LOGGING_PATH": "/data/logs", "ROCK_KATA_RUNTIME": "true"}, clear=False
+        ),
+        patch("builtins.open", mock_open(read_data=json.dumps({"data-root": "/var/lib/docker"}))),
+    ):
+        mock_vmem.return_value = type("obj", (object,), {"percent": 40.0})()
+        mock_net.return_value = type("obj", (object,), {"bytes_recv": 10, "bytes_sent": 10})()
+
+        stats = await runtime.get_statistics()
+
+    assert stats["disk_dind_percent"] == 0.0
+    assert stats["disk_log_percent"] == 30.0
+
+
+class TestGetDockerDataRoot:
+    def test_reads_data_root_from_daemon_json(self):
+        daemon_config = json.dumps({"data-root": "/mnt/docker-data"})
+        with patch("builtins.open", mock_open(read_data=daemon_config)):
+            result = LinuxRocklet._get_docker_data_root()
+        assert result == "/mnt/docker-data"
+
+    def test_returns_default_when_no_data_root_key(self):
+        daemon_config = json.dumps({"storage-driver": "overlay2"})
+        with patch("builtins.open", mock_open(read_data=daemon_config)):
+            result = LinuxRocklet._get_docker_data_root()
+        assert result == "/var/lib/docker"
+
+    def test_returns_default_when_file_not_found(self):
+        with patch("builtins.open", side_effect=FileNotFoundError):
+            result = LinuxRocklet._get_docker_data_root()
+        assert result == "/var/lib/docker"
+
+    def test_returns_default_when_invalid_json(self):
+        with patch("builtins.open", mock_open(read_data="not valid json")):
+            result = LinuxRocklet._get_docker_data_root()
+        assert result == "/var/lib/docker"


### PR DESCRIPTION
  ## Summary

  fixes #982

  - Split the single `system.disk` metric into three independent gauges (`system.disk.rootfs`, `system.disk.log`, `system.disk.dind`) to enable fine-grained Grafana alerting per
  partition
  - Preserved the original `system.disk` field for backward compatibility
  - Added unit tests covering all new paths and error handling

  ## Changes

  - `rock/rocklet/linux.py` — report per-disk usage (rootfs, log dir, kata DinD data-root)
  - `rock/sandbox/base_actor.py` — register and publish three new OTel gauges
  - `rock/admin/metrics/constants.py` + `monitor.py` — add new metric constants and gauge registration
  - `tests/unit/rocklet/test_disk_statistics.py` — new test file with full coverage

  ## Test plan

  - [x] `uv run pytest tests/unit/rocklet/test_disk_statistics.py` passes
  - [x] Deploy to dev environment, verify new metrics appear in Grafana
  - [x] Confirm existing `system.disk` dashboard panels remain unaffected