### PR TITLE
fix(scheduler): split ImageCleanupTask prune (idempotent) from docuum launch

### DIFF
--- a/rock/admin/scheduler/tasks/image_cleanup_task.py
+++ b/rock/admin/scheduler/tasks/image_cleanup_task.py
@@ -63,8 +63,11 @@ class ImageCleanupTask(BaseTask):
         )
 
     async def run_action(self, runtime: RemoteSandboxRuntime) -> dict:
-        """Start docuum daemon, then synchronously prune dangling/build cache."""
-        # 1) docuum: LRU image eviction (long-running, nohup &)
+        """NON-idempotent path: launch docuum daemon (gated by should_run via base run_on_worker)."""
+        return await self._launch_docuum(runtime)
+
+    async def _launch_docuum(self, runtime: RemoteSandboxRuntime) -> dict:
+        """docuum: LRU image eviction (long-running, nohup &). NON-idempotent."""
         check_and_install_cmd = (
             f"command -v docuum > /dev/null 2>&1 || curl {env_vars.ROCK_DOCUUM_INSTALL_URL} -LSfs | sh"
         )
@@ -81,33 +84,53 @@ class ImageCleanupTask(BaseTask):
         result = await runtime.execute(Command(command=command, shell=True))
 
         pid = extract_nohup_pid(result.stdout)
-        logger.info(f"image cleanup task [{pid}] run successfully on worker[{runtime._config.host}]")
-
-        # 2) Dangling/BuildKit prune (sync, fail-soft so an old/missing docker
-        #    subcommand on one worker doesn't abort the rest of the pipeline).
-        prune_exit = None
-        prune_output = ""
-        if self.keep_build_storage:
-            prune_steps = [
-                "docker image prune -f --filter dangling=true",
-                f"docker builder prune -f --keep-storage {self.keep_build_storage}",
-            ]
-            prune_cmd = "; ".join(f"({s}) 2>&1 || true" for s in prune_steps)
-            prune_result = await runtime.execute(Command(command=prune_cmd, shell=True, check=False))
-            prune_output = (prune_result.stdout or "").strip()[:1000]
-            prune_exit = prune_result.exit_code
-            logger.info(
-                f"docker prune done on worker[{runtime._config.host}]: "
-                f"keep_build_storage={self.keep_build_storage}, exit={prune_exit}, "
-                f"output_head={prune_output[:300]}"
-            )
-
+        logger.info(f"docuum launched with PID [{pid}] on worker[{runtime._config.host}]")
         return {
             "pid": pid,
             "disk_threshold": self.disk_threshold,
             "image_whitelist": self.image_whitelist,
+            "status": TaskStatusEnum.RUNNING,
+        }
+
+    async def _run_prune(self, runtime: RemoteSandboxRuntime) -> dict:
+        """Dangling/BuildKit prune (sync, fail-soft). IDEMPOTENT — runs every cycle."""
+        if not self.keep_build_storage:
+            return {"prune_exit_code": None, "prune_output_head": ""}
+        prune_steps = [
+            "docker image prune -f --filter dangling=true",
+            f"docker builder prune -f --keep-storage {self.keep_build_storage}",
+        ]
+        prune_cmd = "; ".join(f"({s}) 2>&1 || true" for s in prune_steps)
+        prune_result = await runtime.execute(Command(command=prune_cmd, shell=True, check=False))
+        prune_output = (prune_result.stdout or "").strip()[:1000]
+        prune_exit = prune_result.exit_code
+        logger.info(
+            f"docker prune done on worker[{runtime._config.host}]: "
+            f"keep_build_storage={self.keep_build_storage}, exit={prune_exit}, "
+            f"output_head={prune_output[:300]}"
+        )
+        return {
             "keep_build_storage": self.keep_build_storage,
             "prune_exit_code": prune_exit,
             "prune_output_head": prune_output,
-            "status": TaskStatusEnum.RUNNING,
         }
+
+    async def run_on_worker(self, ip):
+        """Override base: prune unconditionally (idempotent), then gate docuum on should_run.
+
+        The base run_on_worker skips entire task when should_run returns False, which
+        correctly prevents docuum re-launch but wrongly blocks the idempotent prune
+        step (dangling layers / BuildKit cache pile up forever once docuum is alive).
+        """
+        runtime = self._get_runtime(ip)
+        # prune always runs — idempotent, fail-soft
+        try:
+            await self._run_prune(runtime)
+        except Exception as e:
+            logger.warning(f"[{self.type}] prune failed on worker[{ip}]: {e}")
+        # docuum gated by should_run — non-idempotent
+        if not await self.should_run(runtime):
+            logger.info(f"[{self.type}] docuum already running on worker[{ip}], skip launch")
+            return
+        logger.info(f"[{self.type}] launch docuum on worker[{ip}]")
+        await self.single_run(runtime, ip)

