### PR TITLE
docs(v1.8.0): remove internal dingtalk links from release note

### DIFF
--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.8.x/Release Notes/v1.8.0.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.8.x/Release Notes/v1.8.0.md
@@ -143,7 +143,7 @@
 
 ## ♻️ 代码重构
 
-*   **对象存储**: 将 OSS 上传/下载与客户端环境变量解耦，实现三层配置解析机制 (#943)[《oss重构提测-ROCK-V1.8》](https://alidocs.dingtalk.com/i/nodes/o14dA3GK8gQlkoYwcK5yyo2QV9ekBD76?corpId=dingd8e1123006514592&utm_medium=im_card&iframeQuery=utm_medium%3Dportal_main_colum_create%26utm_source%3Dportal&utm_scene=person_space&utm_source=im&cid=72193729861)
+*   **对象存储**: 将 OSS 上传/下载与客户端环境变量解耦，实现三层配置解析机制 (#943)
     
 
 ## 🔧 构建与工具

--- a/docs/versioned_docs/version-1.8.x/Release Notes/v1.8.0.md
+++ b/docs/versioned_docs/version-1.8.x/Release Notes/v1.8.0.md
@@ -129,7 +129,7 @@ May 21, 2026
 
 ## ♻️ Refactoring
 
-*   **OSS**: Decouple OSS upload/download from client env vars; implement 3-layer config resolution (#943) [《OSS Refactor Test Plan — ROCK V1.8》](https://alidocs.dingtalk.com/i/nodes/o14dA3GK8gQlkoYwcK5yyo2QV9ekBD76?corpId=dingd8e1123006514592&utm_medium=im_card&iframeQuery=utm_medium%3Dportal_main_colum_create%26utm_source%3Dportal&utm_scene=person_space&utm_source=im&cid=72193729861)
+*   **OSS**: Decouple OSS upload/download from client env vars; implement 3-layer config resolution (#943)
 
 ## 🔧 Build & Tooling
 


### PR DESCRIPTION
## Summary
                                                                                                                                                                     
  Follow-up to the merged v1.8.0 release-notes PR. Removes two                                                                                                       
  `alidocs.dingtalk.com` links from the OSS Refactoring entry — these                                                                                                
  point at internal Aliyun documents that external readers can't open.                                                                                               
                                                                                                                                                                     
  ## Change                                                                                                                                                          
                                                                                                                                                                     
  ```diff                                                      
   ## ♻️  Refactoring
                                                                                                                                                                     
  -*   **OSS**: Decouple OSS upload/download from client env vars; implement 3-layer config resolution (#943) [《OSS Refactor Test Plan — ROCK
  V1.8》](https://alidocs.dingtalk.com/i/nodes/...)                                                                                                                  
  +*   **OSS**: Decouple OSS upload/download from client env vars; implement 3-layer config resolution (#943)
  ```                                                                                                                                                                
                                                               
  Same one-line removal applied to the Chinese version.

  | File | Line |
  |---|---|
  | `docs/versioned_docs/version-1.8.x/Release Notes/v1.8.0.md` | L132 |
  | `docs/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.8.x/Release Notes/v1.8.0.md` | L146 |
                                                                                                                                                                     
  Net `+2 / -2` across 2 files. No other content touched.
                                                                                                                                                                     
  ## Test plan                                                 

  - [ ] `cd docs && npm run build` passes (build succeeded locally with                                                                                              
        Node 20.20.2 + webpack pin previously established for this repo)
  - [ ] Visual check on `npm run serve` → 1.8.x → Release Notes → v1.8.0,                                                                                            
        Refactoring section no longer renders the dingtalk link                                                                                                      
  - [ ] Same check on Chinese version       
  
#989
  
  
  