### PR TITLE
fix(rocklet): use cgroup metrics for container memory instead of psutil

### DIFF
--- a/rock/rocklet/linux.py
+++ b/rock/rocklet/linux.py
@@ -34,7 +34,7 @@ from rock.rocklet.exceptions import (
     SessionNotInitializedError,
 )
 from rock.utils import get_executor
-from rock.utils.cgroup_stats import CgroupCpuStats
+from rock.utils.cgroup_stats import CgroupCpuStats, CgroupMemStats
 
 from .rocklet import Rocklet, Session
 
@@ -346,6 +346,7 @@ class LinuxRocklet(Rocklet):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._cgroup_cpu = CgroupCpuStats()
+        self._cgroup_mem = CgroupMemStats()
         self._docker_data_root: str | None = None
 
     def _build_bash_session(self, request: CreateBashSessionRequest) -> Session:
@@ -372,7 +373,7 @@ class LinuxRocklet(Rocklet):
 
         return {
             "cpu": self._cgroup_cpu.cpu_percent(),
-            "mem": psutil.virtual_memory().percent,
+            "mem": self._cgroup_mem.mem_percent(),
             "disk": disk_root.percent,  # legacy metric name, actually rootfs usage percent
             "disk_log_percent": disk_log_percent,
             "disk_dind_percent": disk_dind_percent,

--- a/rock/utils/cgroup_stats.py
+++ b/rock/utils/cgroup_stats.py
@@ -1,4 +1,4 @@
-"""Container-aware CPU metrics via cgroup v1/v2.
+"""Container-aware CPU/memory metrics via cgroup v1/v2.
 
 Falls back to psutil when cgroup files are unavailable (e.g. running
 outside a container or on non-Linux platforms).
@@ -111,3 +111,74 @@ class CgroupCpuStats:
 
         num_cpus = self._read_cpu_quota()
         return min(round((delta_usage / delta_time) / num_cpus * 100, 1), 100.0)
+
+
+class CgroupMemStats:
+    """Reads container memory utilization from cgroup v1/v2 pseudo-files."""
+
+    def __init__(self):
+        self._cgroup_version: int | None = None
+        self._mem_limit: int | None = None
+
+    def _detect_cgroup_version(self) -> int:
+        if self._cgroup_version is not None:
+            return self._cgroup_version
+
+        if Path("/sys/fs/cgroup/cgroup.controllers").exists():
+            self._cgroup_version = 2
+        elif Path("/sys/fs/cgroup/memory/memory.usage_in_bytes").exists():
+            self._cgroup_version = 1
+        else:
+            self._cgroup_version = 0
+
+        return self._cgroup_version
+
+    def _read_mem_usage_bytes(self) -> int | None:
+        try:
+            ver = self._detect_cgroup_version()
+            if ver == 2:
+                return int(Path("/sys/fs/cgroup/memory.current").read_text().strip())
+            elif ver == 1:
+                return int(Path("/sys/fs/cgroup/memory/memory.usage_in_bytes").read_text().strip())
+            return None
+        except Exception:
+            return None
+
+    def _read_mem_limit_bytes(self) -> int | None:
+        if self._mem_limit is not None:
+            return self._mem_limit
+
+        try:
+            ver = self._detect_cgroup_version()
+            if ver == 2:
+                text = Path("/sys/fs/cgroup/memory.max").read_text().strip()
+                if text == "max":
+                    return None
+                limit = int(text)
+                if limit <= 0:
+                    return None
+                self._mem_limit = limit
+                return self._mem_limit
+            elif ver == 1:
+                limit = int(Path("/sys/fs/cgroup/memory/memory.limit_in_bytes").read_text().strip())
+                # cgroup v1 uses a very large number (like PAGE_COUNTER_MAX) for unlimited
+                if limit <= 0 or limit >= (1 << 62):
+                    return None
+                self._mem_limit = limit
+                return self._mem_limit
+        except Exception:
+            pass
+        return None
+
+    def mem_percent(self) -> float:
+        """Return container memory utilization %.
+
+        Falls back to psutil if cgroup files are unavailable or memory is unlimited.
+        """
+        usage = self._read_mem_usage_bytes()
+        limit = self._read_mem_limit_bytes()
+
+        if usage is None or limit is None:
+            return psutil.virtual_memory().percent
+
+        return min(round(usage / limit * 100, 1), 100.0)

--- a/rock/utils/cgroup_stats.py
+++ b/rock/utils/cgroup_stats.py
@@ -133,13 +133,34 @@ class CgroupMemStats:
 
         return self._cgroup_version
 
+    def _read_mem_stat(self, stat_path: str, key: str) -> int:
+        """Read a single counter from a cgroup memory.stat file. Returns 0 on any error."""
+        try:
+            for line in Path(stat_path).read_text().splitlines():
+                parts = line.split()
+                if len(parts) >= 2 and parts[0] == key:
+                    return int(parts[1])
+        except Exception:
+            pass
+        return 0
+
     def _read_mem_usage_bytes(self) -> int | None:
+        """Return container memory usage minus reclaimable page cache (inactive_file).
+
+        Raw cgroup usage counters include page cache, which is reclaimable and not
+        a meaningful signal of application memory pressure. Subtracting inactive_file
+        matches the working-set definition used by docker stats and kubelet.
+        """
         try:
             ver = self._detect_cgroup_version()
             if ver == 2:
-                return int(Path("/sys/fs/cgroup/memory.current").read_text().strip())
+                usage = int(Path("/sys/fs/cgroup/memory.current").read_text().strip())
+                inactive_file = self._read_mem_stat("/sys/fs/cgroup/memory.stat", "inactive_file")
+                return max(usage - inactive_file, 0)
             elif ver == 1:
-                return int(Path("/sys/fs/cgroup/memory/memory.usage_in_bytes").read_text().strip())
+                usage = int(Path("/sys/fs/cgroup/memory/memory.usage_in_bytes").read_text().strip())
+                inactive_file = self._read_mem_stat("/sys/fs/cgroup/memory/memory.stat", "total_inactive_file")
+                return max(usage - inactive_file, 0)
             return None
         except Exception:
             return None

--- a/tests/unit/utils/test_cgroup_stats.py
+++ b/tests/unit/utils/test_cgroup_stats.py
@@ -414,3 +414,71 @@ class TestMemPercent:
         ):
             mock_vmem.return_value.percent = 60.0
             assert stats.mem_percent() == 60.0
