### PR TITLE
feat(scheduler): RayLogCleanupTask 4-stage cleanup of session_latest/logs

### DIFF
--- a/rock/admin/scheduler/tasks/ray_log_cleanup_task.py
+++ b/rock/admin/scheduler/tasks/ray_log_cleanup_task.py
@@ -51,6 +51,7 @@ class RayLogCleanupTask(BaseTask):
         min_age_hours: int = 24,
         live_log_keep_days: int = 7,
         old_logs_keep_hours: int = 24,
+        setup_log_keep_minutes: int = 60,
     ):
         """
         Args:
@@ -63,6 +64,11 @@ class RayLogCleanupTask(BaseTask):
             old_logs_keep_hours: Mtime threshold for files under
                 session_latest/logs/old/ (Ray's own rotation backups).
                 Default 24 hours.
+            setup_log_keep_minutes: Mtime threshold for runtime_env_setup-*
+                files. These are one-shot Ray runtime-env materialisation
+                scripts whose trailing token is a Ray job id (digit OR hex),
+                NOT a Linux PID — PART 2a's PID probe is meaningless for them.
+                Default 60min (matches PART 2a race-window guard).
         """
         super().__init__(
             type="ray_log_cleanup",
@@ -75,10 +81,13 @@ class RayLogCleanupTask(BaseTask):
             raise ValueError(f"ray_log_cleanup.live_log_keep_days must be >= 1, got {live_log_keep_days}")
         if old_logs_keep_hours < 1:
             raise ValueError(f"ray_log_cleanup.old_logs_keep_hours must be >= 1, got {old_logs_keep_hours}")
+        if setup_log_keep_minutes < 1:
+            raise ValueError(f"ray_log_cleanup.setup_log_keep_minutes must be >= 1, got {setup_log_keep_minutes}")
         self.ray_temp_dir = ray_temp_dir.rstrip("/")
         self.min_age_hours = min_age_hours
         self.live_log_keep_days = live_log_keep_days
         self.old_logs_keep_hours = old_logs_keep_hours
+        self.setup_log_keep_minutes = setup_log_keep_minutes
 
     @classmethod
     def from_config(cls, task_config) -> "RayLogCleanupTask":
@@ -88,6 +97,7 @@ class RayLogCleanupTask(BaseTask):
             min_age_hours=task_config.params.get("min_age_hours", 24),
             live_log_keep_days=task_config.params.get("live_log_keep_days", 7),
             old_logs_keep_hours=task_config.params.get("old_logs_keep_hours", 24),
+            setup_log_keep_minutes=task_config.params.get("setup_log_keep_minutes", 60),
         )
 
     async def run_action(self, runtime: RemoteSandboxRuntime) -> dict:
@@ -95,11 +105,14 @@ class RayLogCleanupTask(BaseTask):
         session_age_min = self.min_age_hours * 60
         live_age_min = self.live_log_keep_days * 24 * 60
         old_age_min = self.old_logs_keep_hours * 60
+        setup_age_min = self.setup_log_keep_minutes
 
-        # 3-stage shell pipeline:
-        #   PART 1 — drop stale full session_<ts>_<pid> dirs
-        #   PART 2 — session_latest/logs/ per-file: PID-aware + mtime fallback
-        #   PART 3 — session_latest/logs/old/ time-based
+        # 4-stage shell pipeline:
+        #   PART 1  — drop stale full session_<ts>_<pid> dirs
+        #   PART 2a — session_latest/logs/ PID-aware (worker/runtime_env_setup with digit pid)
+        #   PART 2c — session_latest/logs/ runtime_env_setup-* mtime-only (covers hex variant)
+        #   PART 2b — session_latest/logs/ non-PID, non-daemon stale (long tail)
+        #   PART 3  — session_latest/logs/old/ time-based
         #
         # textwrap.dedent strips common leading whitespace so source can be
         # indented for readability without polluting the emitted shell.
@@ -155,6 +168,21 @@ class RayLogCleanupTask(BaseTask):
                   fi
                 done
 
+              # PART 2c: runtime_env_setup-* — one-shot Ray runtime-env
+              # materialisation scripts. Trailing token is a Ray job id,
+              # NOT a PID; comes in two flavours:
+              #   - pure digits: `runtime_env_setup-31050000.log` — accidentally
+              #     removed by PART 2a (digit > pid_max → kill -0 fails)
+              #   - hex: `runtime_env_setup-f4060000.log` — skipped by PART 2a
+              #     (regex needs digits) and waited 7d for PART 2b
+              # Same retention window as PART 2a ({setup_age_min}min default)
+              # to avoid races with in-flight setups while clearing the bulk.
+              find "$LOGS" -maxdepth 1 -type f -mmin +{setup_age_min} \\
+                  -name 'runtime_env_setup-*' \\
+              | while read -r f; do
+                  rm -f "$f" && echo "removed_setup=$(basename "$f")"
+                done
+
               # PART 2b: non-PID, non-daemon stale files older than
               # {self.live_log_keep_days} days. Daemon files (raylet*,
               # gcs_server*, runtime_env_agent*, dashboard*, monitor*,
@@ -194,13 +222,15 @@ class RayLogCleanupTask(BaseTask):
         # `removed=<sess>` retained for backward compat (PART 1 session dirs).
         removed_sessions = [line.split("=", 1)[1] for line in output.splitlines() if line.startswith("removed=")]
         removed_dead_pid = sum(1 for line in output.splitlines() if line.startswith("removed_dead_pid_log="))
