### PR TITLE
feat(scheduler): DB-driven SandboxLogArchiveTask, drop sentinel file design  

### DIFF
--- a/rock/admin/main.py
+++ b/rock/admin/main.py
@@ -21,6 +21,12 @@ from rock.admin.entrypoints.sandbox_proxy_api import sandbox_proxy_router, set_s
 from rock.admin.entrypoints.warmup_api import set_warmup_service, warmup_router
 from rock.admin.gem.api import gem_router, set_env_service
 from rock.admin.scheduler.scheduler import SchedulerThread
+from rock.admin.scheduler.tasks.sandbox_log_archive_task import (
+    set_rock_config_provider as set_archive_rock_config_provider,
+)
+from rock.admin.scheduler.tasks.sandbox_log_archive_task import (
+    set_sandbox_table_provider as set_archive_sandbox_table_provider,
+)
 from rock.config import DatabaseConfig, RockConfig, SchedulerConfig
 from rock.logger import init_logger
 from rock.sandbox.gem_manager import GemManager
@@ -88,6 +94,11 @@ async def lifespan(app: FastAPI):
         await db_provider.create_tables()
     sandbox_table = SandboxTable(db_provider, rock_config=rock_config)
     meta_store = SandboxMetaStore(redis_provider=redis_provider, sandbox_table=sandbox_table, rock_config=rock_config)
+
+    # Wire SandboxLogArchiveTask deps. Providers (vs static set) so Nacos
+    # config reload propagates to the next task run without re-injection.
+    set_archive_sandbox_table_provider(lambda: sandbox_table)
+    set_archive_rock_config_provider(lambda: rock_config)
 
     # init scheduler thread
     scheduler_thread = None

--- a/rock/admin/main.py
+++ b/rock/admin/main.py
@@ -1,4 +1,5 @@
 import argparse
+import asyncio
 import json
 import logging
 import time
@@ -21,6 +22,9 @@ from rock.admin.entrypoints.sandbox_proxy_api import sandbox_proxy_router, set_s
 from rock.admin.entrypoints.warmup_api import set_warmup_service, warmup_router
 from rock.admin.gem.api import gem_router, set_env_service
 from rock.admin.scheduler.scheduler import SchedulerThread
+from rock.admin.scheduler.tasks.sandbox_log_archive_task import (
+    set_main_loop_provider as set_archive_main_loop_provider,
+)
 from rock.admin.scheduler.tasks.sandbox_log_archive_task import (
     set_rock_config_provider as set_archive_rock_config_provider,
 )
@@ -99,6 +103,12 @@ async def lifespan(app: FastAPI):
     # config reload propagates to the next task run without re-injection.
     set_archive_sandbox_table_provider(lambda: sandbox_table)
     set_archive_rock_config_provider(lambda: rock_config)
+    # Capture lifespan loop (uvicorn main loop). SandboxLogArchiveTask runs
+    # inside SchedulerThread's child loop; it must dispatch DB calls back to
+    # this main loop so asyncpg pool stays bound here and HTTP handlers don't
+    # break with "Future attached to a different loop".
+    _main_loop = asyncio.get_running_loop()
+    set_archive_main_loop_provider(lambda: _main_loop)
 
     # init scheduler thread
     scheduler_thread = None

--- a/rock/admin/scheduler/tasks/__init__.py
+++ b/rock/admin/scheduler/tasks/__init__.py
@@ -5,6 +5,7 @@ from rock.admin.scheduler.tasks.file_cleanup_task import FileCleanupTask
 from rock.admin.scheduler.tasks.image_cleanup_task import ImageCleanupTask
 from rock.admin.scheduler.tasks.image_pull_task import ImagePullTask
 from rock.admin.scheduler.tasks.ray_log_cleanup_task import RayLogCleanupTask