+
+    def test_v2_subtracts_inactive_file_cache(self):
+        """memory.current includes page cache; inactive_file should be subtracted."""
+        stats = CgroupMemStats()
+        stats._cgroup_version = 2
+        read_map = {
+            "/sys/fs/cgroup/memory.current": "1073741824\n",
+            "/sys/fs/cgroup/memory.stat": "anon 524288000\nfile 400000000\ninactive_file 262144000\nactive_file 137856000\n",
+            "/sys/fs/cgroup/memory.max": "2147483648\n",
+        }
+        with patch.object(Path, "read_text", _mock_path_read_text(read_map)):
+            result = stats.mem_percent()
+        # (1073741824 - 262144000) / 2147483648 * 100 = 37.8%
+        assert result == 37.8
+
+    def test_v1_subtracts_total_inactive_file_cache(self):
+        """memory.usage_in_bytes includes page cache; total_inactive_file should be subtracted."""
+        stats = CgroupMemStats()
+        stats._cgroup_version = 1
+        read_map = {
+            "/sys/fs/cgroup/memory/memory.usage_in_bytes": "1073741824\n",
+            "/sys/fs/cgroup/memory/memory.stat": "cache 400000000\ntotal_cache 400000000\ntotal_inactive_file 262144000\n",
+            "/sys/fs/cgroup/memory/memory.limit_in_bytes": "2147483648\n",
+        }
+        with patch.object(Path, "read_text", _mock_path_read_text(read_map)):
+            result = stats.mem_percent()
+        # (1073741824 - 262144000) / 2147483648 * 100 = 37.8%
+        assert result == 37.8
+
+    def test_v2_no_subtraction_when_memory_stat_missing(self):
+        """If memory.stat is unreadable, fall back to raw usage rather than crashing."""
+        stats = CgroupMemStats()
+        stats._cgroup_version = 2
+        # No memory.stat entry — _mock_path_read_text raises FileNotFoundError.
+        read_map = {
+            "/sys/fs/cgroup/memory.current": "524288000\n",
+            "/sys/fs/cgroup/memory.max": "1073741824\n",
+        }
+        with patch.object(Path, "read_text", _mock_path_read_text(read_map)):
+            result = stats.mem_percent()
+        assert result == 48.8
+
+    def test_v2_inactive_file_larger_than_usage_clamped_to_zero(self):
+        """Sanity guard: subtraction must not produce a negative usage."""
+        stats = CgroupMemStats()
+        stats._cgroup_version = 2
+        read_map = {
+            "/sys/fs/cgroup/memory.current": "100\n",
+            "/sys/fs/cgroup/memory.stat": "inactive_file 9999\n",
+            "/sys/fs/cgroup/memory.max": "1000\n",
+        }
+        with patch.object(Path, "read_text", _mock_path_read_text(read_map)):
+            result = stats.mem_percent()
+        assert result == 0.0
+
+    def test_v2_ignores_malformed_memory_stat_lines(self):
+        """memory.stat parser should skip blank/malformed lines without raising."""
+        stats = CgroupMemStats()
+        stats._cgroup_version = 2
+        read_map = {
+            "/sys/fs/cgroup/memory.current": "1000\n",
+            "/sys/fs/cgroup/memory.stat": "\nmalformed\ninactive_file 200\nanon\n",
+            "/sys/fs/cgroup/memory.max": "10000\n",
+        }
+        with patch.object(Path, "read_text", _mock_path_read_text(read_map)):
+            result = stats.mem_percent()
+        # (1000 - 200) / 10000 * 100 = 8.0%
+        assert result == 8.0