+        removed_setup = sum(1 for line in output.splitlines() if line.startswith("removed_setup="))
         removed_stale = sum(1 for line in output.splitlines() if line.startswith("removed_stale_file="))
         removed_old = sum(1 for line in output.splitlines() if line.startswith("removed_old="))
 
         logger.info(
             f"[{self.type}] [{runtime._config.host}] ray_log_cleanup done: "
             f"sessions={len(removed_sessions)}, dead_pid={removed_dead_pid}, "
-            f"stale={removed_stale}, old={removed_old}, output_head={output[:300]}"
+            f"setup={removed_setup}, stale={removed_stale}, old={removed_old}, "
+            f"output_head={output[:300]}"
         )
         return {
             "status": TaskStatusEnum.SUCCESS,
@@ -210,6 +240,7 @@ class RayLogCleanupTask(BaseTask):
             "removed_sessions": removed_sessions,
             # New per-category counters:
             "removed_dead_pid_count": removed_dead_pid,
+            "removed_setup_count": removed_setup,
             "removed_stale_count": removed_stale,
             "removed_old_count": removed_old,
             "output_head": output[:1500],

--- a/rock/admin/scheduler/tasks/ray_log_cleanup_task.py
+++ b/rock/admin/scheduler/tasks/ray_log_cleanup_task.py
@@ -1,4 +1,17 @@
-"""Drop stale /data/tmp/ray/session_* dirs on each worker."""
+"""Clean up Ray temp dir on each worker.
+
+Three layers of cleanup, run together in one shell pipeline:
+  1. Stale full ``session_<ts>_<pid>`` dirs (excluding the live session).
+  2. Inside ``session_latest/logs/``: per-file PID-aware cleanup
+     (delete files whose PID is no longer alive) plus an mtime fallback
+     for non-PID, non-daemon files.
+  3. Inside ``session_latest/logs/old/``: time-based cleanup of Ray's
+     own rotation backups.
+
+Daemon-written files (raylet*, gcs_server*, runtime_env_agent*, etc.)
+are NEVER deleted while the session is alive — Ray holds open fds, so
+removing the inode wouldn't free disk and breaks log following.
+"""
 
 import textwrap
 
@@ -12,18 +25,23 @@ logger = init_logger(name="ray_log_cleanup", file_name=SCHEDULER_LOG_NAME)
 
 
 class RayLogCleanupTask(BaseTask):
-    """Drop /data/tmp/ray/session_* dirs that are NOT the live session.
+    """Clean Ray temp dir: stale session dirs + active session per-file cleanup.
 
     Ray restarts (cluster up/down, head failover) leave dozens of
-    session_<timestamp>_<pid> dirs behind. The currently active one is
-    symlinked as `session_latest`; we resolve that link and skip its target.
-    Sessions younger than `min_age_hours` are also kept as a buffer against
-    a stale symlink.
+    ``session_<timestamp>_<pid>`` dirs behind. The currently active one is
+    symlinked as ``session_latest``; we resolve that link and skip its target
+    when removing stale session dirs.
+
+    Inside the live ``session_latest/logs/``, Ray accumulates per-worker
+    logs (named after the worker PID) that are never reaped after the
+    worker exits, plus its own rotation backups under ``logs/old/`` that
+    Ray never cleans. Without intervention, file count grows to tens or
+    hundreds of thousands on long-running clusters.
 
     NOTE: This is the WORKER side. The ray-head's /data/tmp/ray is cleaned
     by a daily cron baked into the head Dockerfile (rock-internal repo);
     rocklet is not deployed on the head and the worker scheduler does not
-    reach it.
+    reach it. The cron script mirrors this task's shell pipeline.
     """
 
     def __init__(
@@ -31,6 +49,8 @@ class RayLogCleanupTask(BaseTask):
         interval_seconds: int = 86400,
         ray_temp_dir: str = "/data/tmp/ray",
         min_age_hours: int = 24,
+        live_log_keep_days: int = 7,
+        old_logs_keep_hours: int = 24,
     ):
         """
         Args:
@@ -38,6 +58,11 @@ class RayLogCleanupTask(BaseTask):
             ray_temp_dir: Ray's --temp-dir, default /data/tmp/ray.
             min_age_hours: Only delete session dirs whose mtime is older than
                 this AND that are not session_latest. Default 24h.
+            live_log_keep_days: Mtime threshold for non-PID, non-daemon files
+                in session_latest/logs/. Default 7 days.
+            old_logs_keep_hours: Mtime threshold for files under
+                session_latest/logs/old/ (Ray's own rotation backups).
+                Default 24 hours.
         """
         super().__init__(
             type="ray_log_cleanup",
@@ -46,8 +71,14 @@ class RayLogCleanupTask(BaseTask):
         )
         if min_age_hours < 1:
             raise ValueError(f"ray_log_cleanup.min_age_hours must be >= 1, got {min_age_hours}")
+        if live_log_keep_days < 1:
+            raise ValueError(f"ray_log_cleanup.live_log_keep_days must be >= 1, got {live_log_keep_days}")
+        if old_logs_keep_hours < 1:
+            raise ValueError(f"ray_log_cleanup.old_logs_keep_hours must be >= 1, got {old_logs_keep_hours}")
         self.ray_temp_dir = ray_temp_dir.rstrip("/")
         self.min_age_hours = min_age_hours
+        self.live_log_keep_days = live_log_keep_days
+        self.old_logs_keep_hours = old_logs_keep_hours
 
     @classmethod
     def from_config(cls, task_config) -> "RayLogCleanupTask":
@@ -55,44 +86,116 @@ class RayLogCleanupTask(BaseTask):
             interval_seconds=task_config.interval_seconds,
             ray_temp_dir=task_config.params.get("ray_temp_dir", "/data/tmp/ray"),
             min_age_hours=task_config.params.get("min_age_hours", 24),
+            live_log_keep_days=task_config.params.get("live_log_keep_days", 7),
+            old_logs_keep_hours=task_config.params.get("old_logs_keep_hours", 24),
         )
 
     async def run_action(self, runtime: RemoteSandboxRuntime) -> dict:
         ray_dir = self.ray_temp_dir
-        max_age_min = self.min_age_hours * 60
-        # Resolve session_latest -> live basename, then list session_* dirs
-        # older than threshold and rm -rf those that are not the live one.
+        session_age_min = self.min_age_hours * 60
+        live_age_min = self.live_log_keep_days * 24 * 60
+        old_age_min = self.old_logs_keep_hours * 60
+
+        # 3-stage shell pipeline:
+        #   PART 1 — drop stale full session_<ts>_<pid> dirs
+        #   PART 2 — session_latest/logs/ per-file: PID-aware + mtime fallback
+        #   PART 3 — session_latest/logs/old/ time-based
+        #
         # textwrap.dedent strips common leading whitespace so source can be
         # indented for readability without polluting the emitted shell.
         command = textwrap.dedent(
             f"""\
-            if [ -d "{ray_dir}" ]; then
-              LIVE=$(readlink "{ray_dir}/session_latest" 2>/dev/null | xargs -I{{}} basename {{}} 2>/dev/null)
-              echo "live_session=${{LIVE:-<none>}}"
-              find "{ray_dir}" -maxdepth 1 -type d -name "session_*" \\
-                ! -name "session_latest" -mmin +{max_age_min} \\
-              | while read -r d; do
-                  bn=$(basename "$d")
-                  if [ "$bn" != "$LIVE" ]; then
-                    rm -rf "$d" && echo "removed=$bn"
+            set +e
+            if [ ! -d "{ray_dir}" ]; then
+              echo "ray_temp_dir_not_found"
+              exit 0
+            fi
+
+            # PART 1: stale full session_<ts>_<pid> dirs (not session_latest)
+            LIVE=$(readlink "{ray_dir}/session_latest" 2>/dev/null | xargs -I{{}} basename {{}} 2>/dev/null)
+            echo "live_session=${{LIVE:-<none>}}"
+            find "{ray_dir}" -maxdepth 1 -type d -name "session_*" \\
+              ! -name "session_latest" -mmin +{session_age_min} \\
+            | while read -r d; do
+                bn=$(basename "$d")
+                if [ "$bn" != "$LIVE" ]; then
+                  rm -rf "$d" && echo "removed=$bn"
+                fi
+              done
+
+            LOGS="{ray_dir}/session_latest/logs"
+            if [ -d "$LOGS" ]; then
+              # PART 2a: PID-aware — files matching *[_-]<pid>.{{log,err,out}}
+              # Probe `kill -0 <pid>`; if PID is dead, remove. Only files older
+              # than 60 minutes are considered, to avoid racing with new
+              # worker startups still writing their first log line.
+              find "$LOGS" -maxdepth 1 -type f -mmin +60 \\
+                  -regextype posix-extended \\
+                  -regex '.*[_-][0-9]+\\.(log|err|out)$' \\
+              | while read -r f; do
+                  bn=$(basename "$f")
+                  pid=$(echo "$bn" | grep -oE '[_-][0-9]+\\.(log|err|out)$' | grep -oE '[0-9]+' | head -1)
+                  [ -z "$pid" ] && continue
+                  if ! kill -0 "$pid" 2>/dev/null; then
+                    rm -f "$f" && echo "removed_dead_pid_log=$bn"
                   fi
                 done
-              echo "ray_log_cleanup_done"
-            else
-              echo "ray_temp_dir_not_found"
-            fi"""
+
+              # PART 2b: non-PID, non-daemon stale files older than
+              # {self.live_log_keep_days} days. Daemon files (raylet*,
+              # gcs_server*, runtime_env_agent*, dashboard*, monitor*,
+              # log_monitor*) are NEVER deleted while session is alive —
+              # Ray holds open fds, removal wouldn't free disk.
+              find "$LOGS" -maxdepth 1 -type f -mmin +{live_age_min} \\
+                  -regextype posix-extended \\
+                  ! -regex '.*[_-][0-9]+\\.(log|err|out)$' \\
+                  ! -name 'raylet*' \\
+                  ! -name 'gcs_server*' \\
+                  ! -name 'runtime_env_agent*' \\
+                  ! -name 'dashboard*' \\
+                  ! -name 'monitor*' \\
+                  ! -name 'log_monitor*' \\
+              | while read -r f; do
+                  rm -f "$f" && echo "removed_stale_file=$(basename "$f")"
+                done
+            fi
+
+            # PART 3: session_latest/logs/old/ — Ray's own rotation backups
+            OLD="$LOGS/old"
+            if [ -d "$OLD" ]; then
+              find "$OLD" -type f -mmin +{old_age_min} \\
+              | while read -r f; do
+                  rm -f "$f" && echo "removed_old=$(basename "$f")"
+                done
+            fi
+
+            echo "ray_log_cleanup_done"
+            """
         )
         result = await runtime.execute(Command(command=command, shell=True, check=False))
         output = (result.stdout or "").strip()
-        removed = [line.split("=", 1)[1] for line in output.splitlines() if line.startswith("removed=")]
+
+        # Parse per-category removal counts from output.
+        # `removed=<sess>` retained for backward compat (PART 1 session dirs).
+        removed_sessions = [line.split("=", 1)[1] for line in output.splitlines() if line.startswith("removed=")]
+        removed_dead_pid = sum(1 for line in output.splitlines() if line.startswith("removed_dead_pid_log="))
+        removed_stale = sum(1 for line in output.splitlines() if line.startswith("removed_stale_file="))
+        removed_old = sum(1 for line in output.splitlines() if line.startswith("removed_old="))
+
         logger.info(
             f"[{self.type}] [{runtime._config.host}] ray_log_cleanup done: "
-            f"removed={len(removed)} sessions, output_head={output[:300]}"
+            f"sessions={len(removed_sessions)}, dead_pid={removed_dead_pid}, "
+            f"stale={removed_stale}, old={removed_old}, output_head={output[:300]}"
         )
         return {
             "status": TaskStatusEnum.SUCCESS,
             "exit_code": result.exit_code,
-            "removed_count": len(removed),
-            "removed_sessions": removed,
-            "output_head": output[:1000],
+            # Backward-compatible fields (session-level removal):
+            "removed_count": len(removed_sessions),
+            "removed_sessions": removed_sessions,
+            # New per-category counters:
+            "removed_dead_pid_count": removed_dead_pid,
+            "removed_stale_count": removed_stale,
+            "removed_old_count": removed_old,
+            "output_head": output[:1500],
         }

--- a/rock/admin/scheduler/tasks/ray_log_cleanup_task.py
+++ b/rock/admin/scheduler/tasks/ray_log_cleanup_task.py
@@ -129,9 +129,23 @@ class RayLogCleanupTask(BaseTask):
               # Probe `kill -0 <pid>`; if PID is dead, remove. Only files older
               # than 60 minutes are considered, to avoid racing with new
               # worker startups still writing their first log line.
+              #
+              # Daemon files are excluded by name FIRST (same whitelist as
+              # PART 2b). Without this guard, names like `agent-<id>.err` —
+              # where <id> is a Ray-generated agent identifier, NOT a PID —
+              # match the PID regex; kill -0 <id> fails because <id> exceeds
+              # the Linux PID range, so the file gets wrongly removed even
+              # though Ray's runtime env agent is still writing to it.
               find "$LOGS" -maxdepth 1 -type f -mmin +60 \\
                   -regextype posix-extended \\
                   -regex '.*[_-][0-9]+\\.(log|err|out)$' \\
+                  ! -name 'raylet*' \\
+                  ! -name 'gcs_server*' \\
+                  ! -name 'runtime_env_agent*' \\
+                  ! -name 'dashboard*' \\
+                  ! -name 'monitor*' \\
+                  ! -name 'log_monitor*' \\
+                  ! -name 'agent-*' \\
               | while read -r f; do
                   bn=$(basename "$f")
                   pid=$(echo "$bn" | grep -oE '[_-][0-9]+\\.(log|err|out)$' | grep -oE '[0-9]+' | head -1)
@@ -144,8 +158,8 @@ class RayLogCleanupTask(BaseTask):
               # PART 2b: non-PID, non-daemon stale files older than
               # {self.live_log_keep_days} days. Daemon files (raylet*,
               # gcs_server*, runtime_env_agent*, dashboard*, monitor*,
-              # log_monitor*) are NEVER deleted while session is alive —
-              # Ray holds open fds, removal wouldn't free disk.
+              # log_monitor*, agent-*) are NEVER deleted while session is
+              # alive — Ray holds open fds, removal wouldn't free disk.
               find "$LOGS" -maxdepth 1 -type f -mmin +{live_age_min} \\
                   -regextype posix-extended \\
                   ! -regex '.*[_-][0-9]+\\.(log|err|out)$' \\
@@ -155,6 +169,7 @@ class RayLogCleanupTask(BaseTask):
                   ! -name 'dashboard*' \\
                   ! -name 'monitor*' \\
                   ! -name 'log_monitor*' \\
+                  ! -name 'agent-*' \\
               | while read -r f; do
                   rm -f "$f" && echo "removed_stale_file=$(basename "$f")"
                 done

--- a/rock/admin/scheduler/tasks/ray_log_cleanup_task.py
+++ b/rock/admin/scheduler/tasks/ray_log_cleanup_task.py
@@ -52,6 +52,7 @@ class RayLogCleanupTask(BaseTask):
         live_log_keep_days: int = 7,
         old_logs_keep_hours: int = 24,
         setup_log_keep_minutes: int = 60,
+        rotated_daemon_keep_hours: int = 24,
     ):
         """
         Args:
@@ -69,6 +70,11 @@ class RayLogCleanupTask(BaseTask):
                 scripts whose trailing token is a Ray job id (digit OR hex),
                 NOT a Linux PID — PART 2a's PID probe is meaningless for them.
                 Default 60min (matches PART 2a race-window guard).
+            rotated_daemon_keep_hours: Mtime threshold for rotated daemon log
+                files (raylet.N.out, gcs_server.N.err, etc.). Ray performs
+                in-place rotation: active file (raylet.out) stays open with
+                an fd held; rotated copies (raylet.1.out, raylet.2.out, ...)
+                have NO open fd and are safe to delete. Default 24h.
         """
         super().__init__(
             type="ray_log_cleanup",
@@ -83,11 +89,14 @@ class RayLogCleanupTask(BaseTask):
             raise ValueError(f"ray_log_cleanup.old_logs_keep_hours must be >= 1, got {old_logs_keep_hours}")
         if setup_log_keep_minutes < 1:
             raise ValueError(f"ray_log_cleanup.setup_log_keep_minutes must be >= 1, got {setup_log_keep_minutes}")
+        if rotated_daemon_keep_hours < 1:
+            raise ValueError(f"ray_log_cleanup.rotated_daemon_keep_hours must be >= 1, got {rotated_daemon_keep_hours}")
         self.ray_temp_dir = ray_temp_dir.rstrip("/")
         self.min_age_hours = min_age_hours
         self.live_log_keep_days = live_log_keep_days
         self.old_logs_keep_hours = old_logs_keep_hours
         self.setup_log_keep_minutes = setup_log_keep_minutes
+        self.rotated_daemon_keep_hours = rotated_daemon_keep_hours
 
     @classmethod
     def from_config(cls, task_config) -> "RayLogCleanupTask":
@@ -98,6 +107,7 @@ class RayLogCleanupTask(BaseTask):
             live_log_keep_days=task_config.params.get("live_log_keep_days", 7),
             old_logs_keep_hours=task_config.params.get("old_logs_keep_hours", 24),
             setup_log_keep_minutes=task_config.params.get("setup_log_keep_minutes", 60),
+            rotated_daemon_keep_hours=task_config.params.get("rotated_daemon_keep_hours", 24),
         )
 
     async def run_action(self, runtime: RemoteSandboxRuntime) -> dict:
@@ -106,11 +116,13 @@ class RayLogCleanupTask(BaseTask):
         live_age_min = self.live_log_keep_days * 24 * 60
         old_age_min = self.old_logs_keep_hours * 60
         setup_age_min = self.setup_log_keep_minutes
+        rotated_age_min = self.rotated_daemon_keep_hours * 60
 
-        # 4-stage shell pipeline:
+        # 5-stage shell pipeline:
         #   PART 1  — drop stale full session_<ts>_<pid> dirs
         #   PART 2a — session_latest/logs/ PID-aware (worker/runtime_env_setup with digit pid)
         #   PART 2c — session_latest/logs/ runtime_env_setup-* mtime-only (covers hex variant)
+        #   PART 2d — session_latest/logs/ rotated daemon logs (raylet.N.out, gcs_server.N.err, etc.)
         #   PART 2b — session_latest/logs/ non-PID, non-daemon stale (long tail)
         #   PART 3  — session_latest/logs/old/ time-based
         #
@@ -183,6 +195,21 @@ class RayLogCleanupTask(BaseTask):
                   rm -f "$f" && echo "removed_setup=$(basename "$f")"
                 done
 
+              # PART 2d: rotated daemon log backups — Ray performs in-place
+              # rotation for long-running daemon processes: the active file
+              # (e.g. raylet.out) keeps its fd open; rotated copies
+              # (raylet.1.out, raylet.2.out, ...) have NO open fd and are
+              # safe to delete. Without this stage the daemon whitelist
+              # (! -name 'raylet*') protects rotated copies indefinitely,
+              # causing multi-GB accumulation on long-running clusters.
+              # Pattern: <daemon>.<N>.<ext> where N is a positive integer.
+              find "$LOGS" -maxdepth 1 -type f -mmin +{rotated_age_min} \\
+                  -regextype posix-extended \\
+                  -regex '.*/((raylet|gcs_server|runtime_env_agent|dashboard|monitor|log_monitor)\\.[0-9]+\\.(out|err|log))$' \\
+              | while read -r f; do
+                  rm -f "$f" && echo "removed_rotated_daemon=$(basename "$f")"
+                done
+
               # PART 2b: non-PID, non-daemon stale files older than
               # {self.live_log_keep_days} days. Daemon files (raylet*,
               # gcs_server*, runtime_env_agent*, dashboard*, monitor*,
