### PR TITLE
fix(sdk): sanitize generated Harbor job names

### DIFF
--- a/rock/sdk/bench/models/job/config.py
+++ b/rock/sdk/bench/models/job/config.py
@@ -230,16 +230,18 @@ class HarborJobConfig(_BaseJobConfig):
         import uuid as _uuid
 
         if self.job_name is not None:
+            if "/" in self.job_name:
+                raise ValueError("job_name must not contain '/'")
             return self
 
         parts: list[str] = []
         if self.datasets:
             ds = self.datasets[0]
             if getattr(ds, "name", None):
-                parts.append(ds.name)
+                parts.append(ds.name.rsplit("/", 1)[-1])
             task_names = getattr(ds, "task_names", None) or []
             if len(task_names) == 1:
-                parts.append(task_names[0])
+                parts.append(task_names[0].rsplit("/", 1)[-1])
 
         parts.append(_uuid.uuid4().hex[:8])
         self.job_name = "_".join(parts)


### PR DESCRIPTION
## Summary

- reject explicit Harbor `job_name` values that contain `/`
- strip path-like prefixes from dataset names and single task names when generating default Harbor job names

## Why

Harbor job names are used as flat identifiers and path components in downstream job handling. Preserving slash-separated dataset/task identifiers can produce path-like job names and break consumers that expect a single flat name segment.

Fixes #1030

## Validation

- `git diff --check`
- `/Users/keluo/Code/rock-keluo/.venv/bin/python -m pytest tests/unit/sdk/job/test_config.py::TestHarborJobConfigAutoJobName -q` -> 4 passed
- manual Python check for `suite/my-dataset` + `group/my-task` generation and `bad/name` validation