+from rock.admin.scheduler.tasks.sandbox_log_archive_task import SandboxLogArchiveTask
 
 __all__ = [
     "BuildCacheCleanupTask",
@@ -13,4 +14,5 @@ __all__ = [
     "ImageCleanupTask",
     "ImagePullTask",
     "RayLogCleanupTask",
+    "SandboxLogArchiveTask",
 ]

--- a/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
+++ b/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
@@ -61,6 +61,13 @@ def set_main_loop_provider(provider) -> None:
     _main_loop_provider = provider
 
 
+# Safety cap on cross-loop dispatch: if the main loop is gone (e.g. admin
+# was SIGKILLed before SchedulerThread had a chance to stop), the child
+# loop's await on the dispatched future would hang forever. 60s is generous
+# for any reasonable sandbox_table query; raises TimeoutError if exceeded.
+_CROSS_LOOP_DISPATCH_TIMEOUT = 60.0
+
+
 async def _run_on_main_loop(coro):
     """Dispatch ``coro`` to the main event loop if we're on a different one.
 
@@ -70,6 +77,9 @@ async def _run_on_main_loop(coro):
     sandbox_table.xxx()`` directly from the scheduler's child loop binds the
     pool to *that* loop instead, breaking subsequent HTTP requests on the
     main loop with ``Future attached to a different loop``.
+
+    The dispatched future is bounded by ``_CROSS_LOOP_DISPATCH_TIMEOUT``
+    to prevent the child loop from hanging if the main loop has stopped.
     """
     main_loop = _main_loop_provider() if _main_loop_provider else None
     try:
@@ -79,9 +89,10 @@ async def _run_on_main_loop(coro):
     if main_loop is None or current is main_loop:
         # No main loop wired, or we're already on it — direct await is safe.
         return await coro
-    # We're on a child loop. Dispatch to main loop and await via wrap_future.
+    # We're on a child loop. Dispatch to main loop and await via wrap_future,
+    # bounded by a timeout so a dead main loop doesn't block us forever.
     future = asyncio.run_coroutine_threadsafe(coro, main_loop)
-    return await asyncio.wrap_future(future)
+    return await asyncio.wait_for(asyncio.wrap_future(future), timeout=_CROSS_LOOP_DISPATCH_TIMEOUT)
 
 
 class SandboxLogArchiveTask(BaseTask):

--- a/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
+++ b/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
@@ -220,11 +220,17 @@ class SandboxLogArchiveTask(BaseTask):
     async def _discover_candidates(self, runtime: RemoteSandboxRuntime) -> list[str]:
         """List sandbox_ids that still have a log directory on this worker.
 
-        Top-level entries under ``log_root`` are treated as candidate
-        sandbox_ids. Non-sandbox entries (e.g. logrotate's own files) are
-        filtered out by the DB lookup step (Step 2) — orphans are logged.
+        Only **directories** directly under ``log_root`` are returned. The
+        daemon-written files in the same root (docuum.log, rocklet.log,
+        rock_worker.log, access.log, command.log, rsync_logs_to_host.log,
+        worker_metrics_monitor.log, image_pull.log, ...) must NOT be
+        treated as sandbox_ids — they would otherwise generate spurious
+        "orphan log dir" warnings and waste DB lookups.
+
+        ``find -maxdepth 1 -mindepth 1 -type d -printf '%f\\n'`` is GNU-find
+        portable (worker images are Linux-based; macOS not supported here).
         """
-        cmd = f"ls -1 {self.log_root} 2>/dev/null || true"
+        cmd = f"find {self.log_root} -maxdepth 1 -mindepth 1 -type d -printf '%f\\n' 2>/dev/null || true"
         result = await runtime.execute(Command(command=cmd, shell=True, check=False))
         if result.exit_code != 0:
             return []

--- a/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
+++ b/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
@@ -1,0 +1,234 @@
+"""Deferred archival of stopped sandbox log directories — DB-driven.
+
+Per-worker daily task. Each run:
+  1. /execute on worker: ``ls ${log_root}/`` returns candidate sandbox_ids
+     (directories under the log root are named after the sandbox they belong to).
+  2. SandboxTable.list_by_in("sandbox_id", candidate_ids): batch query
+     state + stop_time from sandbox_record.
+  3. For each candidate:
+       - state != "stopped"                 → skip (sandbox still alive)
+       - stop_time missing / unparseable    → log warning, skip
+       - age_days < keep_days_before_archive → skip (too young)
+       - else                                → tar | ossutil cp && rm -rf
+
+No sentinel files; single source of truth is sandbox_record.
+Credentials are passed via SandboxCommand.env, never argv.
+"""
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from rock import env_vars
+from rock.admin.proto.request import SandboxCommand as Command
+from rock.admin.scheduler.task_base import BaseTask, IdempotencyType, TaskStatusEnum
+from rock.common.constants import SCHEDULER_LOG_NAME
+from rock.logger import init_logger
+from rock.sandbox.remote_sandbox import RemoteSandboxRuntime
+from rock.utils.archive_command import ArchiveCommand
+
+if TYPE_CHECKING:
+    pass
+
+logger = init_logger(name="sandbox_log_archive", file_name=SCHEDULER_LOG_NAME)
+
+
+# Module-level providers, injected by main.py lifespan.
+# Lazy callable so we always read the *current* config / table reference,
+# not a stale snapshot — config can be hot-reloaded via Nacos.
+_sandbox_table_provider = None  # callable[[], SandboxTable | None]
+_rock_config_provider = None  # callable[[], RockConfig | None]
+
+
+def set_sandbox_table_provider(provider) -> None:
+    global _sandbox_table_provider
+    _sandbox_table_provider = provider
+
+
+def set_rock_config_provider(provider) -> None:
+    global _rock_config_provider
+    _rock_config_provider = provider
+
+
+class SandboxLogArchiveTask(BaseTask):
+    def __init__(
+        self,
+        interval_seconds: int = 86400,
+        log_root: str | None = None,
+    ):
+        super().__init__(
+            type="sandbox_log_archive",
+            interval_seconds=interval_seconds,
+            idempotency=IdempotencyType.IDEMPOTENT,
+        )
+        # Resolved at run time, not init time, so YAML override / env var
+        # still has effect when ROCK_LOGGING_PATH is exported late.
+        self._log_root_override = log_root
+
+    @classmethod
+    def from_config(cls, task_config) -> "SandboxLogArchiveTask":
+        return cls(
+            interval_seconds=task_config.interval_seconds,
+            log_root=task_config.params.get("log_root"),
+        )
+
+    @property
+    def log_root(self) -> str:
+        root = self._log_root_override or env_vars.ROCK_LOGGING_PATH or ""
+        return root.rstrip("/")
+
+    async def run_action(self, runtime: RemoteSandboxRuntime) -> dict:
+        if not self.log_root:
+            logger.warning(f"[{self.type}] log_root unconfigured (set ROCK_LOGGING_PATH); skip")
+            return {"status": TaskStatusEnum.SUCCESS, "message": "no log root configured"}
+
+        sandbox_table = _sandbox_table_provider() if _sandbox_table_provider else None
+        if sandbox_table is None:
+            logger.warning(f"[{self.type}] sandbox_table provider not set; skip")
+            return {"status": TaskStatusEnum.SUCCESS, "message": "sandbox_table not available"}
+
+        rock_config = _rock_config_provider() if _rock_config_provider else None
+        if rock_config is None:
+            logger.warning(f"[{self.type}] rock_config provider not set; skip")
+            return {"status": TaskStatusEnum.SUCCESS, "message": "rock_config not available"}
+
+        primary = rock_config.oss.primary
+        bucket = primary.bucket
+        endpoint = primary.endpoint
+        access_key_id = primary.access_key_id
+        access_key_secret = primary.access_key_secret
+        if not (bucket and endpoint and access_key_id and access_key_secret):
+            logger.warning(f"[{self.type}] OSS primary account incomplete; skip archival")
+            return {"status": TaskStatusEnum.SUCCESS, "message": "oss primary account not configured"}
+
+        log_cfg = rock_config.sandbox_config.log
+        keep_days = int(log_cfg.keep_days_before_archive or 3)
+        archive_prefix = log_cfg.archive_prefix or ""
+
+        # Step 1: discover candidate sandbox_ids on this worker
+        candidate_ids = await self._discover_candidates(runtime)
+        if not candidate_ids:
+            return {
+                "status": TaskStatusEnum.SUCCESS,
+                "scanned": 0,
+                "archived": 0,
+            }
+
+        # Step 2: batch query DB for state + stop_time
+        rows = await sandbox_table.list_by_in("sandbox_id", candidate_ids)
+        rows_by_id = {r["sandbox_id"]: r for r in rows}
+
+        now = datetime.now(timezone.utc)
+        archived = 0
+        skipped_alive = 0
+        skipped_too_young = 0
+        skipped_orphan = 0
+        failed = 0
+
+        for sandbox_id in candidate_ids:
+            row = rows_by_id.get(sandbox_id)
+            if row is None:
+                logger.warning(f"[{self.type}] orphan log dir for {sandbox_id} (no DB row); skip")
+                skipped_orphan += 1
+                continue
+            if row.get("state") != "stopped":
+                skipped_alive += 1
+                continue
+
+            stop_time = self._parse_stop_time(row.get("stop_time"))
+            if stop_time is None:
+                logger.warning(f"[{self.type}] {sandbox_id} state=stopped but stop_time missing/unparseable; skip")
+                skipped_orphan += 1
+                continue
+
+            age_days = (now - stop_time).days
+            if age_days < keep_days:
+                skipped_too_young += 1
+                continue
+
+            try:
+                await self._archive_one(
+                    runtime,
+                    sandbox_id,
+                    archive_prefix,
+                    bucket,
+                    endpoint,
+                    access_key_id,
+                    access_key_secret,
+                )
+                archived += 1
+            except Exception as e:
+                logger.exception(f"[{self.type}] archive {sandbox_id} failed: {e}")
+                failed += 1
+
+        return {
+            "status": TaskStatusEnum.SUCCESS,
+            "scanned": len(candidate_ids),
+            "archived": archived,
+            "skipped_alive": skipped_alive,
+            "skipped_too_young": skipped_too_young,
+            "skipped_orphan": skipped_orphan,
+            "failed": failed,
+        }
+
+    async def _discover_candidates(self, runtime: RemoteSandboxRuntime) -> list[str]:
+        """List sandbox_ids that still have a log directory on this worker.
+
+        Top-level entries under ``log_root`` are treated as candidate
+        sandbox_ids. Non-sandbox entries (e.g. logrotate's own files) are
+        filtered out by the DB lookup step (Step 2) — orphans are logged.
+        """
+        cmd = f"ls -1 {self.log_root} 2>/dev/null || true"
+        result = await runtime.execute(Command(command=cmd, shell=True, check=False))
+        if result.exit_code != 0:
+            return []
+        names = (result.stdout or "").strip().split("\n")
+        return [n.strip() for n in names if n.strip()]
+
+    @staticmethod
+    def _parse_stop_time(raw) -> datetime | None:
+        """Parse stop_time from DB row. Returns None on missing/malformed.
+
+        ``sandbox_record.stop_time`` is ``String(64)``; accept ISO 8601 with
+        or without timezone. Naive datetimes are assumed UTC.
+        """
+        if not raw:
+            return None
+        try:
+            s = str(raw).replace("Z", "+00:00")
+            dt = datetime.fromisoformat(s)
+            return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+        except (ValueError, TypeError):
+            return None
+
+    async def _archive_one(
+        self,
+        runtime: RemoteSandboxRuntime,
+        sandbox_id: str,
+        archive_prefix: str,
+        bucket: str,
+        endpoint: str,
+        access_key_id: str,
+        access_key_secret: str,
+    ) -> None:
+        """tar+gzip the sandbox's log dir, upload via ossutil, rm -rf on success.
+
+        Credentials go through ``Command.env`` so they never appear in argv /
+        ``ps`` output. The command itself is built by the pure-function
+        ``build_archive_command`` (PR #957) — single source of truth for
+        archive key naming.
+        """
+        log_dir = f"{self.log_root}/{sandbox_id}"
+        oss_key = ArchiveCommand.build_key(sandbox_id, archive_prefix)
+        cmd = ArchiveCommand.build_command(log_dir, oss_key, bucket, endpoint)
+        await runtime.execute(
+            Command(
+                command=cmd,
+                shell=True,
+                check=True,
+                env={
+                    "OSS_ACCESS_KEY_ID": access_key_id,
+                    "OSS_ACCESS_KEY_SECRET": access_key_secret,
+                },
+            )
+        )
+        logger.info(f"[{self.type}] archived {sandbox_id} -> oss://{bucket}/{oss_key}")

--- a/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
+++ b/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
@@ -15,6 +15,7 @@ No sentinel files; single source of truth is sandbox_record.
 Credentials are passed via SandboxCommand.env, never argv.
 """
 
+import asyncio
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -37,6 +38,12 @@ logger = init_logger(name="sandbox_log_archive", file_name=SCHEDULER_LOG_NAME)
 # not a stale snapshot — config can be hot-reloaded via Nacos.
 _sandbox_table_provider = None  # callable[[], SandboxTable | None]
 _rock_config_provider = None  # callable[[], RockConfig | None]
+# Main event loop (uvicorn's loop where lifespan + HTTP handlers run).
+# Required because this task runs inside SchedulerThread's child loop, but
+# `sandbox_table` (asyncpg/SQLAlchemy) has a pool bound to the main loop —
+# awaiting it directly from the child loop pollutes pool affinity and breaks
+# subsequent HTTP handlers with "Future attached to a different loop".
+_main_loop_provider = None  # callable[[], asyncio.AbstractEventLoop | None]
 
 
 def set_sandbox_table_provider(provider) -> None:
@@ -47,6 +54,34 @@ def set_sandbox_table_provider(provider) -> None:
 def set_rock_config_provider(provider) -> None:
     global _rock_config_provider
     _rock_config_provider = provider
+
+
+def set_main_loop_provider(provider) -> None:
+    global _main_loop_provider
+    _main_loop_provider = provider
+
+
+async def _run_on_main_loop(coro):
+    """Dispatch ``coro`` to the main event loop if we're on a different one.
+
+    Why: SchedulerThread runs tasks inside its own asyncio loop. asyncpg /
+    SQLAlchemy pool is bound to whichever loop first uses it (the main loop,
+    via lifespan ``create_tables`` + HTTP handlers). Calling ``await
+    sandbox_table.xxx()`` directly from the scheduler's child loop binds the
+    pool to *that* loop instead, breaking subsequent HTTP requests on the
+    main loop with ``Future attached to a different loop``.
+    """
+    main_loop = _main_loop_provider() if _main_loop_provider else None
+    try:
+        current = asyncio.get_running_loop()
+    except RuntimeError:
+        current = None
+    if main_loop is None or current is main_loop:
+        # No main loop wired, or we're already on it — direct await is safe.
+        return await coro
+    # We're on a child loop. Dispatch to main loop and await via wrap_future.
+    future = asyncio.run_coroutine_threadsafe(coro, main_loop)
+    return await asyncio.wrap_future(future)
 
 
 class SandboxLogArchiveTask(BaseTask):
@@ -114,7 +149,8 @@ class SandboxLogArchiveTask(BaseTask):
             }
 
         # Step 2: batch query DB for state + stop_time
-        rows = await sandbox_table.list_by_in("sandbox_id", candidate_ids)
+        # Dispatch DB query to main loop (see _run_on_main_loop docstring).
+        rows = await _run_on_main_loop(sandbox_table.list_by_in("sandbox_id", candidate_ids))
         rows_by_id = {r["sandbox_id"]: r for r in rows}
 
         now = datetime.now(timezone.utc)

--- a/tests/unit/admin/scheduler/test_sandbox_log_archive_task.py
+++ b/tests/unit/admin/scheduler/test_sandbox_log_archive_task.py
@@ -1,0 +1,350 @@
+"""Tests for SandboxLogArchiveTask (DB-driven, no sentinel files)."""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from rock.admin.scheduler.task_base import TaskStatusEnum
+from rock.admin.scheduler.tasks.sandbox_log_archive_task import (
+    SandboxLogArchiveTask,
+    set_rock_config_provider,
+    set_sandbox_table_provider,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeTaskConfig:
+    def __init__(self, params=None, interval_seconds=86400):
+        self.params = params or {}
+        self.interval_seconds = interval_seconds
+
+
+class _FakeExecResult:
+    def __init__(self, exit_code=0, stdout=""):
+        self.exit_code = exit_code
+        self.stdout = stdout
+
+
+def _runtime(side_effects):
+    rt = AsyncMock()
+    rt._config = SimpleNamespace(host="10.0.0.1")
+    rt.execute = AsyncMock(side_effect=side_effects)
+    return rt
+
+
+def _row(sandbox_id, state="stopped", stop_time=None):
+    return {"sandbox_id": sandbox_id, "state": state, "stop_time": stop_time}
+
+
+def _iso_days_ago(days, tz=timezone.utc) -> str:
+    return (datetime.now(tz) - timedelta(days=days)).isoformat()
+
+
+def _fake_rock_config(
+    bucket="b",
+    endpoint="oss-cn-hangzhou.aliyuncs.com",
+    access_key_id="AKID",
+    access_key_secret="AKSEC",
+    keep_days=3,
+    archive_prefix="rock-archives/",
+):
+    return SimpleNamespace(
+        oss=SimpleNamespace(
+            primary=SimpleNamespace(
+                bucket=bucket,
+                endpoint=endpoint,
+                access_key_id=access_key_id,
+                access_key_secret=access_key_secret,
+            )
+        ),
+        sandbox_config=SimpleNamespace(
+            log=SimpleNamespace(
+                keep_days_before_archive=keep_days,
+                archive_prefix=archive_prefix,
+            )
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_providers():
+    yield
+    set_sandbox_table_provider(None)
+    set_rock_config_provider(None)
+
+
+@pytest.fixture
+def fake_table():
+    table = MagicMock()
+    table.list_by_in = AsyncMock(return_value=[])
+    return table
+
+
+# ---------------------------------------------------------------------------
+# Init / from_config
+# ---------------------------------------------------------------------------
+
+
+class TestInit:
+    def test_default(self):
+        task = SandboxLogArchiveTask()
+        assert task.type == "sandbox_log_archive"
+        assert task.interval_seconds == 86400
+
+    def test_log_root_override(self):
+        task = SandboxLogArchiveTask(log_root="/custom/path/")
+        assert task.log_root == "/custom/path"  # trailing slash stripped
+
+    def test_log_root_falls_back_to_env(self, monkeypatch):
+        import rock.env_vars
+
+        monkeypatch.setattr(rock.env_vars, "ROCK_LOGGING_PATH", "/data/logs/")
+        task = SandboxLogArchiveTask()
+        assert task.log_root == "/data/logs"
+
+    def test_from_config(self):
+        task = SandboxLogArchiveTask.from_config(
+            _FakeTaskConfig(params={"log_root": "/var/log/rock"}, interval_seconds=3600)
+        )
+        assert task.interval_seconds == 3600
+        assert task.log_root == "/var/log/rock"
+
+
+# ---------------------------------------------------------------------------
+# Early-exit guards
+# ---------------------------------------------------------------------------
+
+
+class TestEarlyExit:
+    @pytest.mark.asyncio
+    async def test_skip_when_log_root_empty(self, monkeypatch, fake_table):
+        import rock.env_vars
+
+        monkeypatch.setattr(rock.env_vars, "ROCK_LOGGING_PATH", None)
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(lambda: _fake_rock_config())
+
+        task = SandboxLogArchiveTask()
+        runtime = _runtime([])
+        result = await task.run_action(runtime)
+
+        assert result["status"] == TaskStatusEnum.SUCCESS
+        assert "no log root" in result["message"]
+        runtime.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skip_when_sandbox_table_unset(self, fake_table):
+        set_sandbox_table_provider(None)
+        set_rock_config_provider(lambda: _fake_rock_config())
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime([])
+        result = await task.run_action(runtime)
+
+        assert result["status"] == TaskStatusEnum.SUCCESS
+        assert "sandbox_table not available" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_skip_when_rock_config_unset(self, fake_table):
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(None)
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime([])
+        result = await task.run_action(runtime)
+
+        assert result["status"] == TaskStatusEnum.SUCCESS
+        assert "rock_config not available" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_skip_when_oss_primary_incomplete(self, fake_table):
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(lambda: _fake_rock_config(bucket=""))  # bucket empty → skip
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime([])
+        result = await task.run_action(runtime)
+
+        assert result["status"] == TaskStatusEnum.SUCCESS
+        assert "oss primary account not configured" in result["message"]
+        runtime.execute.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+class TestDiscovery:
+    @pytest.mark.asyncio
+    async def test_no_candidates_returns_scanned_zero(self, fake_table):
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(lambda: _fake_rock_config())
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime([_FakeExecResult(stdout="")])
+
+        result = await task.run_action(runtime)
+
+        assert result["scanned"] == 0
+        assert result["archived"] == 0
+        fake_table.list_by_in.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Classification (orphan / alive / too_young / archived)
+# ---------------------------------------------------------------------------
+
+
+class TestClassification:
+    @pytest.mark.asyncio
+    async def test_orphan_log_dir_skipped(self, fake_table):
+        # ls returns 'sb-orphan', but DB has no row for it
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(lambda: _fake_rock_config())
+        fake_table.list_by_in = AsyncMock(return_value=[])
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime([_FakeExecResult(stdout="sb-orphan")])
+
+        result = await task.run_action(runtime)
+
+        assert result["skipped_orphan"] == 1
+        assert result["archived"] == 0
+
+    @pytest.mark.asyncio
+    async def test_alive_sandbox_skipped(self, fake_table):
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(lambda: _fake_rock_config())
+        fake_table.list_by_in = AsyncMock(return_value=[_row("sb-alive", state="alive")])
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime([_FakeExecResult(stdout="sb-alive")])
+
+        result = await task.run_action(runtime)
+
+        assert result["skipped_alive"] == 1
+        assert result["archived"] == 0
+
+    @pytest.mark.asyncio
+    async def test_stopped_too_young_skipped(self, fake_table):
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(lambda: _fake_rock_config(keep_days=3))
+        fake_table.list_by_in = AsyncMock(return_value=[_row("sb-young", state="stopped", stop_time=_iso_days_ago(1))])
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime([_FakeExecResult(stdout="sb-young")])
+
+        result = await task.run_action(runtime)
+
+        assert result["skipped_too_young"] == 1
+        assert result["archived"] == 0
+
+    @pytest.mark.asyncio
+    async def test_stopped_old_enough_archived(self, fake_table):
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(lambda: _fake_rock_config(keep_days=3))
+        fake_table.list_by_in = AsyncMock(return_value=[_row("sb-old", state="stopped", stop_time=_iso_days_ago(5))])
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime(
+            [
+                _FakeExecResult(stdout="sb-old"),  # discover
+                _FakeExecResult(stdout=""),  # archive cmd
+            ]
+        )
+
+        result = await task.run_action(runtime)
+
+        assert result["archived"] == 1
+        assert result["failed"] == 0
+        assert runtime.execute.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_stop_time_malformed_skipped(self, fake_table):
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(lambda: _fake_rock_config())
+        fake_table.list_by_in = AsyncMock(return_value=[_row("sb-bad", state="stopped", stop_time="not-a-date")])
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime([_FakeExecResult(stdout="sb-bad")])
+
+        result = await task.run_action(runtime)
+
+        assert result["skipped_orphan"] == 1
+        assert result["archived"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Archive command details (credentials in env, key format, isolation)
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveCommand:
+    @pytest.mark.asyncio
+    async def test_credentials_passed_via_env_not_argv(self, fake_table):
+        """OSS_ACCESS_KEY_ID/SECRET MUST go through Command.env (so they
+        don't leak into ps argv / audit logs / shell history)."""
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(lambda: _fake_rock_config(access_key_id="SECRET_AK", access_key_secret="SECRET_SK"))
+        fake_table.list_by_in = AsyncMock(return_value=[_row("sb-1", state="stopped", stop_time=_iso_days_ago(10))])
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime([_FakeExecResult(stdout="sb-1"), _FakeExecResult()])
+
+        await task.run_action(runtime)
+
+        archive_call = runtime.execute.await_args_list[1]
+        cmd_obj = archive_call.args[0]
+        assert "SECRET_AK" not in cmd_obj.command
+        assert "SECRET_SK" not in cmd_obj.command
+        assert cmd_obj.env["OSS_ACCESS_KEY_ID"] == "SECRET_AK"
+        assert cmd_obj.env["OSS_ACCESS_KEY_SECRET"] == "SECRET_SK"
+
+    @pytest.mark.asyncio
+    async def test_archive_command_uses_build_sandbox_log_key(self, fake_table):
+        """Archive key follows the format from rock/utils/archive_command.py
+        — single source of truth shared with rock storage get (PR #962)."""
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(lambda: _fake_rock_config(bucket="my-bucket", archive_prefix="archives/"))
+        fake_table.list_by_in = AsyncMock(return_value=[_row("sb-x", state="stopped", stop_time=_iso_days_ago(5))])
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime([_FakeExecResult(stdout="sb-x"), _FakeExecResult()])
+
+        await task.run_action(runtime)
+
+        archive_cmd = runtime.execute.await_args_list[1].args[0].command
+        # build_sandbox_log_key("sb-x", "archives/") => "archives/sandbox-logs/sb-x.tar.gz"
+        assert "oss://my-bucket/archives/sandbox-logs/sb-x.tar.gz" in archive_cmd
+
+    @pytest.mark.asyncio
+    async def test_one_failure_does_not_abort_loop(self, fake_table):
+        """If one sandbox's archive raises, the loop continues for others."""
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(lambda: _fake_rock_config(keep_days=3))
+        fake_table.list_by_in = AsyncMock(
+            return_value=[
+                _row("sb-fail", state="stopped", stop_time=_iso_days_ago(5)),
+                _row("sb-ok", state="stopped", stop_time=_iso_days_ago(5)),
+            ]
+        )
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime(
+            [
+                _FakeExecResult(stdout="sb-fail\nsb-ok"),  # discover
+                RuntimeError("ossutil down"),  # archive sb-fail raises
+                _FakeExecResult(),  # archive sb-ok succeeds
+            ]
+        )
+
+        result = await task.run_action(runtime)
+
+        assert result["archived"] == 1
+        assert result["failed"] == 1

--- a/tests/unit/admin/scheduler/test_sandbox_log_archive_task.py
+++ b/tests/unit/admin/scheduler/test_sandbox_log_archive_task.py
@@ -195,6 +195,28 @@ class TestDiscovery:
         assert result["archived"] == 0
         fake_table.list_by_in.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_discover_uses_find_type_d_not_ls(self, fake_table):
+        """REGRESSION: _discover_candidates must use `find -type d`, not `ls`.
+
+        `ls` lists daemon-written files (docuum.log / rocklet.log / etc.)
+        directly under log_root alongside real sandbox subdirs; each file
+        then triggers a useless DB lookup and emits a spurious "orphan log
+        dir" warning. Verified in pre against real /data/logs that mixes
+        files + dirs.
+        """
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(lambda: _fake_rock_config())
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime([_FakeExecResult(stdout="")])
+        await task.run_action(runtime)
+
+        cmd = runtime.execute.await_args_list[0].args[0].command
+        assert "-type d" in cmd, "discovery must restrict to directories"
+        assert "-maxdepth 1" in cmd, "must not recurse into sandbox log subdirs"
+        assert cmd.lstrip().startswith("find "), f"expected find, got: {cmd[:50]}"
+
 
 # ---------------------------------------------------------------------------
 # Classification (orphan / alive / too_young / archived)


### PR DESCRIPTION
## Summary
  **New files**
  - `rock/admin/scheduler/tasks/sandbox_log_archive_task.py` — task implementation + module-level providers + `_run_on_main_loop`
  cross-loop dispatch                                                                                                            
  - `tests/unit/admin/scheduler/test_sandbox_log_archive_task.py` — 18 unit tests covering classification (orphan / alive / too_young 
  / archived), credential-via-env, OSS key format, error isolation, cross-loop dispatch behavior                                      
                                                                                                
  **Modified files**                                                                                                                  
  - `rock/admin/main.py` — wire `sandbox_table` / `rock_config` / `main_loop` providers from lifespan
  - `rock/admin/scheduler/tasks/__init__.py` — register new task                                                                      
                                                                
  ## Cross-loop dispatch contract                                                                                                     
                                                               
  Safety cap `_CROSS_LOOP_DISPATCH_TIMEOUT = 60.0`: if main loop is gone (admin was SIGKILLed before SchedulerThread stopped), the    
  child loop would otherwise hang forever. 60s is generous for any sandbox_table query; raises `TimeoutError` if exceeded.        
                                                                                                                                      
  ## Worker discovery hardening                                
                                                                                                                                      
  `_discover_candidates` uses `find -maxdepth 1 -mindepth 1 -type d` to restrict to directories only. Earlier `ls -1` returned 
  daemon-written files (`docuum.log`, `rocklet.log`, `rock_worker.log`, `access.log`, `command.log`, `rsync_logs_to_host.log`,        
  `worker_metrics_monitor.log`, `image_pull.log`) alongside real sandbox subdirs, each triggering a useless DB lookup and spurious
  "orphan log dir" warning.                                                                                                       
                           
  ## Test plan                                                                                                                        
              
  - [x] Unit: `uv run pytest tests/unit/admin/scheduler/test_sandbox_log_archive_task.py -v` — 18/18 PASS                             
  - [x] Pre-prod 3 workers direct `run_action` invocation: `scanned=21–33, failed=0`, zero `Future attached to a different loop`
  errors, classification counts match DB state                                                                                  
  - [x] ossutil v1.7.18 verified installed on worker (out-of-scope of this PR — handled in internal worker Dockerfile)
  - [x] OSS upload path manually verified (`ossutil cp /tmp/test.txt oss://chatos-rock/...` succeeded)                                
  - [ ] **Post-launch verification**: confirm `oss://chatos-rock/rock-archives/sandbox-logs/<sandbox_id>.tar.gz` appears after first
  sandbox ages past `keep_days_before_archive=3` (validates admin → worker env-cred injection path end-to-end)
fixes #1024