@@ -223,13 +250,15 @@ class RayLogCleanupTask(BaseTask):
         removed_sessions = [line.split("=", 1)[1] for line in output.splitlines() if line.startswith("removed=")]
         removed_dead_pid = sum(1 for line in output.splitlines() if line.startswith("removed_dead_pid_log="))
         removed_setup = sum(1 for line in output.splitlines() if line.startswith("removed_setup="))
+        removed_rotated_daemon = sum(1 for line in output.splitlines() if line.startswith("removed_rotated_daemon="))
         removed_stale = sum(1 for line in output.splitlines() if line.startswith("removed_stale_file="))
         removed_old = sum(1 for line in output.splitlines() if line.startswith("removed_old="))
 
         logger.info(
             f"[{self.type}] [{runtime._config.host}] ray_log_cleanup done: "
             f"sessions={len(removed_sessions)}, dead_pid={removed_dead_pid}, "
-            f"setup={removed_setup}, stale={removed_stale}, old={removed_old}, "
+            f"setup={removed_setup}, rotated_daemon={removed_rotated_daemon}, "
+            f"stale={removed_stale}, old={removed_old}, "
             f"output_head={output[:300]}"
         )
         return {
@@ -241,6 +270,7 @@ class RayLogCleanupTask(BaseTask):
             # New per-category counters:
             "removed_dead_pid_count": removed_dead_pid,
             "removed_setup_count": removed_setup,
+            "removed_rotated_daemon_count": removed_rotated_daemon,
             "removed_stale_count": removed_stale,
             "removed_old_count": removed_old,
             "output_head": output[:1500],

--- a/tests/unit/admin/scheduler/test_ray_log_cleanup_task.py
+++ b/tests/unit/admin/scheduler/test_ray_log_cleanup_task.py
@@ -40,6 +40,7 @@ class TestInit:
         assert task.min_age_hours == 24
         assert task.live_log_keep_days == 7
         assert task.old_logs_keep_hours == 24
+        assert task.setup_log_keep_minutes == 60
 
     def test_strips_trailing_slash(self):
         task = RayLogCleanupTask(ray_temp_dir="/data/ray/")
@@ -57,6 +58,10 @@ class TestInit:
         with pytest.raises(ValueError, match="old_logs_keep_hours must be >= 1"):
             RayLogCleanupTask(old_logs_keep_hours=0)
 
+    def test_rejects_setup_log_keep_minutes_below_one(self):
+        with pytest.raises(ValueError, match="setup_log_keep_minutes must be >= 1"):
+            RayLogCleanupTask(setup_log_keep_minutes=0)
+
     def test_custom_thresholds(self):
         task = RayLogCleanupTask(live_log_keep_days=3, old_logs_keep_hours=12)
         assert task.live_log_keep_days == 3
@@ -70,6 +75,7 @@ class TestFromConfig:
         assert task.min_age_hours == 24
         assert task.live_log_keep_days == 7
         assert task.old_logs_keep_hours == 24
+        assert task.setup_log_keep_minutes == 60
 
     def test_from_config_custom(self):
         cfg = _FakeTaskConfig(
@@ -78,6 +84,7 @@ class TestFromConfig:
                 "min_age_hours": 48,
                 "live_log_keep_days": 14,
                 "old_logs_keep_hours": 6,
+                "setup_log_keep_minutes": 30,
             },
             interval_seconds=3600,
         )