--- a/tests/unit/admin/scheduler/test_image_cleanup_task.py
+++ b/tests/unit/admin/scheduler/test_image_cleanup_task.py
@@ -1,4 +1,13 @@
-"""Tests for ImageCleanupTask (docuum LRU + dangling/BuildKit prune)."""
+"""Tests for ImageCleanupTask (docuum LRU + dangling/BuildKit prune).
+
+Architecture (post split):
+- ``run_action`` only launches docuum daemon (NON-idempotent).
+- ``_run_prune`` performs dangling/BuildKit prune (IDEMPOTENT).
+- ``run_on_worker`` overrides base: prune unconditionally, then gate
+  docuum on ``should_run``. This decoupling fixes the regression where
+  the whole task was skipped once docuum was alive, causing dangling
+  layers and BuildKit cache to accumulate forever.
+"""
 
 from unittest.mock import AsyncMock
 
@@ -28,16 +37,20 @@ def _runtime(side_effects):
     return rt
 
 
-# Fixed call sequence for run_action when keep_build_storage is set:
+# Call sequence for _launch_docuum (run_action):
 #   1) docuum install check
 #   2) docuum start (returns PID-tagged stdout)
-#   3) docker image prune + docker builder prune (one combined cmd)
-def _default_results(pid=12345, prune_stdout="Total reclaimed space: 1.2GB"):
+def _docuum_results(pid=12345):
     return [
         _FakeExecResult(),
         _FakeExecResult(stdout=f"PIDSTART{pid}PIDEND"),
-        _FakeExecResult(stdout=prune_stdout),
     ]
+
+
+# Call sequence for _run_prune (single combined cmd):
+#   1) docker image prune + docker builder prune (one combined cmd)
+def _prune_results(prune_stdout="Total reclaimed space: 1.2GB"):
+    return [_FakeExecResult(stdout=prune_stdout)]
 
 
 class TestInit:
@@ -90,32 +103,69 @@ class TestFromConfig:
 
 
 class TestRunAction:
+    """run_action now only launches docuum — prune moved to _run_prune."""
+
     @pytest.mark.asyncio
     async def test_docuum_command_includes_threshold(self):
         task = ImageCleanupTask(disk_threshold="500G")
-        runtime = _runtime(_default_results())
+        runtime = _runtime(_docuum_results())
 
         await task.run_action(runtime)
+
+        # call 0: install check; call 1: docuum start
         docuum_cmd = runtime.execute.await_args_list[1].args[0].command
         assert "docuum --threshold 500G" in docuum_cmd
 
     @pytest.mark.asyncio
     async def test_docuum_command_passes_whitelist(self):
         task = ImageCleanupTask(image_whitelist=[r"^rock-base.*$", r"^pinned:.*$"])
-        runtime = _runtime(_default_results())
+        runtime = _runtime(_docuum_results())
 
         await task.run_action(runtime)
+
         docuum_cmd = runtime.execute.await_args_list[1].args[0].command
         assert "--keep '^rock-base.*$'" in docuum_cmd
         assert "--keep '^pinned:.*$'" in docuum_cmd
 
     @pytest.mark.asyncio
-    async def test_prune_command_includes_image_and_builder_prune(self):
-        task = ImageCleanupTask(keep_build_storage="10GB")
-        runtime = _runtime(_default_results())
+    async def test_run_action_returns_pid_and_status(self):
+        task = ImageCleanupTask()
+        runtime = _runtime(_docuum_results(pid=98765))
+
+        result = await task.run_action(runtime)
+
+        assert result["status"] == TaskStatusEnum.RUNNING
+        assert result["pid"] == 98765
+        assert result["disk_threshold"] == "1T"
+        assert result["image_whitelist"] == []
+
+    @pytest.mark.asyncio
+    async def test_run_action_does_not_invoke_prune(self):
+        """Regression guard: run_action MUST NOT call prune (decoupled to _run_prune)."""
+        task = ImageCleanupTask()
+        runtime = _runtime(_docuum_results())
 
         await task.run_action(runtime)
