### PR TITLE
fix(sandbox): preserve stop reason in stop() lost in #988 FSM refactor

### DIFF
--- a/rock/sandbox/sandbox_manager.py
+++ b/rock/sandbox/sandbox_manager.py
@@ -178,20 +178,26 @@ class SandboxManager(BaseManager):
         )
 
     @monitor_sandbox_operation()
-    async def stop(self, sandbox_id: str):
+    async def stop(self, sandbox_id: str, reason: StopReason = StopReason.MANUAL):
         sm = await self._get_current_statemachine(sandbox_id)
         if sm is None:
             logger.info(f"stop dangling sandbox {sandbox_id}")
             sandbox_info: SandboxInfo = {"state": State.STOPPED}
             try:
-                await self._operator.stop(sandbox_id)
+                await self._operator.stop(sandbox_id, reason=reason)
             except ValueError as e:
                 logger.error(f"ray get actor, actor {sandbox_id} not exist", exc_info=e)
             await self._meta_store.archive(sandbox_id, sandbox_info)
         elif sm.current_state.value == State.STOPPED:
             await sm.send("stop_noop", sandbox_id=sandbox_id)
         else:
-            await sm.send("stop", sandbox_id=sandbox_id, operator=self._operator, meta_store=self._meta_store)
+            await sm.send(
+                "stop",
+                sandbox_id=sandbox_id,
+                operator=self._operator,
+                meta_store=self._meta_store,
+                reason=reason,
+            )
 
     async def get_mount(self, sandbox_id):
         async with self._ray_service.get_ray_rwlock().read_lock():

--- a/rock/sandbox/sandbox_statemachine.py
+++ b/rock/sandbox/sandbox_statemachine.py
@@ -12,6 +12,7 @@ from statemachine import StateChart
 from rock.actions.sandbox.response import State as RockState
 from rock.actions.sandbox.sandbox_info import SandboxInfo
 from rock.admin.metrics.billing import log_billing_info
+from rock.common.constants import StopReason
 from rock.logger import init_logger
 from rock.utils.system import get_iso8601_timestamp
 
@@ -53,8 +54,8 @@ class SandboxStateMachine(StateChart):
 
     # Callbacks
 
-    async def on_stop(self, sandbox_id: str, operator, meta_store) -> None:
-        logger.info(f"stop sandbox {sandbox_id}")
+    async def on_stop(self, sandbox_id: str, operator, meta_store, reason: StopReason = StopReason.MANUAL) -> None:
+        logger.info(f"stop sandbox {sandbox_id} (reason={reason.value})")
         sandbox_info = self.sandbox_info or {}
 
         # Initialize sandbox_info with default values if not set
@@ -67,7 +68,7 @@ class SandboxStateMachine(StateChart):
             log_billing_info(sandbox_info=sandbox_info)
 
         try:
-            await operator.stop(sandbox_id)
+            await operator.stop(sandbox_id, reason=reason)
         except ValueError as e:
             logger.error(f"ray get actor, actor {sandbox_id} not exist", exc_info=e)
 

--- a/tests/unit/sandbox/test_sandbox_statemachine.py
+++ b/tests/unit/sandbox/test_sandbox_statemachine.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from rock.actions.sandbox.response import State
+from rock.common.constants import StopReason
 from rock.sandbox.sandbox_statemachine import SandboxStateMachine
 
 # ---------------------------------------------------------------------------
@@ -158,7 +159,7 @@ class TestOnStop:
     async def test_stops_operator_and_archives(self, mock_operator, mock_meta_store):
         sm = await SandboxStateMachine.from_state_value(State.RUNNING, sandbox_info={})
         await sm.send("stop", sandbox_id="sb-1", operator=mock_operator, meta_store=mock_meta_store)
-        mock_operator.stop.assert_awaited_once_with("sb-1")
+        mock_operator.stop.assert_awaited_once_with("sb-1", reason=StopReason.MANUAL)
         mock_meta_store.archive.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/tests/unit/sandbox/test_sandbox_transitions.py
+++ b/tests/unit/sandbox/test_sandbox_transitions.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from rock.actions.sandbox.response import State
+from rock.common.constants import StopReason
 from rock.sandbox.sandbox_manager import SandboxManager
 from rock.sdk.common.exceptions import BadRequestRockError, InternalServerRockError
 
@@ -75,7 +76,7 @@ class TestManagerStop:
     async def test_stop_not_found_attempts_cleanup(self, mgr, mock_meta_store, mock_operator):
         mock_meta_store.get.return_value = None
         await mgr.stop("sb-1")
-        mock_operator.stop.assert_awaited_once_with("sb-1")
+        mock_operator.stop.assert_awaited_once_with("sb-1", reason=StopReason.MANUAL)
         mock_meta_store.archive.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -95,14 +96,14 @@ class TestManagerStop:
     async def test_stop_running_calls_operator_and_archives(self, mgr, mock_meta_store, mock_operator):
         mock_meta_store.get.return_value = {"state": State.RUNNING}
         await mgr.stop("sb-1")
-        mock_operator.stop.assert_awaited_once_with("sb-1")
+        mock_operator.stop.assert_awaited_once_with("sb-1", reason=StopReason.MANUAL)
         mock_meta_store.archive.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_stop_pending_calls_operator_and_archives(self, mgr, mock_meta_store, mock_operator):
         mock_meta_store.get.return_value = {"state": State.PENDING}
         await mgr.stop("sb-1")
-        mock_operator.stop.assert_awaited_once_with("sb-1")
+        mock_operator.stop.assert_awaited_once_with("sb-1", reason=StopReason.MANUAL)
         mock_meta_store.archive.assert_awaited_once()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
close #914 

The SandboxStateMachine refactor (#988) dropped the `reason` parameter from SandboxManager.stop() and from the on_stop callback chain, breaking the EXPIRED-vs-MANUAL distinction that auto-cleanup relies on (the _check_stop watchdog passes reason=StopReason.EXPIRED to differentiate timed-out sandboxes from user-initiated stops).

Restore the parameter and forward it through:
  - SandboxManager.stop(sandbox_id, reason=StopReason.MANUAL)
  - dangling path: operator.stop(sandbox_id, reason=reason)
  - normal path:   sm.send("stop", ..., reason=reason)
  - SandboxStateMachine.on_stop(... , reason=StopReason.MANUAL)
  - log message: "stop sandbox {id} (reason={reason.value})"
  - operator.stop(sandbox_id, reason=reason) inside on_stop

Behavior matches pre-#988 master.