--- a/tests/unit/utils/test_cgroup_stats.py
+++ b/tests/unit/utils/test_cgroup_stats.py
@@ -1,10 +1,8 @@
-"""Tests for rock.utils.cgroup_stats — container-aware CPU metrics."""
+"""Tests for rock.utils.cgroup_stats — container-aware CPU/memory metrics."""
 
 from unittest.mock import patch
 
-import pytest
-
-from rock.utils.cgroup_stats import CgroupCpuStats, Path
+from rock.utils.cgroup_stats import CgroupCpuStats, CgroupMemStats, Path
 
 
 def _mock_path_exists(mapping: dict[str, bool]):
@@ -286,3 +284,133 @@ class TestCpuQuota:
             patch("rock.utils.cgroup_stats.os.cpu_count", return_value=2),
         ):
             assert stats._read_cpu_quota() == 2.0
+
+
+# ---------- Memory cgroup version detection ----------
+
+
+class TestMemDetectCgroupVersion:
+    def test_detects_v2(self):
+        stats = CgroupMemStats()
+        exists_map = {"/sys/fs/cgroup/cgroup.controllers": True}
+        with patch.object(Path, "exists", _mock_path_exists(exists_map)):
+            assert stats._detect_cgroup_version() == 2
+
+    def test_detects_v1(self):
+        stats = CgroupMemStats()
+        exists_map = {
+            "/sys/fs/cgroup/cgroup.controllers": False,
+            "/sys/fs/cgroup/memory/memory.usage_in_bytes": True,
+        }
+        with patch.object(Path, "exists", _mock_path_exists(exists_map)):
+            assert stats._detect_cgroup_version() == 1
+
+    def test_detects_no_cgroup(self):
+        stats = CgroupMemStats()
+        exists_map = {
+            "/sys/fs/cgroup/cgroup.controllers": False,
+            "/sys/fs/cgroup/memory/memory.usage_in_bytes": False,
+        }
+        with patch.object(Path, "exists", _mock_path_exists(exists_map)):
+            assert stats._detect_cgroup_version() == 0
+
+    def test_caches_result(self):
+        stats = CgroupMemStats()
+        stats._cgroup_version = 2
+        assert stats._detect_cgroup_version() == 2
+
+
+# ---------- Memory percent ----------
+
+
+class TestMemPercent:
+    def test_v2_mem_calculation(self):
+        stats = CgroupMemStats()
+        stats._cgroup_version = 2
+        read_map = {
+            "/sys/fs/cgroup/memory.current": "524288000\n",
+            "/sys/fs/cgroup/memory.max": "1073741824\n",
+        }
+        with patch.object(Path, "read_text", _mock_path_read_text(read_map)):
+            result = stats.mem_percent()
+        # 524288000 / 1073741824 * 100 = 48.8%
+        assert result == 48.8
+
+    def test_v1_mem_calculation(self):
+        stats = CgroupMemStats()
+        stats._cgroup_version = 1
+        read_map = {
+            "/sys/fs/cgroup/memory/memory.usage_in_bytes": "734003200\n",
+            "/sys/fs/cgroup/memory/memory.limit_in_bytes": "1073741824\n",
+        }
+        with patch.object(Path, "read_text", _mock_path_read_text(read_map)):
+            result = stats.mem_percent()
+        # 734003200 / 1073741824 * 100 = 68.4%
+        assert result == 68.4
+
+    def test_fallback_to_psutil_when_no_cgroup(self):
+        stats = CgroupMemStats()
+        stats._cgroup_version = 0
+        with patch("rock.utils.cgroup_stats.psutil.virtual_memory") as mock_vmem:
+            mock_vmem.return_value.percent = 55.3
+            assert stats.mem_percent() == 55.3
+
+    def test_fallback_to_psutil_when_unlimited_v2(self):
+        stats = CgroupMemStats()
+        stats._cgroup_version = 2
+        read_map = {
+            "/sys/fs/cgroup/memory.current": "524288000\n",
+            "/sys/fs/cgroup/memory.max": "max\n",
+        }
+        with (
+            patch.object(Path, "read_text", _mock_path_read_text(read_map)),
+            patch("rock.utils.cgroup_stats.psutil.virtual_memory") as mock_vmem,
+        ):
+            mock_vmem.return_value.percent = 33.0
+            assert stats.mem_percent() == 33.0
+
+    def test_fallback_to_psutil_when_unlimited_v1(self):
+        stats = CgroupMemStats()
+        stats._cgroup_version = 1
+        read_map = {
+            "/sys/fs/cgroup/memory/memory.usage_in_bytes": "524288000\n",
+            "/sys/fs/cgroup/memory/memory.limit_in_bytes": "9223372036854771712\n",
+        }
+        with (
+            patch.object(Path, "read_text", _mock_path_read_text(read_map)),
+            patch("rock.utils.cgroup_stats.psutil.virtual_memory") as mock_vmem,
+        ):
+            mock_vmem.return_value.percent = 45.0
+            assert stats.mem_percent() == 45.0
+
+    def test_capped_at_100(self):
+        stats = CgroupMemStats()
+        stats._cgroup_version = 2
+        stats._mem_limit = 1073741824
+        read_map = {
+            "/sys/fs/cgroup/memory.current": "2147483648\n",
+        }
+        with patch.object(Path, "read_text", _mock_path_read_text(read_map)):
+            result = stats.mem_percent()
+        assert result == 100.0
+
+    def test_caches_mem_limit(self):
+        stats = CgroupMemStats()
+        stats._cgroup_version = 2
+        read_map = {
+            "/sys/fs/cgroup/memory.current": "524288000\n",
+            "/sys/fs/cgroup/memory.max": "1073741824\n",
+        }
+        with patch.object(Path, "read_text", _mock_path_read_text(read_map)):
+            stats.mem_percent()
+        assert stats._mem_limit == 1073741824
+
+    def test_fallback_to_psutil_on_read_error(self):
+        stats = CgroupMemStats()
+        stats._cgroup_version = 2
+        with (
+            patch.object(Path, "read_text", side_effect=PermissionError),
+            patch("rock.utils.cgroup_stats.psutil.virtual_memory") as mock_vmem,
+        ):
+            mock_vmem.return_value.percent = 60.0
+            assert stats.mem_percent() == 60.0