-        prune_cmd = runtime.execute.await_args_list[2].args[0].command
+
+        # exactly 2 execute calls: install check + docuum start (NO prune call)
+        assert runtime.execute.await_count == 2
+        for call in runtime.execute.await_args_list:
+            cmd = call.args[0].command
+            assert "docker image prune" not in cmd
+            assert "docker builder prune" not in cmd
+
+
+class TestRunPrune:
+    """_run_prune is idempotent and runs every cycle (via run_on_worker)."""
+
+    @pytest.mark.asyncio
+    async def test_prune_command_includes_image_and_builder_prune(self):
+        task = ImageCleanupTask(keep_build_storage="10GB")
+        runtime = _runtime(_prune_results())
+
+        await task._run_prune(runtime)
+
+        prune_cmd = runtime.execute.await_args_list[0].args[0].command
         assert "docker image prune -f --filter dangling=true" in prune_cmd
         assert "docker builder prune -f --keep-storage 10GB" in prune_cmd
 
@@ -124,48 +174,149 @@ class TestRunAction:
         # Long-running sandboxes may attach named volumes; we don't want to
         # drop them on schedule.
         task = ImageCleanupTask()
-        runtime = _runtime(_default_results())
+        runtime = _runtime(_prune_results())
 
-        await task.run_action(runtime)
-        prune_cmd = runtime.execute.await_args_list[2].args[0].command
+        await task._run_prune(runtime)
+
+        prune_cmd = runtime.execute.await_args_list[0].args[0].command
         assert "docker volume prune" not in prune_cmd
 
     @pytest.mark.asyncio
     async def test_prune_step_is_fail_soft(self):
         task = ImageCleanupTask()
-        runtime = _runtime(_default_results())
+        runtime = _runtime(_prune_results())
 
-        await task.run_action(runtime)
-        prune_cmd = runtime.execute.await_args_list[2].args[0].command
+        await task._run_prune(runtime)
+
+        prune_cmd = runtime.execute.await_args_list[0].args[0].command
         # `(...) 2>&1 || true` makes a missing/old docker subcommand non-fatal.
         assert "|| true" in prune_cmd
 
     @pytest.mark.asyncio
-    async def test_prune_skipped_when_keep_build_storage_falsy(self):
-        task = ImageCleanupTask(keep_build_storage=None)
-        # Only 2 execute calls expected: install check + docuum start.
-        runtime = _runtime(_default_results()[:2])
-
-        result = await task.run_action(runtime)
-        assert runtime.execute.await_count == 2
-        assert result["prune_exit_code"] is None
-        assert result["prune_output_head"] == ""
-
-    @pytest.mark.asyncio
-    async def test_run_action_returns_pid_and_status(self):
+    async def test_prune_records_output(self):
         task = ImageCleanupTask()
-        runtime = _runtime(_default_results(pid=98765))
+        runtime = _runtime(_prune_results(prune_stdout="Total reclaimed space: 3.5GB\n(more)"))
 
-        result = await task.run_action(runtime)
-        assert result["status"] == TaskStatusEnum.RUNNING
-        assert result["pid"] == 98765
-        assert result["disk_threshold"] == "1T"
+        result = await task._run_prune(runtime)
+
+        assert "Total reclaimed space" in result["prune_output_head"]
+        assert result["prune_exit_code"] == 0
         assert result["keep_build_storage"] == "20GB"
 
     @pytest.mark.asyncio
-    async def test_run_action_records_prune_output(self):
-        task = ImageCleanupTask()
-        runtime = _runtime(_default_results(prune_stdout="Total reclaimed space: 3.5GB\n(more)"))
+    async def test_prune_skipped_when_keep_build_storage_falsy(self):
+        """keep_build_storage=None → fast return, no docker exec."""
+        task = ImageCleanupTask(keep_build_storage=None)
+        runtime = AsyncMock()
+        runtime.execute = AsyncMock()
 