@@ -86,6 +93,7 @@ class TestFromConfig:
         assert task.min_age_hours == 48
         assert task.live_log_keep_days == 14
         assert task.old_logs_keep_hours == 6
+        assert task.setup_log_keep_minutes == 30
         assert task.interval_seconds == 3600
 
 
@@ -200,6 +208,33 @@ class TestCommandShape:
             assert f"! -name '{daemon}*'" in part2a, f"PART 2a missing daemon whitelist: {daemon}"
 
     @pytest.mark.asyncio
+    async def test_part2c_uses_setup_log_keep_minutes(self):
+        """PART 2c (runtime_env_setup-*) mtime threshold = setup_log_keep_minutes."""
+        task = RayLogCleanupTask(setup_log_keep_minutes=30)
+        runtime = _runtime()
+        await task.run_action(runtime)
+
+        cmd = runtime.execute.await_args.args[0].command
+        # The first textual occurrence is the comment block; search for the
+        # actual filter line "-name 'runtime_env_setup-*'" to skip past it.
+        idx = cmd.find("-name 'runtime_env_setup-*'")
+        assert idx >= 0, "PART 2c -name 'runtime_env_setup-*' filter not found"
+        window = cmd[max(0, idx - 150):idx]
+        assert "-mmin +30" in window, f"PART 2c missing -mmin +30 in nearby window: {window!r}"
+
+    @pytest.mark.asyncio
+    async def test_part2c_targets_runtime_env_setup_glob(self):
+        """PART 2c must use -name 'runtime_env_setup-*' (covers both digit and hex suffix)."""
+        task = RayLogCleanupTask()
+        runtime = _runtime()
+        await task.run_action(runtime)
+
+        cmd = runtime.execute.await_args.args[0].command
+        assert "-name 'runtime_env_setup-*'" in cmd
+        # Emits removed_setup= marker so output parser can count it
+        assert "removed_setup=" in cmd
+
+    @pytest.mark.asyncio
     async def test_part3_uses_old_logs_keep_hours(self):
         """PART 3 old-dir mtime threshold = old_logs_keep_hours * 60 minutes."""
         task = RayLogCleanupTask(old_logs_keep_hours=24)
@@ -276,6 +311,25 @@ class TestOutputParsing:
         assert result["removed_stale_count"] == 2
 
     @pytest.mark.asyncio