### PR DESCRIPTION

## Summary                                                                                                                                                                                               
  fixes #1014                                                                                                                                                                                                          
  Fixes inaccurate container memory usage reporting in rocklet. This PR contains two commits:                                                                                                              
                                                                                                                                                                                                           
  - `psutil` reports host-level memory, not the container's cgroup-limited memory. Switch to reading cgroup counters first (`memory.current` / `memory.max` on v2,                       
  `memory.usage_in_bytes` / `memory.limit_in_bytes` on v1), and fall back to psutil only when running outside a container or when no memory limit is set.                                                  
  - Raw cgroup counters include reclaimable page cache, which inflates the reported usage. Subtract `inactive_file` (v2) / `total_inactive_file` (v1) from the usage value to match the  
  working-set definition used by `docker stats` and kubelet, so the reported number reflects real application memory pressure.                                                                             
   
  ## Changes                                                                                                                                                                                               
                  
  | File | Change |                                                                                                                                                                                        
  |------|--------|
  | `rock/utils/cgroup_stats.py` | Added `CgroupMemStats` with v1/v2 cgroup support; subtracts inactive_file from usage |                                                                                  
  | `rock/rocklet/linux.py` | Memory collection switched from `psutil.virtual_memory()` to `CgroupMemStats` |                                                                                              
  | `tests/unit/utils/test_cgroup_stats.py` | Tests covering v1/v2 paths, psutil fallback, page-cache subtraction, and tolerance of missing/malformed `memory.stat` |                                      
                                                                                                                                                                                                           
  ## Test plan                                                                                                                                                                                             
                                                                                                                                                                                                           
  - [x] `uv run pytest tests/unit/utils/test_cgroup_stats.py` — all new and updated unit tests pass                                                                                                        
  - [x] Start rocklet inside a container with a memory limit set; confirm reported `mem_percent` is close to the working set shown by `docker stats`
  - [x] Start rocklet in an environment without a cgroup memory limit (bare metal / no `--memory`); confirm the psutil fallback still reports correctly                                                    
  - [x] Run on both a cgroup v1 and a cgroup v2 host; confirm `inactive_file` is subtracted correctly on both paths