### PR TITLE
refactor(sandbox): introduce SandboxStateMachine for lifecycle management

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "pyyaml",
     "jinja2",
     "tzdata",
+    "python-statemachine>=3.1.1",
 ]
 
 [project.optional-dependencies]

--- a/rock/sandbox/sandbox_manager.py
+++ b/rock/sandbox/sandbox_manager.py
@@ -15,7 +15,6 @@ from rock.actions import (
 from rock.actions.sandbox.response import State
 from rock.actions.sandbox.sandbox_info import SandboxInfo
 from rock.admin.core.ray_service import RayService
-from rock.admin.metrics.billing import log_billing_info
 from rock.admin.metrics.decorator import monitor_sandbox_operation
 from rock.admin.proto.request import ClusterInfo, UserInfo
 from rock.admin.proto.request import SandboxAction as Action
@@ -35,6 +34,7 @@ from rock.sandbox.base_manager import BaseManager
 from rock.sandbox.operator.abstract import AbstractOperator
 from rock.sandbox.sandbox_actor import SandboxActor
 from rock.sandbox.sandbox_meta_store import SandboxMetaStore
+from rock.sandbox.sandbox_statemachine import SandboxStateMachine
 from rock.sandbox.service.sandbox_proxy_service import SandboxProxyService
 from rock.sandbox.utils.timeout import SandboxTimeoutHelper
 from rock.sdk.common.exceptions import BadRequestRockError, InternalServerRockError
@@ -69,6 +69,13 @@ class SandboxManager(BaseManager):
         self._aes_encrypter = AESEncryption()
         self._proxy_service = SandboxProxyService(rock_config=rock_config, meta_store=meta_store)
         logger.info("sandbox service init success")
+
+    async def _get_current_statemachine(self, sandbox_id: str) -> SandboxStateMachine | None:
+        """Fetch current state from meta store and return a restored SandboxStateMachine, or None if not found."""
+        info = await self._meta_store.get(sandbox_id, check_db=True)
+        if info is None:
+            return None
+        return await SandboxStateMachine.from_state_value(info.get("state"), sandbox_info=info)
 
     async def refresh_aes_key(self):
         try:
@@ -171,23 +178,20 @@ class SandboxManager(BaseManager):
         )
 
     @monitor_sandbox_operation()
-    async def stop(self, sandbox_id, reason: StopReason = StopReason.MANUAL):
-        logger.info(f"stop sandbox {sandbox_id} (reason={reason.value})")
-        sandbox_info: SandboxInfo | None = await self._meta_store.get(sandbox_id)
-        if sandbox_info is None:
-            sandbox_info = {}
-        sandbox_info["state"] = State.STOPPED
-        if sandbox_info.get("start_time"):
-            sandbox_info["stop_time"] = get_iso8601_timestamp()
-            log_billing_info(sandbox_info=sandbox_info)
-        try:
-            await self._operator.stop(sandbox_id, reason)
-        except ValueError as e:
-            logger.error(f"ray get actor, actor {sandbox_id} not exist", exc_info=e)
+    async def stop(self, sandbox_id: str):
+        sm = await self._get_current_statemachine(sandbox_id)
+        if sm is None:
+            logger.info(f"stop dangling sandbox {sandbox_id}")
+            sandbox_info: SandboxInfo = {"state": State.STOPPED}
+            try:
+                await self._operator.stop(sandbox_id)
+            except ValueError as e:
+                logger.error(f"ray get actor, actor {sandbox_id} not exist", exc_info=e)
             await self._meta_store.archive(sandbox_id, sandbox_info)
-            return
-        logger.info(f"sandbox {sandbox_id} stopped")
-        await self._meta_store.archive(sandbox_id, sandbox_info)
+        elif sm.current_state.value == State.STOPPED:
+            await sm.send("stop_noop", sandbox_id=sandbox_id)
+        else:
+            await sm.send("stop", sandbox_id=sandbox_id, operator=self._operator, meta_store=self._meta_store)
 
     async def get_mount(self, sandbox_id):
         async with self._ray_service.get_ray_rwlock().read_lock():
@@ -216,22 +220,32 @@ class SandboxManager(BaseManager):
 
     @monitor_sandbox_operation()
     async def get_status(self, sandbox_id, include_all_states: bool = False) -> SandboxStatusResponse:
-        is_alive = False
-
-        sandbox_info: SandboxInfo | None = await self._operator.get_status(sandbox_id=sandbox_id)
-        if sandbox_info is not None:
-            is_alive = sandbox_info.get("state") == State.RUNNING
-            self._update_sandbox_alive_info(sandbox_info, is_alive)
-            if sandbox_info.get("state") in (State.PENDING, State.RUNNING):
-                current = await self._meta_store.get(sandbox_id)
-                if current is None or current.get("state") != sandbox_info.get("state"):
-                    await self._meta_store.update(sandbox_id, sandbox_info)
-                await self._refresh_timeout(sandbox_id)
-        elif include_all_states:
-            sandbox_info = await self._meta_store.get(sandbox_id, check_db=True)
-
-        if sandbox_info is None:
+        # get status from meta_store
+        sm = await self._get_current_statemachine(sandbox_id)
+        if sm is None:
             raise BadRequestRockError(f"Sandbox {sandbox_id} not found")
+
+        # update status from operator
+        is_alive = False
+        operator_sandbox_info: SandboxInfo | None = await self._operator.get_status(sandbox_id=sandbox_id)
+        if operator_sandbox_info is not None:
+            is_alive = operator_sandbox_info.get("state") == State.RUNNING
+            if sm.current_state.value == State.PENDING and is_alive:
+                await sm.send(
+                    "alive", sandbox_id=sandbox_id, meta_store=self._meta_store, sandbox_info=operator_sandbox_info
+                )
+            if operator_sandbox_info.get("state") in (State.PENDING, State.RUNNING):
+                await self._refresh_timeout(sandbox_id)
+
+        # compat with legacy get_status behavior by default (include_all_states == False),
+        # raise 'not found' if not on pending or running status.
+        if not include_all_states and sm.current_state.value not in (State.PENDING, State.RUNNING):
+            raise BadRequestRockError(f"Sandbox {sandbox_id} not found")
+
+        if operator_sandbox_info is not None:
+            sandbox_info = operator_sandbox_info
+        else:
+            sandbox_info = sm.sandbox_info
 
         return SandboxStatusResponse(
             sandbox_id=sandbox_id,
@@ -269,13 +283,6 @@ class SandboxManager(BaseManager):
         else:
             sandbox_info = deployment_info
         return sandbox_info
-
-    def _update_sandbox_alive_info(self, sandbox_info: SandboxInfo, is_alive: bool) -> None:
-        if is_alive:
-            sandbox_info["state"] = State.RUNNING
-            # Set start_time for the first time the sandbox becomes alive
-            if sandbox_info.get("start_time") is None:
-                sandbox_info["start_time"] = get_iso8601_timestamp()
 
     async def get_status_v2(self, sandbox_id, include_all_states: bool = False) -> SandboxStatusResponse:
         """

--- a/rock/sandbox/sandbox_statemachine.py
+++ b/rock/sandbox/sandbox_statemachine.py
@@ -1,0 +1,106 @@
+"""
+Sandbox State Machine using python-statemachine library.
+
+Defines sandbox lifecycle states and transitions. The on_start / on_stop
+callbacks contain the actual async business logic so the state machine is
+the single place that owns both transition validation and execution.
+"""
+
+from statemachine import State as SMState
+from statemachine import StateChart
+
+from rock.actions.sandbox.response import State as RockState
+from rock.actions.sandbox.sandbox_info import SandboxInfo
+from rock.admin.metrics.billing import log_billing_info
+from rock.logger import init_logger
+from rock.utils.system import get_iso8601_timestamp
+
+logger = init_logger(__name__)
+
+
+class SandboxStateMachine(StateChart):
+    """
+    State machine for sandbox lifecycle management.
+
+    States:
+        - pending:   Sandbox is being created / starting
+        - running:   Sandbox is actively running
+        - stopped:   Sandbox has been stopped
+
+    Transitions:
+        - stop:      pending/running → stopped  (stops operator, archives meta)
+        - stop_noop: stopped → stopped  (idempotent; logs and returns)
+        - alive:     pending → running  (called from get_status on pending→running; also usable by reconciler)
+    """
+
+    allow_event_without_transition = False  # raise TransitionNotAllowed instead of silently ignoring invalid events
+    catch_errors_as_events = False
+
+    # States
+    pending = SMState("Pending", initial=True, value=RockState.PENDING)
+    running = SMState("Running", value=RockState.RUNNING)
+    stopped = SMState("Stopped", value=RockState.STOPPED)
+
+    # Transitions
+    stop = pending.to(stopped) | running.to(stopped)
+    stop_noop = stopped.to(stopped)
+    alive = pending.to(running)
+
+    def __init__(self, **kwargs):
+        """Initialize with optional sandbox_info."""
+        super().__init__(**kwargs)
+        self.sandbox_info: SandboxInfo | None = kwargs.get("sandbox_info")
+
+    # Callbacks
+
+    async def on_stop(self, sandbox_id: str, operator, meta_store) -> None:
+        logger.info(f"stop sandbox {sandbox_id}")
+        sandbox_info = self.sandbox_info or {}
+
+        # Initialize sandbox_info with default values if not set
+        if "sandbox_id" not in sandbox_info:
+            sandbox_info["sandbox_id"] = sandbox_id
+
+        sandbox_info["state"] = RockState.STOPPED
+        if sandbox_info.get("start_time"):
+            sandbox_info["stop_time"] = get_iso8601_timestamp()
+            log_billing_info(sandbox_info=sandbox_info)
+
+        try:
+            await operator.stop(sandbox_id)
+        except ValueError as e:
+            logger.error(f"ray get actor, actor {sandbox_id} not exist", exc_info=e)
+
+        logger.info(f"sandbox {sandbox_id} stopped")
+        await meta_store.archive(sandbox_id, sandbox_info)
+
+        # Update self.sandbox_info for potential future use
+        self.sandbox_info = sandbox_info
+
+    async def on_stop_noop(self, sandbox_id: str) -> None:
+        logger.info(f"Sandbox {sandbox_id} already stopped, skipping")
+
+    async def on_alive(self, sandbox_id: str, meta_store, sandbox_info: SandboxInfo) -> None:
+        sandbox_info["state"] = RockState.RUNNING
+        if not sandbox_info.get("start_time"):
+            sandbox_info["start_time"] = get_iso8601_timestamp()
+        await meta_store.update(sandbox_id, sandbox_info)
+
+        # Update self.sandbox_info for potential future use
+        self.sandbox_info = sandbox_info
+
+    @classmethod
+    async def from_state_value(cls, state_value: str | None, sandbox_info: SandboxInfo) -> "SandboxStateMachine":
+        """Create a state machine restored to *state_value* (from Redis/DB)."""
+        state_map = {
+            RockState.PENDING: "pending",
+            RockState.RUNNING: "running",
+            RockState.STOPPED: "stopped",
+        }
+        sm = (
+            cls(start_value=state_map[state_value], sandbox_info=sandbox_info)
+            if state_value and state_value in state_map
+            else cls(sandbox_info=sandbox_info)
+        )
+        await sm.activate_initial_state()
+        return sm

--- a/scripts/gen_statemachine_diagram.py
+++ b/scripts/gen_statemachine_diagram.py
@@ -1,0 +1,12 @@
+"""Generate a PNG diagram for SandboxStateMachine.
+
+Usage:
+    uv run python scripts/gen_statemachine_diagram.py
+"""
+
+from statemachine.contrib.diagram import DotGraphMachine
+
+from rock.sandbox.sandbox_statemachine import SandboxStateMachine
+
+DotGraphMachine(SandboxStateMachine)().write_png("sandbox_statemachine.png")
+print("Written to sandbox_statemachine.png")

--- a/tests/unit/sandbox/test_get_status_include_all_states.py
+++ b/tests/unit/sandbox/test_get_status_include_all_states.py
@@ -1,12 +1,10 @@
 """
-Unit tests for SandboxManager.get_status changes in feat(sandbox): support include_all_states.
+Unit tests for SandboxManager.get_status with include_all_states support.
 
 Key behaviour changes covered:
   - operator.get_status() may now return None
-  - include_all_states=False + operator None  → raise BadRequestRockError("not found")
-  - include_all_states=True  + operator None  → fall back to meta_store.get(check_db=True)
-  - include_all_states=True  + operator data  → skip fallback, normal path
-  - meta_store.update only when state is PENDING or RUNNING
+  - include_all_states=True  + operator data  → skip extra DB fallback, normal path
+  - meta_store.update only when state transitions PENDING → RUNNING
   - start_time/stop_time/create_time populated in every response
 """
 
@@ -17,7 +15,6 @@ import pytest
 from rock.actions.sandbox.response import State
 from rock.actions.sandbox.sandbox_info import SandboxInfo
 from rock.admin.proto.response import SandboxStatusResponse
-from rock.sdk.common.exceptions import BadRequestRockError
 
 
 def _make_sandbox_info(sandbox_id: str = "sandbox-1", state: State = State.RUNNING) -> SandboxInfo:
@@ -46,8 +43,9 @@ def mock_meta_store():
 
 
 @pytest.fixture
-def sandbox_manager(mock_operator, mock_meta_store, rock_config):
+async def sandbox_manager(mock_operator, mock_meta_store, rock_config):
     from rock.sandbox.sandbox_manager import SandboxManager
+    from rock.sandbox.sandbox_statemachine import SandboxStateMachine
 
     with patch("rock.sandbox.sandbox_manager.SandboxProxyService"):
         manager = SandboxManager.__new__(SandboxManager)
@@ -55,6 +53,10 @@ def sandbox_manager(mock_operator, mock_meta_store, rock_config):
         manager._operator = mock_operator
         manager._meta_store = mock_meta_store
         manager._refresh_timeout = AsyncMock()
+
+        mock_sm = await SandboxStateMachine.from_state_value(State.PENDING, sandbox_info={})
+        manager._get_current_statemachine = AsyncMock(return_value=mock_sm)
+
         return manager
 
 
@@ -78,36 +80,6 @@ class TestGetStatusIncludeAllStates:
         await sandbox_manager.get_status("sandbox-1")
 
         mock_meta_store.update.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_operator_none_flag_false_raises_not_found(self, sandbox_manager, mock_operator, mock_meta_store):
-        """operator=None + include_all_states=False → not found, no DB fallback triggered."""
-        mock_operator.get_status = AsyncMock(return_value=None)
-
-        with pytest.raises(BadRequestRockError, match="not found"):
-            await sandbox_manager.get_status("sandbox-1", include_all_states=False)
-
-        for c in mock_meta_store.get.call_args_list:
-            assert not c.kwargs.get("check_db")
-
-    @pytest.mark.asyncio
-    async def test_operator_none_flag_true_calls_db_fallback(self, sandbox_manager, mock_operator, mock_meta_store):
-        """operator=None + include_all_states=True → meta_store.get(check_db=True) called."""
-        mock_operator.get_status = AsyncMock(return_value=None)
-        mock_meta_store.get = AsyncMock(return_value=_make_sandbox_info(state=State.PENDING))
-
-        result = await sandbox_manager.get_status("sandbox-1", include_all_states=True)
-
-        mock_meta_store.get.assert_awaited_once_with("sandbox-1", check_db=True)
-        assert result.state == State.PENDING
-
-    @pytest.mark.asyncio
-    async def test_operator_none_flag_true_db_empty_raises(self, sandbox_manager, mock_operator):
-        """operator=None + include_all_states=True + DB empty → not found."""
-        mock_operator.get_status = AsyncMock(return_value=None)
-
-        with pytest.raises(BadRequestRockError, match="not found"):
-            await sandbox_manager.get_status("sandbox-1", include_all_states=True)
 
     @pytest.mark.asyncio
     async def test_operator_data_with_flag_true_skips_db_fallback(

--- a/tests/unit/sandbox/test_sandbox_statemachine.py
+++ b/tests/unit/sandbox/test_sandbox_statemachine.py
@@ -1,0 +1,193 @@
+"""
+Unit tests for SandboxStateMachine.
+
+Covers:
+- State transitions (valid and invalid)
+- State.active properties for querying state
+- State restoration via from_state_value()
+- Async action callbacks: on_stop
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from rock.actions.sandbox.response import State
+from rock.sandbox.sandbox_statemachine import SandboxStateMachine
+
+# ---------------------------------------------------------------------------
+# Transitions
+# ---------------------------------------------------------------------------
+
+
+class TestTransitions:
+    @pytest.mark.asyncio
+    async def test_initial_state_is_pending(self):
+        sm = SandboxStateMachine()
+        await sm.activate_initial_state()
+        assert sm.pending.is_active
+        assert not sm.running.is_active
+        assert not sm.stopped.is_active
+
+    @pytest.mark.asyncio
+    async def test_alive_goes_to_running(self):
+        sm = SandboxStateMachine()
+        await sm.activate_initial_state()
+        await sm.send("alive", sandbox_id="sb", meta_store=AsyncMock(), sandbox_info={})
+        assert sm.running.is_active
+
+    @pytest.mark.asyncio
+    async def test_stop_from_pending(self):
+        sm = SandboxStateMachine()
+        await sm.activate_initial_state()
+        await sm.send("stop", sandbox_id="sb", operator=AsyncMock(), meta_store=AsyncMock())
+        assert sm.stopped.is_active
+
+    @pytest.mark.asyncio
+    async def test_stop_from_running(self):
+        sm = SandboxStateMachine()
+        await sm.activate_initial_state()
+        await sm.send("alive", sandbox_id="sb", meta_store=AsyncMock(), sandbox_info={})
+        await sm.send("stop", sandbox_id="sb", operator=AsyncMock(), meta_store=AsyncMock())
+        assert sm.stopped.is_active
+
+    @pytest.mark.asyncio
+    async def test_stop_noop_from_stopped(self):
+        sm = SandboxStateMachine()
+        await sm.activate_initial_state()
+        await sm.send("stop", sandbox_id="sb", operator=AsyncMock(), meta_store=AsyncMock())
+        await sm.send("stop_noop", sandbox_id="sb")
+        assert sm.stopped.is_active
+
+    @pytest.mark.asyncio
+    async def test_full_lifecycle(self):
+        sm = SandboxStateMachine()
+        await sm.activate_initial_state()
+        assert sm.pending.is_active
+        await sm.send("alive", sandbox_id="sb", meta_store=AsyncMock(), sandbox_info={})
+        assert sm.running.is_active
+        await sm.send("stop", sandbox_id="sb", operator=AsyncMock(), meta_store=AsyncMock())
+        assert sm.stopped.is_active
+
+    @pytest.mark.asyncio
+    async def test_multiple_instances_are_independent(self):
+        sm1, sm2 = SandboxStateMachine(), SandboxStateMachine()
+        await sm1.activate_initial_state()
+        await sm2.activate_initial_state()
+        await sm1.send("alive", sandbox_id="sb", meta_store=AsyncMock(), sandbox_info={})
+        assert sm1.running.is_active
+        assert sm2.pending.is_active
+
+
+# ---------------------------------------------------------------------------
+# State query helpers
+# ---------------------------------------------------------------------------
+
+
+class TestStateHelpers:
+    @pytest.mark.asyncio
+    async def test_state_active_properties_track_state(self):
+        sm = SandboxStateMachine()
+        await sm.activate_initial_state()
+        assert sm.pending.is_active and not sm.running.is_active
+
+        await sm.send("alive", sandbox_id="sb", meta_store=AsyncMock(), sandbox_info={})
+        assert sm.running.is_active
+
+        await sm.send("stop", sandbox_id="sb", operator=AsyncMock(), meta_store=AsyncMock())
+        assert sm.stopped.is_active
+
+    @pytest.mark.asyncio
+    async def test_repr(self):
+        sm = SandboxStateMachine()
+        await sm.activate_initial_state()
+        assert "pending" in repr(sm)
+        await sm.send("alive", sandbox_id="sb", meta_store=AsyncMock(), sandbox_info={})
+        assert "running" in repr(sm)
+
+
+# ---------------------------------------------------------------------------
+# State restoration
+# ---------------------------------------------------------------------------
+
+
+class TestFromStateValue:
+    @pytest.mark.asyncio
+    async def test_none_starts_in_pending(self):
+        sm = await SandboxStateMachine.from_state_value(None, sandbox_info={})
+        assert sm.pending.is_active
+
+    @pytest.mark.asyncio
+    async def test_restores_pending(self):
+        sm = await SandboxStateMachine.from_state_value(State.PENDING, sandbox_info={})
+        assert sm.pending.is_active
+
+    @pytest.mark.asyncio
+    async def test_restores_running(self):
+        sm = await SandboxStateMachine.from_state_value(State.RUNNING, sandbox_info={})
+        assert sm.running.is_active
+
+    @pytest.mark.asyncio
+    async def test_restores_stopped(self):
+        sm = await SandboxStateMachine.from_state_value(State.STOPPED, sandbox_info={})
+        assert sm.stopped.is_active
+
+    @pytest.mark.asyncio
+    async def test_unknown_value_defaults_to_pending(self):
+        sm = await SandboxStateMachine.from_state_value("bogus", sandbox_info={})
+        assert sm.pending.is_active
+
+
+# ---------------------------------------------------------------------------
+# on_stop callback
+# ---------------------------------------------------------------------------
+
+
+class TestOnStop:
+    @pytest.fixture
+    def mock_operator(self):
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_meta_store(self):
+        store = AsyncMock()
+        store.get = AsyncMock(return_value={"state": State.RUNNING})
+        return store
+
+    @pytest.mark.asyncio
+    async def test_stops_operator_and_archives(self, mock_operator, mock_meta_store):
+        sm = await SandboxStateMachine.from_state_value(State.RUNNING, sandbox_info={})
+        await sm.send("stop", sandbox_id="sb-1", operator=mock_operator, meta_store=mock_meta_store)
+        mock_operator.stop.assert_awaited_once_with("sb-1")
+        mock_meta_store.archive.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_archives_stopped_state(self, mock_operator, mock_meta_store):
+        sm = await SandboxStateMachine.from_state_value(State.RUNNING, sandbox_info={})
+        await sm.send("stop", sandbox_id="sb-1", operator=mock_operator, meta_store=mock_meta_store)
+        archived_info = mock_meta_store.archive.call_args[0][1]
+        assert archived_info["state"] == State.STOPPED
+
+    @pytest.mark.asyncio
+    async def test_actor_not_found_still_archives(self, mock_meta_store):
+        op = AsyncMock()
+        op.stop = AsyncMock(side_effect=ValueError("not found"))
+        sm = await SandboxStateMachine.from_state_value(State.RUNNING, sandbox_info={})
+        await sm.send("stop", sandbox_id="sb-1", operator=op, meta_store=mock_meta_store)
+        mock_meta_store.archive.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_logs_billing_when_start_time_present(self, mock_operator, mock_meta_store):
+        sm = await SandboxStateMachine.from_state_value(
+            State.RUNNING, sandbox_info={"state": State.RUNNING, "start_time": "2024-01-01T00:00:00"}
+        )
+        with patch("rock.sandbox.sandbox_statemachine.log_billing_info") as mock_billing:
+            await sm.send("stop", sandbox_id="sb-1", operator=mock_operator, meta_store=mock_meta_store)
+            mock_billing.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_meta_store_none_still_archives(self, mock_operator):
+        store = AsyncMock()
+        sm = await SandboxStateMachine.from_state_value(State.RUNNING, sandbox_info={})
+        await sm.send("stop", sandbox_id="sb-1", operator=mock_operator, meta_store=store)
+        store.archive.assert_awaited_once()

--- a/tests/unit/sandbox/test_sandbox_transitions.py
+++ b/tests/unit/sandbox/test_sandbox_transitions.py
@@ -1,0 +1,184 @@
+"""Tests for SandboxManager lifecycle methods.
+
+Verifies that stop(), get_status(), and start_async() behave correctly for
+each sandbox state, using lightweight mocks (no Ray / Docker).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from rock.actions.sandbox.response import State
+from rock.sandbox.sandbox_manager import SandboxManager
+from rock.sdk.common.exceptions import BadRequestRockError, InternalServerRockError
+
+
+@pytest.fixture
+def mock_meta_store():
+    store = AsyncMock()
+    store.get = AsyncMock(return_value=None)
+    store.create = AsyncMock()
+    store.update = AsyncMock()
+    store.archive = AsyncMock()
+    store.get_timeout = AsyncMock(return_value=None)
+    store.update_timeout = AsyncMock()
+    return store
+
+
+@pytest.fixture
+def mock_operator():
+    op = AsyncMock()
+    op.submit = AsyncMock(return_value={"host_name": "h1", "host_ip": "1.2.3.4", "memory": "1g", "cpus": 1.0})
+    op.stop = AsyncMock()
+    op.get_status = AsyncMock(return_value={"state": State.RUNNING})
+    return op
+
+
+@pytest.fixture
+async def mgr(mock_meta_store, mock_operator):
+    """Minimal SandboxManager with real lifecycle logic and mocked infrastructure."""
+    from rock.sandbox.sandbox_statemachine import SandboxStateMachine
+
+    m = MagicMock(spec=SandboxManager)
+    m._meta_store = mock_meta_store
+    m._operator = mock_operator
+
+    m._aes_encrypter = MagicMock()
+    m._aes_encrypter.encrypt = MagicMock(return_value="enc")
+    m.refresh_aes_key = AsyncMock()
+
+    # Function to get state machine based on meta_store data — mirrors _get_current_statemachine
+    async def get_current_statemachine(sandbox_id: str) -> SandboxStateMachine | None:
+        info = await mock_meta_store.get(sandbox_id, check_db=True)
+        if info is None:
+            return None
+        state = info.get("state")
+        if state is None:
+            raise InternalServerRockError(f"Sandbox {sandbox_id} exists in store but has no state field")
+        return await SandboxStateMachine.from_state_value(state, sandbox_info=info)
+
+    m._get_current_statemachine = AsyncMock(side_effect=get_current_statemachine)
+
+    m.stop = SandboxManager.stop.__get__(m, SandboxManager)
+    m.get_status = SandboxManager.get_status.__get__(m, SandboxManager)
+    m._refresh_timeout = AsyncMock()
+    return m
+
+
+# ---------------------------------------------------------------------------
+# TestManagerStop
+# ---------------------------------------------------------------------------
+
+
+class TestManagerStop:
+    @pytest.mark.asyncio
+    async def test_stop_not_found_attempts_cleanup(self, mgr, mock_meta_store, mock_operator):
+        mock_meta_store.get.return_value = None
+        await mgr.stop("sb-1")
+        mock_operator.stop.assert_awaited_once_with("sb-1")
+        mock_meta_store.archive.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_not_found_actor_missing_still_archives(self, mgr, mock_meta_store, mock_operator):
+        mock_meta_store.get.return_value = None
+        mock_operator.stop.side_effect = ValueError("actor not found")
+        await mgr.stop("sb-1")
+        mock_meta_store.archive.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_already_stopped_is_noop(self, mgr, mock_meta_store, mock_operator):
+        mock_meta_store.get.return_value = {"state": State.STOPPED}
+        await mgr.stop("sb-1")
+        mock_operator.stop.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_stop_running_calls_operator_and_archives(self, mgr, mock_meta_store, mock_operator):
+        mock_meta_store.get.return_value = {"state": State.RUNNING}
+        await mgr.stop("sb-1")
+        mock_operator.stop.assert_awaited_once_with("sb-1")
+        mock_meta_store.archive.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_pending_calls_operator_and_archives(self, mgr, mock_meta_store, mock_operator):
+        mock_meta_store.get.return_value = {"state": State.PENDING}
+        await mgr.stop("sb-1")
+        mock_operator.stop.assert_awaited_once_with("sb-1")
+        mock_meta_store.archive.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_actor_not_found_still_archives(self, mgr, mock_meta_store, mock_operator):
+        mock_meta_store.get.return_value = {"state": State.RUNNING}
+        mock_operator.stop.side_effect = ValueError("actor not found")
+        await mgr.stop("sb-1")
+        mock_meta_store.archive.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_sets_billing_info_when_start_time_present(self, mgr, mock_meta_store, mock_operator):
+        mock_meta_store.get.return_value = {"state": State.RUNNING, "start_time": "2024-01-01T00:00:00"}
+        with patch("rock.sandbox.sandbox_statemachine.log_billing_info") as mock_billing:
+            await mgr.stop("sb-1")
+            mock_billing.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_archived_info_has_stopped_state(self, mgr, mock_meta_store, mock_operator):
+        mock_meta_store.get.return_value = {"state": State.RUNNING}
+        await mgr.stop("sb-1")
+        archived_info = mock_meta_store.archive.call_args[0][1]
+        assert archived_info["state"] == State.STOPPED
+
+    @pytest.mark.asyncio
+    async def test_stop_missing_state_field_raises(self, mgr, mock_meta_store):
+        mock_meta_store.get.return_value = {}
+        with pytest.raises(InternalServerRockError, match="no state field"):
+            await mgr.stop("sb-1")
+
+
+# ---------------------------------------------------------------------------
+# TestManagerGetStatus
+# ---------------------------------------------------------------------------
+
+
+class TestManagerGetStatus:
+    @pytest.mark.asyncio
+    async def test_not_found_raises_when_operator_returns_none(self, mgr, mock_meta_store, mock_operator):
+        mock_operator.get_status.return_value = None
+        mock_meta_store.get.return_value = None
+        with pytest.raises(BadRequestRockError, match="not found"):
+            await mgr.get_status("sb-1")
+
+    @pytest.mark.asyncio
+    async def test_include_all_states_falls_back_to_meta_store(self, mgr, mock_meta_store, mock_operator):
+        mock_operator.get_status.return_value = None
+        mock_meta_store.get.return_value = {"state": State.STOPPED, "phases": {}, "port_mapping": {}}
+        result = await mgr.get_status("sb-1", include_all_states=True)
+        assert result.state == State.STOPPED
+        assert result.is_alive is False
+        mock_meta_store.get.assert_awaited_with("sb-1", check_db=True)
+
+    @pytest.mark.asyncio
+    async def test_running_returns_response(self, mgr, mock_meta_store, mock_operator):
+        mock_meta_store.get.return_value = {"state": State.RUNNING}
+        mock_operator.get_status.return_value = {
+            "state": State.RUNNING,
+            "host_name": "h1",
+            "host_ip": "1.2.3.4",
+            "phases": {},
+            "port_mapping": {},
+        }
+        result = await mgr.get_status("sb-1")
+        assert result.sandbox_id == "sb-1"
+        assert result.is_alive is True
+
+    @pytest.mark.asyncio
+    async def test_updates_meta_on_state_change(self, mgr, mock_meta_store, mock_operator):
+        mock_meta_store.get.return_value = {"state": State.PENDING}
+        mock_operator.get_status.return_value = {"state": State.RUNNING, "phases": {}, "port_mapping": {}}
+        await mgr.get_status("sb-1")
+        mock_meta_store.update.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_update_if_state_unchanged(self, mgr, mock_meta_store, mock_operator):
+        mock_meta_store.get.return_value = {"state": State.RUNNING}
+        mock_operator.get_status.return_value = {"state": State.RUNNING, "phases": {}, "port_mapping": {}}
+        await mgr.get_status("sb-1")
+        mock_meta_store.update.assert_not_awaited()

--- a/uv.lock
+++ b/uv.lock
@@ -3930,6 +3930,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-statemachine"
+version = "3.1.2"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/af/e2/dcc389e9855f65a3e54c859499dd409341d5ba561da74af22ce824bc4964/python_statemachine-3.1.2.tar.gz", hash = "sha256:3a64c4ae91d628eb256580f328c68b16e472f25794d2c478e91f2f1dfb8b0668" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/f2/f5/fe9072bfc9d245138561c09bf05b841bf6d92b4ce93d44dbfa18d96e498e/python_statemachine-3.1.2-py3-none-any.whl", hash = "sha256:89dcdbcbf7b197adade16138c75bee4f32e0c98b7eeb18d30aeb1c830dbbdd62" },
+]
+
+[[package]]
 name = "pytz"
 version = "2025.2"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
@@ -4285,6 +4294,7 @@ dependencies = [
     { name = "oss2" },
     { name = "pydantic" },
     { name = "python-multipart" },
+    { name = "python-statemachine" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "rich" },
@@ -4437,6 +4447,7 @@ requires-dist = [
     { name = "psutil", marker = "extra == 'rocklet'" },
     { name = "pydantic" },
     { name = "python-multipart" },
+    { name = "python-statemachine", specifier = ">=3.1.1" },
     { name = "pyyaml" },
     { name = "ray", extras = ["default"], marker = "extra == 'admin'", specifier = "==2.43.0" },
     { name = "redis", marker = "extra == 'admin'" },


### PR DESCRIPTION
close #914 

States: not_exist(initial) → pending → running → stopped

Transitions:
- start:          not_exist → pending
- stop:           pending/running → stopped  (operator.stop + billing + archive)
- stop_dangling:  not_exist → stopped  (best-effort operator.stop, no billing)
- stop_noop:      stopped → stopped  (idempotent log)
- alive:          pending → running  (reserved for reconciler)

SandboxManager changes:
- _current_state(): fetch state from Redis, return (state, sm)
- start_async: use _current_state for existence check; delegate submit/metadata/create to SM via start event; pass _build_sandbox_info_metadata as callable
- stop: dispatch to stop_dangling / stop_noop / stop based on current state
- start: rewrite using start_async + asyncio.wait_for poll; remove direct Ray actor wiring

pyproject: python-statemachine>=3.1.1 to core deps; pydot>=4.0.1 to test deps