+    async def test_extracts_part2c_setup_count_digit_and_hex(self):
+        """REGRESSION: PART 2c must count both digit-suffix AND hex-suffix
+        runtime_env_setup files. Pre-fix, only the digit variant was cleaned
+        (accidentally by PART 2a's pid_max overflow); hex variant waited 7d
+        for PART 2b."""
+        stdout = (
+            "live_session=session_xxx\n"
+            "removed_setup=runtime_env_setup-31050000.log\n"   # pure digits
+            "removed_setup=runtime_env_setup-f4060000.log\n"   # hex — the main fix
+            "removed_setup=runtime_env_setup-b6000000.log\n"   # hex
+            "ray_log_cleanup_done"
+        )
+        task = RayLogCleanupTask()
+        runtime = _runtime(stdout=stdout)
+
+        result = await task.run_action(runtime)
+        assert result["removed_setup_count"] == 3
+
+    @pytest.mark.asyncio
     async def test_extracts_part3_old_count(self):
         stdout = (
             "live_session=session_xxx\n"
@@ -299,6 +353,7 @@ class TestOutputParsing:
         result = await task.run_action(runtime)
         assert result["removed_count"] == 0
         assert result["removed_dead_pid_count"] == 0
+        assert result["removed_setup_count"] == 0
         assert result["removed_stale_count"] == 0
         assert result["removed_old_count"] == 0
 

--- a/tests/unit/admin/scheduler/test_ray_log_cleanup_task.py
+++ b/tests/unit/admin/scheduler/test_ray_log_cleanup_task.py
@@ -1,4 +1,4 @@
-"""Tests for RayLogCleanupTask."""
+"""Tests for RayLogCleanupTask (3-stage: stale sessions + logs/ PID-aware + logs/old/)."""
 
 from unittest.mock import AsyncMock
 
@@ -27,12 +27,19 @@ def _runtime(stdout="ray_log_cleanup_done", exit_code=0):
     return rt
 
 
+# ---------------------------------------------------------------------------
+# Init / from_config
+# ---------------------------------------------------------------------------
+
+
 class TestInit:
     def test_default(self):
         task = RayLogCleanupTask()
         assert task.type == "ray_log_cleanup"
         assert task.ray_temp_dir == "/data/tmp/ray"
         assert task.min_age_hours == 24
+        assert task.live_log_keep_days == 7
+        assert task.old_logs_keep_hours == 24
 
     def test_strips_trailing_slash(self):
         task = RayLogCleanupTask(ray_temp_dir="/data/ray/")
@@ -42,27 +49,54 @@ class TestInit:
         with pytest.raises(ValueError, match="min_age_hours must be >= 1"):
             RayLogCleanupTask(min_age_hours=0)
 
+    def test_rejects_live_log_keep_days_below_one(self):
+        with pytest.raises(ValueError, match="live_log_keep_days must be >= 1"):
+            RayLogCleanupTask(live_log_keep_days=0)
+
+    def test_rejects_old_logs_keep_hours_below_one(self):
+        with pytest.raises(ValueError, match="old_logs_keep_hours must be >= 1"):
+            RayLogCleanupTask(old_logs_keep_hours=0)
+
+    def test_custom_thresholds(self):
+        task = RayLogCleanupTask(live_log_keep_days=3, old_logs_keep_hours=12)
+        assert task.live_log_keep_days == 3
+        assert task.old_logs_keep_hours == 12
+
 
 class TestFromConfig:
     def test_from_config_defaults(self):
         task = RayLogCleanupTask.from_config(_FakeTaskConfig())
         assert task.ray_temp_dir == "/data/tmp/ray"
         assert task.min_age_hours == 24
+        assert task.live_log_keep_days == 7
+        assert task.old_logs_keep_hours == 24
 
     def test_from_config_custom(self):
         cfg = _FakeTaskConfig(
-            params={"ray_temp_dir": "/data/ray", "min_age_hours": 48},
+            params={
+                "ray_temp_dir": "/data/ray",
+                "min_age_hours": 48,
+                "live_log_keep_days": 14,
+                "old_logs_keep_hours": 6,
+            },
             interval_seconds=3600,
         )
         task = RayLogCleanupTask.from_config(cfg)
         assert task.ray_temp_dir == "/data/ray"
         assert task.min_age_hours == 48
+        assert task.live_log_keep_days == 14
+        assert task.old_logs_keep_hours == 6
         assert task.interval_seconds == 3600
 
 
-class TestRunAction:
+# ---------------------------------------------------------------------------
+# Shell command shape — verify the 3 stages and their parameters
+# ---------------------------------------------------------------------------
+
+
+class TestCommandShape:
     @pytest.mark.asyncio
-    async def test_command_skips_session_latest(self):
+    async def test_part1_skips_session_latest(self):
         task = RayLogCleanupTask()
         runtime = _runtime()
         await task.run_action(runtime)
@@ -75,7 +109,7 @@ class TestRunAction:
         assert 'name "session_*"' in cmd
 
     @pytest.mark.asyncio
-    async def test_command_uses_min_age_in_minutes(self):
+    async def test_part1_uses_min_age_in_minutes(self):
         task = RayLogCleanupTask(min_age_hours=48)
         runtime = _runtime()
         await task.run_action(runtime)
@@ -92,9 +126,78 @@ class TestRunAction:
 
         cmd = runtime.execute.await_args.args[0].command
         assert '"/data/ray"' in cmd
+        assert "/data/ray/session_latest/logs" in cmd
 
     @pytest.mark.asyncio
-    async def test_extracts_removed_count_from_output(self):
+    async def test_part2a_uses_kill_zero_pid_probe(self):
+        """PART 2a must probe PID with `kill -0` (no-signal liveness check)."""
+        task = RayLogCleanupTask()
+        runtime = _runtime()
+        await task.run_action(runtime)
+
+        cmd = runtime.execute.await_args.args[0].command
+        assert "kill -0" in cmd
+        # PID regex must match Ray's worker file naming
+        assert "[_-][0-9]+" in cmd
+        # Only files older than 60 min are candidates (race-window guard)
+        assert "-mmin +60" in cmd
+
+    @pytest.mark.asyncio
+    async def test_part2b_uses_live_log_keep_days(self):
+        """PART 2b stale-file mtime threshold = live_log_keep_days * 24 * 60 minutes."""
+        task = RayLogCleanupTask(live_log_keep_days=7)
+        runtime = _runtime()
+        await task.run_action(runtime)
+
+        cmd = runtime.execute.await_args.args[0].command
+        # 7d * 24h * 60min = 10080
+        assert "-mmin +10080" in cmd
+
+    @pytest.mark.asyncio
+    async def test_part2b_daemon_whitelist_protected(self):
+        """raylet*, gcs_server*, runtime_env_agent*, dashboard*, monitor*,
+        log_monitor* must all be excluded by name (regression guard — Ray
+        holds fds; deletion wouldn't free disk)."""
+        task = RayLogCleanupTask()
+        runtime = _runtime()
+        await task.run_action(runtime)
+
+        cmd = runtime.execute.await_args.args[0].command
+        for daemon in ("raylet", "gcs_server", "runtime_env_agent", "dashboard", "monitor", "log_monitor"):
+            assert f"! -name '{daemon}*'" in cmd, f"daemon whitelist missing: {daemon}"
+
+    @pytest.mark.asyncio
+    async def test_part3_uses_old_logs_keep_hours(self):
+        """PART 3 old-dir mtime threshold = old_logs_keep_hours * 60 minutes."""
+        task = RayLogCleanupTask(old_logs_keep_hours=24)
+        runtime = _runtime()
+        await task.run_action(runtime)
+
+        cmd = runtime.execute.await_args.args[0].command
+        # 24h * 60 = 1440
+        assert "-mmin +1440" in cmd
+        assert "session_latest/logs/old" in cmd
+
+    @pytest.mark.asyncio
+    async def test_part3_uses_old_logs_keep_hours_custom(self):
+        task = RayLogCleanupTask(old_logs_keep_hours=6)
+        runtime = _runtime()
+        await task.run_action(runtime)
+
+        cmd = runtime.execute.await_args.args[0].command
+        # 6h * 60 = 360
+        assert "-mmin +360" in cmd
+
+
+# ---------------------------------------------------------------------------
+# Output parsing — per-category counters
+# ---------------------------------------------------------------------------
+
+
+class TestOutputParsing:
+    @pytest.mark.asyncio
+    async def test_extracts_part1_removed_sessions(self):
+        """PART 1 session removals reported via `removed=<sess>` (backward compat)."""
         stdout = (
             "live_session=session_2026_03_01_xyz_111\n"
             "removed=session_2026_02_15_aaa_222\n"
@@ -111,6 +214,62 @@ class TestRunAction:
         assert "session_2026_02_20_bbb_333" in result["removed_sessions"]
 
     @pytest.mark.asyncio
+    async def test_extracts_part2a_dead_pid_count(self):
+        stdout = (
+            "live_session=session_xxx\n"
+            "removed_dead_pid_log=python-core-worker-aaaa_12345.log\n"
+            "removed_dead_pid_log=worker-bbbb-c205-67890.err\n"
+            "removed_dead_pid_log=worker-bbbb-c205-67890.out\n"
+            "ray_log_cleanup_done"
+        )
+        task = RayLogCleanupTask()
+        runtime = _runtime(stdout=stdout)
+
+        result = await task.run_action(runtime)
+        assert result["removed_dead_pid_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_extracts_part2b_stale_count(self):
+        stdout = (
+            "live_session=session_xxx\n"
+            "removed_stale_file=runtime_env_setup-60010000.log\n"
+            "removed_stale_file=runtime_env_setup-5c010000.log\n"
+            "ray_log_cleanup_done"
+        )
+        task = RayLogCleanupTask()
+        runtime = _runtime(stdout=stdout)
+
+        result = await task.run_action(runtime)
+        assert result["removed_stale_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_extracts_part3_old_count(self):
+        stdout = (
+            "live_session=session_xxx\n"
+            "removed_old=python-core-worker-aaa.log.1\n"
+            "removed_old=python-core-worker-aaa.log.2\n"
+            "removed_old=raylet.out.1\n"
+            "ray_log_cleanup_done"
+        )
+        task = RayLogCleanupTask()
+        runtime = _runtime(stdout=stdout)
+
+        result = await task.run_action(runtime)
+        assert result["removed_old_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_all_counters_zero_when_nothing_removed(self):
+        stdout = "live_session=session_xxx\nray_log_cleanup_done"
+        task = RayLogCleanupTask()
+        runtime = _runtime(stdout=stdout)
+
+        result = await task.run_action(runtime)
+        assert result["removed_count"] == 0
+        assert result["removed_dead_pid_count"] == 0
+        assert result["removed_stale_count"] == 0
+        assert result["removed_old_count"] == 0
+
+    @pytest.mark.asyncio
     async def test_handles_missing_ray_dir(self):
         task = RayLogCleanupTask()
         runtime = _runtime(stdout="ray_temp_dir_not_found")
@@ -118,3 +277,36 @@ class TestRunAction:
         result = await task.run_action(runtime)
         assert result["status"] == TaskStatusEnum.SUCCESS
         assert result["removed_count"] == 0
+        assert result["removed_dead_pid_count"] == 0
+        assert result["removed_stale_count"] == 0
+        assert result["removed_old_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Regression guards — must-have command properties
+# ---------------------------------------------------------------------------
+
+
+class TestRegressionGuards:
+    @pytest.mark.asyncio
+    async def test_command_does_not_recurse_into_session_dirs_at_top_level(self):
+        """Top-level walk MUST keep `-maxdepth 1`; we explicitly DO recurse
+        into `session_latest/logs/old/` in PART 3 but never into other
+        `session_<ts>_<pid>` internals (only whole-dir rm -rf for those)."""
+        task = RayLogCleanupTask()
+        runtime = _runtime()
+        await task.run_action(runtime)
+
+        cmd = runtime.execute.await_args.args[0].command
+        # PART 1 stale-session walk: must have maxdepth 1
+        assert '-maxdepth 1 -type d -name "session_*"' in cmd
+
+    @pytest.mark.asyncio
+    async def test_command_uses_session_latest_logs_path(self):
+        """PART 2/3 must scope to session_latest/logs explicitly, not arbitrary session dirs."""
+        task = RayLogCleanupTask()
+        runtime = _runtime()
+        await task.run_action(runtime)
+
+        cmd = runtime.execute.await_args.args[0].command
+        assert "session_latest/logs" in cmd

--- a/tests/unit/admin/scheduler/test_ray_log_cleanup_task.py
+++ b/tests/unit/admin/scheduler/test_ray_log_cleanup_task.py
@@ -41,6 +41,7 @@ class TestInit:
         assert task.live_log_keep_days == 7
         assert task.old_logs_keep_hours == 24
         assert task.setup_log_keep_minutes == 60
+        assert task.rotated_daemon_keep_hours == 24
 
     def test_strips_trailing_slash(self):
         task = RayLogCleanupTask(ray_temp_dir="/data/ray/")
@@ -62,6 +63,10 @@ class TestInit:
         with pytest.raises(ValueError, match="setup_log_keep_minutes must be >= 1"):
             RayLogCleanupTask(setup_log_keep_minutes=0)
 
+    def test_rejects_rotated_daemon_keep_hours_below_one(self):
+        with pytest.raises(ValueError, match="rotated_daemon_keep_hours must be >= 1"):
+            RayLogCleanupTask(rotated_daemon_keep_hours=0)
+
     def test_custom_thresholds(self):
         task = RayLogCleanupTask(live_log_keep_days=3, old_logs_keep_hours=12)
         assert task.live_log_keep_days == 3
@@ -76,6 +81,7 @@ class TestFromConfig:
         assert task.live_log_keep_days == 7
         assert task.old_logs_keep_hours == 24
         assert task.setup_log_keep_minutes == 60
+        assert task.rotated_daemon_keep_hours == 24
 
     def test_from_config_custom(self):
         cfg = _FakeTaskConfig(
@@ -85,6 +91,7 @@ class TestFromConfig:
                 "live_log_keep_days": 14,
                 "old_logs_keep_hours": 6,
                 "setup_log_keep_minutes": 30,
+                "rotated_daemon_keep_hours": 12,
             },
             interval_seconds=3600,
         )
@@ -94,6 +101,7 @@ class TestFromConfig:
         assert task.live_log_keep_days == 14
         assert task.old_logs_keep_hours == 6
         assert task.setup_log_keep_minutes == 30
+        assert task.rotated_daemon_keep_hours == 12
         assert task.interval_seconds == 3600
 
 
@@ -235,6 +243,51 @@ class TestCommandShape:
         assert "removed_setup=" in cmd
 
     @pytest.mark.asyncio
+    async def test_part2d_uses_rotated_daemon_keep_hours(self):
+        """PART 2d mtime threshold = rotated_daemon_keep_hours * 60 minutes."""
+        task = RayLogCleanupTask(rotated_daemon_keep_hours=48)
+        runtime = _runtime()
+        await task.run_action(runtime)
+
+        cmd = runtime.execute.await_args.args[0].command
+        # 48h * 60 = 2880
+        assert "-mmin +2880" in cmd
+
+    @pytest.mark.asyncio
+    async def test_part2d_matches_rotated_daemon_pattern(self):
+        """PART 2d must match <daemon>.<N>.<ext> but NOT the active file <daemon>.<ext>."""
+        task = RayLogCleanupTask()
+        runtime = _runtime()
+        await task.run_action(runtime)
+
+        cmd = runtime.execute.await_args.args[0].command
+        # Must use regex matching rotated copies (daemon.N.ext)
+        assert "raylet|gcs_server|runtime_env_agent|dashboard|monitor|log_monitor" in cmd
+        assert r"\.[0-9]+\." in cmd
+        # Emits removed_rotated_daemon= marker
+        assert "removed_rotated_daemon=" in cmd
+
+    @pytest.mark.asyncio
+    async def test_part2d_does_not_match_active_daemon_files(self):
+        """Active daemon files (raylet.out, raylet.err) must NOT match PART 2d regex.
+
+        The regex requires a numeric segment between daemon name and extension:
+        raylet.1.out matches, raylet.out does NOT."""
+        import re
+
+        task = RayLogCleanupTask()
+        runtime = _runtime()
+        await task.run_action(runtime)
+
+        # The regex uses \.[0-9]+ between daemon name and extension,
+        # so `raylet.out` (no number) can never match.
+        pattern = r"(raylet|gcs_server|runtime_env_agent|dashboard|monitor|log_monitor)\.[0-9]+\.(out|err|log)"
+        assert not re.match(pattern, "raylet.out")
+        assert not re.match(pattern, "raylet.err")
+        assert re.match(pattern, "raylet.1.out")
+        assert re.match(pattern, "gcs_server.2.err")
+
+    @pytest.mark.asyncio
     async def test_part3_uses_old_logs_keep_hours(self):
         """PART 3 old-dir mtime threshold = old_logs_keep_hours * 60 minutes."""
         task = RayLogCleanupTask(old_logs_keep_hours=24)
@@ -330,6 +383,24 @@ class TestOutputParsing:
         assert result["removed_setup_count"] == 3
 
     @pytest.mark.asyncio
+    async def test_extracts_part2d_rotated_daemon_count(self):
+        """PART 2d must count rotated daemon log files (raylet.N.out etc.)."""
+        stdout = (
+            "live_session=session_xxx\n"
+            "removed_rotated_daemon=raylet.1.out\n"
+            "removed_rotated_daemon=raylet.2.out\n"
+            "removed_rotated_daemon=raylet.3.out\n"
+            "removed_rotated_daemon=gcs_server.1.err\n"
+            "removed_rotated_daemon=dashboard.1.log\n"
+            "ray_log_cleanup_done"
+        )
+        task = RayLogCleanupTask()
+        runtime = _runtime(stdout=stdout)
+
+        result = await task.run_action(runtime)
+        assert result["removed_rotated_daemon_count"] == 5
+
+    @pytest.mark.asyncio
     async def test_extracts_part3_old_count(self):
         stdout = (
             "live_session=session_xxx\n"
@@ -354,6 +425,7 @@ class TestOutputParsing:
         assert result["removed_count"] == 0
         assert result["removed_dead_pid_count"] == 0
         assert result["removed_setup_count"] == 0
+        assert result["removed_rotated_daemon_count"] == 0
         assert result["removed_stale_count"] == 0
         assert result["removed_old_count"] == 0
 
@@ -366,6 +438,7 @@ class TestOutputParsing:
         assert result["status"] == TaskStatusEnum.SUCCESS
         assert result["removed_count"] == 0
         assert result["removed_dead_pid_count"] == 0
+        assert result["removed_rotated_daemon_count"] == 0
         assert result["removed_stale_count"] == 0
         assert result["removed_old_count"] == 0
 

--- a/tests/unit/admin/scheduler/test_ray_log_cleanup_task.py
+++ b/tests/unit/admin/scheduler/test_ray_log_cleanup_task.py
@@ -156,8 +156,8 @@ class TestCommandShape:
     @pytest.mark.asyncio
     async def test_part2b_daemon_whitelist_protected(self):
         """raylet*, gcs_server*, runtime_env_agent*, dashboard*, monitor*,
-        log_monitor* must all be excluded by name (regression guard — Ray
-        holds fds; deletion wouldn't free disk)."""
+        log_monitor*, agent-* must all be excluded by name (regression guard
+        — Ray holds fds; deletion wouldn't free disk)."""
         task = RayLogCleanupTask()
         runtime = _runtime()
         await task.run_action(runtime)
@@ -165,6 +165,39 @@ class TestCommandShape:
         cmd = runtime.execute.await_args.args[0].command
         for daemon in ("raylet", "gcs_server", "runtime_env_agent", "dashboard", "monitor", "log_monitor"):
             assert f"! -name '{daemon}*'" in cmd, f"daemon whitelist missing: {daemon}"
+        assert "! -name 'agent-*'" in cmd, "daemon whitelist missing: agent-*"
+
+    @pytest.mark.asyncio
+    async def test_part2a_daemon_whitelist_protects_agent_files(self):
+        """CORE REGRESSION (task #25): PART 2a (PID-aware) MUST also exclude
+        daemon-named files BEFORE the kill -0 probe. Without this guard,
+        `agent-<id>.err` matches the PID regex; kill -0 <id> fails because
+        <id> is a Ray-generated agent identifier (NOT a Linux PID) that
+        exceeds the PID range, so the file gets wrongly removed even though
+        Ray's runtime env agent is still writing to it."""
+        task = RayLogCleanupTask()
+        runtime = _runtime()
+        await task.run_action(runtime)
+
+        cmd = runtime.execute.await_args.args[0].command
+        # PART 2a section starts with `-mmin +60` (race-window guard).
+        # Find the segment from "+60" up to the next pipe (end of find expr).
+        idx = cmd.find("-mmin +60")
+        assert idx >= 0, "PART 2a -mmin +60 marker not found"
+        part2a = cmd[idx : cmd.find("| while read -r f", idx)]
+        # All daemon whitelist names must appear in PART 2a's find filter,
+        # not just PART 2b. Otherwise agent-* / runtime_env_agent* etc. get
+        # wrongly probed and removed.
+        for daemon in (
+            "raylet",
+            "gcs_server",
+            "runtime_env_agent",
+            "dashboard",
+            "monitor",
+            "log_monitor",
+            "agent-",
+        ):
+            assert f"! -name '{daemon}*'" in part2a, f"PART 2a missing daemon whitelist: {daemon}"
 
     @pytest.mark.asyncio
     async def test_part3_uses_old_logs_keep_hours(self):


### PR DESCRIPTION
## Summary                                                                                                                          
                                                               
  **Modified files**                                                                                                                  
  - `rock/admin/scheduler/tasks/ray_log_cleanup_task.py` — 4-stage shell pipeline + daemon whitelist + 3 new tunable params
  (`live_log_keep_days`, `old_logs_keep_hours`, `setup_log_keep_minutes`) + per-category counters in return dict           
  - `tests/unit/admin/scheduler/test_ray_log_cleanup_task.py` — 29 tests covering all 4 stages, daemon whitelist regression guards
  (especially PART 2a), output parsing, init validation, from_config defaults                                                         
                                                                             
  ## New tunables (all backward compatible, defaults preserve existing behavior)                                                      
                                                                                
  - `live_log_keep_days` — PART 2b mtime threshold for non-PID non-daemon files (default 7)                                           
  - `old_logs_keep_hours` — PART 3 mtime threshold for `logs/old/` files (default 24)      
  - `setup_log_keep_minutes` — PART 2c mtime threshold for `runtime_env_setup-*` (default 60)                                         
                                                                                                                                      
  ## Cron mirror (out of scope of this PR)    
                                                                                                                                      
  The ray-head node runs an identical shell pipeline via `cron daily` (no rocklet on ray-head, scheduler doesn't reach it). The shell 
  mirror lives in the rock-internal repo and is kept lock-step with this task's pipeline (manual sync — both stages added together).

  ## Test plan

  - [x] Unit: `uv run pytest tests/unit/admin/scheduler/test_ray_log_cleanup_task.py -v` — 29/29 PASS
  - [x] Pre-prod worker `11.8.74.237` (6-month Ray session, 1705 files):
    - **160 daemon files preserved** (BEFORE=160 → AFTER=160, zero diff) ← validates fix
    - **41 dead-PID worker files removed** in single run (PART 2a)
    - `runtime_env_setup-<hex>` files correctly handled by new PART 2c (verified 770+ such files exist on production worker)
    - PART 3 verified by synthetic test: touched 25h-old file → deleted, fresh file → preserved
  - [x] Regression: ran the task on a long-lived session that had `agent-1183572637.err` etc. — agent / log_monitor / dashboard_agent
  files preserved as expected
fixes #1028