### PR TITLE
fix(sdk): drop wget -c so OSS upload overwrites existing target_path

### DIFF
--- a/rock/sdk/sandbox/oss_client.py
+++ b/rock/sdk/sandbox/oss_client.py
@@ -210,8 +210,18 @@ class OssClient:
                 mode=RunMode.NORMAL,
             )
 
-            # wget the signed URL
-            download_cmd = f"wget -c -O {target_path} '{url}'"
+            # wget the signed URL.
+            # Note: NO `-c` (continue/resume). With `-c`, wget skips download
+            # entirely if the local file already exists with size matching the
+            # remote object — but the OSS object name is derived from
+            # (sandbox_id|local_path|sandbox_path), not file content, so a
+            # repeat upload to the same target re-uses the same OSS key. The
+            # remote object IS overwritten by `resumable_upload` above (new
+            # content), but `wget -c` would compare sizes, see they match, and
+            # exit 0 without fetching, leaving the sandbox file at its old
+            # content while we still report success. `-O` alone forces wget
+            # to truncate and rewrite, regardless of existing local state.
+            download_cmd = f"wget -O {shlex.quote(target_path)} '{url}'"
             await self._sandbox.arun(cmd=download_cmd, wait_timeout=600, mode=RunMode.NOHUP)
 
             # Verify target exists in sandbox. Use execute() instead of arun(),

--- a/tests/unit/sdk/sandbox/test_oss_client.py
+++ b/tests/unit/sdk/sandbox/test_oss_client.py
@@ -388,6 +388,92 @@ class TestUploadViaOss:
 
         assert response.success is False
 
+    async def test_wget_command_has_no_continue_flag(self):
+        """Regression: `wget -c` would skip download when target exists with
+        matching size — but OSS object key is path-based (not content-based),
+        so a repeat upload re-uses the same key and `-c` would leave the
+        sandbox file at its old content. We must use `-O` alone to force
+        truncate-and-rewrite."""
+        sandbox = _make_sandbox()
+        sandbox.sandbox_id = "sb-123"
+        sandbox.arun = AsyncMock(return_value=MagicMock(exit_code=0))
+        sandbox.execute = AsyncMock(return_value=MagicMock(exit_code=0))
+
+        client = OssClient(sandbox)
+        client._bucket = MagicMock()
+        client._bucket.sign_url = MagicMock(return_value="https://oss/signed?token=xxx")
+
+        with patch("rock.sdk.sandbox.oss_client.oss2.resumable_upload"):
+            await client.upload_via_oss("/local/foo.json", "/sandbox/dst/foo.json")
+
+        # arun() is invoked twice: first for `mkdir -p`, second for `wget`.
+        wget_call = next(
+            c for c in sandbox.arun.await_args_list
+            if "wget" in (c.kwargs.get("cmd") or (c.args[0] if c.args else ""))
+        )
+        wget_cmd = wget_call.kwargs.get("cmd") or wget_call.args[0]
+        # The bug was `wget -c -O ...` — `-c` makes wget skip a same-sized local file.
+        assert " -c " not in f" {wget_cmd} ", f"wget should not use -c: {wget_cmd!r}"
+        assert " -O " in wget_cmd, f"wget must use -O to force overwrite: {wget_cmd!r}"
+
+    async def test_wget_command_quotes_target_path(self):
+        """target_path is interpolated into a shell command; if it contains
+        spaces or shell metachars (`;`, `$`, `&`, etc.) the unquoted form
+        would either fail or, worse, execute injected commands. shlex.quote
+        is the standard fix."""
+        sandbox = _make_sandbox()
+        sandbox.sandbox_id = "sb-123"
+        sandbox.arun = AsyncMock(return_value=MagicMock(exit_code=0))
+        sandbox.execute = AsyncMock(return_value=MagicMock(exit_code=0))
+
+        client = OssClient(sandbox)
+        client._bucket = MagicMock()
+        client._bucket.sign_url = MagicMock(return_value="https://oss/signed")
+
+        unsafe_target = "/sandbox/dir with spaces/foo.json"
+        with patch("rock.sdk.sandbox.oss_client.oss2.resumable_upload"):
+            await client.upload_via_oss("/local/foo.json", unsafe_target)
+
+        wget_call = next(
+            c for c in sandbox.arun.await_args_list
+            if "wget" in (c.kwargs.get("cmd") or (c.args[0] if c.args else ""))
+        )
+        wget_cmd = wget_call.kwargs.get("cmd") or wget_call.args[0]
+        # shlex.quote wraps a path-with-spaces in single quotes.
+        assert "'/sandbox/dir with spaces/foo.json'" in wget_cmd, \
+            f"target_path with spaces must be shell-quoted: {wget_cmd!r}"
+
+    async def test_repeat_upload_to_same_target_does_not_skip_via_wget(self):
+        """End-to-end intent: repeat upload(local_v2, /tmp/x) after upload(local_v1, /tmp/x)
+        must issue a wget command that *will* overwrite — i.e. wget must be invoked
+        with -O alone (not -c -O). We can't observe sandbox file content in unit
+        tests, but verifying the command shape forces the correct behavior."""
+        sandbox = _make_sandbox()
+        sandbox.sandbox_id = "sb-fixed"
+        sandbox.arun = AsyncMock(return_value=MagicMock(exit_code=0))
+        sandbox.execute = AsyncMock(return_value=MagicMock(exit_code=0))
+
+        client = OssClient(sandbox)
+        client._bucket = MagicMock()
+        client._bucket.sign_url = MagicMock(return_value="https://oss/v1")
+
+        with patch("rock.sdk.sandbox.oss_client.oss2.resumable_upload"):
+            # Round 1: upload local_a → /sandbox/x
+            await client.upload_via_oss("/local/a.bin", "/sandbox/x.bin")
+            # Round 2: upload local_b (different content, hypothetically) → SAME target
+            client._bucket.sign_url = MagicMock(return_value="https://oss/v2")
+            await client.upload_via_oss("/local/b.bin", "/sandbox/x.bin")
+
+        # Both rounds must produce a wget cmd without `-c`.
+        wget_calls = [
+            (c.kwargs.get("cmd") or (c.args[0] if c.args else ""))
+            for c in sandbox.arun.await_args_list
+            if "wget" in (c.kwargs.get("cmd") or (c.args[0] if c.args else ""))
+        ]
+        assert len(wget_calls) == 2
+        for wget_cmd in wget_calls:
+            assert " -c " not in f" {wget_cmd} ", f"`-c` regressed: {wget_cmd!r}"
+
 
 class TestDownloadViaOss:
     async def test_oss_unavailable_returns_failure(self, tmp_path):