-        result = await task.run_action(runtime)
-        assert "Total reclaimed space" in result["prune_output_head"]
+        result = await task._run_prune(runtime)
+
+        assert result == {"prune_exit_code": None, "prune_output_head": ""}
+        runtime.execute.assert_not_awaited()
+
+
+class TestRunOnWorker:
+    """run_on_worker overrides base: prune unconditionally, then gate docuum on should_run.
+
+    Verifies the fix for the regression where the entire task was skipped once
+    docuum daemon was alive (NON_IDEMPOTENT idempotency type → should_run False
+    → run_action skipped → prune never ran → dangling layers accumulated forever).
+    """
+
+    @pytest.mark.asyncio
+    async def test_first_run_launches_both(self, monkeypatch):
+        """status=None / docuum dead → prune runs AND single_run (docuum launch) runs."""
+        task = ImageCleanupTask()
+        runtime = AsyncMock()
+        monkeypatch.setattr(task, "_get_runtime", lambda ip: runtime)
+        monkeypatch.setattr(task, "should_run", AsyncMock(return_value=True))
+        monkeypatch.setattr(task, "single_run", AsyncMock())
+        prune_spy = AsyncMock(return_value={})
+        monkeypatch.setattr(task, "_run_prune", prune_spy)
+
+        await task.run_on_worker("10.0.0.1")
+
+        prune_spy.assert_awaited_once_with(runtime)
+        task.single_run.assert_awaited_once_with(runtime, "10.0.0.1")
+
+    @pytest.mark.asyncio
+    async def test_docuum_alive_still_prunes(self, monkeypatch):
+        """CORE REGRESSION: docuum pid alive (should_run=False) → prune STILL runs.
+
+        Before the fix, base run_on_worker would skip the entire task when
+        should_run returned False, blocking prune indefinitely once docuum
+        was alive (which is forever — docuum is a long-running daemon).
+        """
+        task = ImageCleanupTask()
+        runtime = AsyncMock()
+        monkeypatch.setattr(task, "_get_runtime", lambda ip: runtime)
+        monkeypatch.setattr(task, "should_run", AsyncMock(return_value=False))
+        single_run = AsyncMock()
+        monkeypatch.setattr(task, "single_run", single_run)
+        prune_spy = AsyncMock(return_value={})
+        monkeypatch.setattr(task, "_run_prune", prune_spy)
+
+        await task.run_on_worker("10.0.0.1")
+
+        prune_spy.assert_awaited_once_with(runtime)
+        single_run.assert_not_awaited()  # docuum NOT relaunched (correctly)
+
+    @pytest.mark.asyncio
+    async def test_prune_exception_does_not_block_docuum(self, monkeypatch):
+        """prune raises → docuum launch still proceeds per should_run; no crash propagates."""
+        task = ImageCleanupTask()
+        runtime = AsyncMock()
+        monkeypatch.setattr(task, "_get_runtime", lambda ip: runtime)
+        monkeypatch.setattr(task, "_run_prune", AsyncMock(side_effect=RuntimeError("docker down")))
+        monkeypatch.setattr(task, "should_run", AsyncMock(return_value=True))
+        single_run = AsyncMock()
+        monkeypatch.setattr(task, "single_run", single_run)
+
+        # Must not raise (run_on_worker catches prune exception with try/except)
+        await task.run_on_worker("10.0.0.1")
+
+        single_run.assert_awaited_once_with(runtime, "10.0.0.1")
+
+    @pytest.mark.asyncio
+    async def test_docuum_dead_relaunches(self, monkeypatch):
+        """docuum pid not alive (should_run=True) → single_run called → docuum relaunched."""
+        task = ImageCleanupTask()
+        runtime = AsyncMock()
+        monkeypatch.setattr(task, "_get_runtime", lambda ip: runtime)
+        monkeypatch.setattr(task, "should_run", AsyncMock(return_value=True))
+        single_run = AsyncMock()
+        monkeypatch.setattr(task, "single_run", single_run)
+        monkeypatch.setattr(task, "_run_prune", AsyncMock(return_value={}))
+
+        await task.run_on_worker("10.0.0.1")
+
+        single_run.assert_awaited_once_with(runtime, "10.0.0.1")
+
+    @pytest.mark.asyncio
+    async def test_prune_runs_before_docuum_check(self, monkeypatch):
+        """Order matters: prune must complete (or fail-soft) BEFORE should_run check.
+
+        Guarantees prune always gets its chance even if should_run later
+        decides to skip docuum launch.
+        """
+        task = ImageCleanupTask()
+        runtime = AsyncMock()
+        call_order = []
+        monkeypatch.setattr(task, "_get_runtime", lambda ip: runtime)
+
+        async def fake_prune(rt):
+            call_order.append("prune")
+            return {}
+
+        async def fake_should_run(rt):
+            call_order.append("should_run")
+            return False
+
+        monkeypatch.setattr(task, "_run_prune", fake_prune)
+        monkeypatch.setattr(task, "should_run", fake_should_run)
+        monkeypatch.setattr(task, "single_run", AsyncMock())
+
+        await task.run_on_worker("10.0.0.1")
+
+        assert call_order == ["prune", "should_run"]


### PR DESCRIPTION
## Summary                                                   
  - Extract `_launch_docuum()` (idempotent-gated) and `_run_prune()` (always runs)
  - Override `run_on_worker()` to always call prune, then conditionally launch docuum                                                 
  - Add tests covering both code paths and the regression scenario                                                                    
                                                                                                                                      
  ## Test plan                                                                                                                        
  - [x] `uv run pytest tests/unit/admin/scheduler/test_image_cleanup_task.py -v` PASS                                                 
  - [x] Pre-prod ops_jobs trigger (`{"tasks": ["image_cleanup"]}`) — prune output observed in admin log on every run regardless of    
  docuum state 
fixes #1022