### PR DESCRIPTION
## Summary
                                                                                                                                                                                                                   
  `oss_client.py:upload_via_oss` was using `wget -c -O <target> <url>`. The                                                                                                                                        
  `-c` flag makes wget skip the download when the local file already exists
  with size matching the remote. Combined with the path-based OSS object                                                                                                                                           
  naming (`_compute_object_name(sandbox_id|local|sandbox_path)`), a repeat                                                                                                                                         
  upload to the same `target_path` re-used the same OSS key — the OSS object                                                                                                                                       
  was correctly overwritten, but the sandbox-side wget short-circuited and                                                                                                                                         
  left the file at its old content. SDK still returned `success=True`.                                                                                                                                             
                                                                                                                                                                                                                   
  ## Change                                                                                                                                                                                                        
                                                                                                                                                                                                                   
  ```diff                                                                                                                                                                                                          
  - download_cmd = f"wget -c -O {target_path} '{url}'"
  + download_cmd = f"wget -O {shlex.quote(target_path)} '{url}'"                                                                                                                                                   
  ```                                                                                                                                                                                                              
                                                                                                                                                                                                                   
  - Drop `-c`. `-O` alone forces wget to truncate-and-rewrite, regardless of                                                                                                                                       
    existing local state. `-c` was a misuse — its semantics assume the
    remote object content is stable across attempts, but ROCK's OSS object                                                                                                                                         
    is intentionally treated as ephemeral transit storage with deterministic
    path-based keys.                                                                                                                                                                                               
  - Add `shlex.quote(target_path)` to defend against paths containing                                                                                                                                              
    spaces or shell metacharacters.                                                                                                                                                                                
  - Inline comment explaining why `-c` is wrong (so this doesn't get added                                                                                                                                         
    back).                                                                                                                                                                                                         
                                                                                                                                                                                                                   
  ## Test plan                                                                                                                                                                                                     
                                                                                                                                                                                                                   
  3 new regression tests in `TestUploadViaOss`:                                                                                                                                                                    
   

  ```diff
  - download_cmd = f"wget -c -O {target_path} '{url}'"
  + download_cmd = f"wget -O {shlex.quote(target_path)} '{url}'"
  ```

  - Drop `-c`. `-O` alone forces wget to truncate-and-rewrite, regardless of
    existing local state. `-c` was a misuse — its semantics assume the
    remote object content is stable across attempts, but ROCK's OSS object
    is intentionally treated as ephemeral transit storage with deterministic
    path-based keys.
  - Add `shlex.quote(target_path)` to defend against paths containing
  - Add `shlex.quote(target_path)` to defend against paths containing
    spaces or shell metacharacters.
  - Inline comment explaining why `-c` is wrong (so this doesn't get added
    back).

  ## Test plan

  3 new regression tests in `TestUploadViaOss`:

  - `test_wget_command_has_no_continue_flag` — asserts ` -c ` absent and
    ` -O ` present in the wget invocation.
  - `test_wget_command_quotes_target_path` — target with spaces is
    shell-quoted.
  - `test_repeat_upload_to_same_target_does_not_skip_via_wget` — simulates
    the production overwrite scenario; both rounds must invoke wget without
    `-c`.

  All 43 tests in `test_oss_client.py` pass. `ruff check` clean.

  ## Why pre-existing tests missed this

  Tests used unique timestamped `target_path` per call (e.g.
  `/tmp/oss_auto_large_{ts}.txt`), so target never pre-existed → wget never
  short-circuited → bug invisible.

  ## Risk

  Minimal. The only behavioral change is wget always fetches even when target
  exists — but that's the correct behavior for a temporary OSS-as-transit
  upload model. No public API change.


fixes #991