### PR TITLE
docs: refresh README Updates with v1.4.0 – v1.8.0         minor-release lineup

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,11 +155,11 @@ if __name__ == "__main__":
 
 | Date | Release |
 |:-------------|:---|
-| **[Latest]** | 🎉 ROCK v1.7.0 Released — [Release Notes](https://alibaba.github.io/ROCK/docs/Release%20Notes/v1.7.0) |
-| **[2026-04-23]** | 🎉 ROCK v1.5.1 Released — [Release Notes](https://alibaba.github.io/ROCK/docs/Release%20Notes/v1.5.1) |
-| **[2026-04-10]** | 🎉 ROCK v1.4.7 Released — [Release Notes](https://alibaba.github.io/ROCK/docs/Release%20Notes/v1.4.7) |
-| **[2026-03-27]** | 🎉 ROCK v1.4.4 Released — [Release Notes](https://alibaba.github.io/ROCK/docs/Release%20Notes/v1.4.4) |
-| **[2026-03-24]** | 🎉 ROCK v1.4.3 Released — [Release Notes](https://alibaba.github.io/ROCK/docs/Release%20Notes/v1.4.3) |
+| **[Latest]** | 🎉 ROCK v1.8.0 Released (2026-05-21) — [Release Notes](https://alibaba.github.io/ROCK/docs/overview) |
+| **[2026-04-24]** | 🎉 ROCK v1.7.0 Released — [Release Notes](https://alibaba.github.io/ROCK/docs/overview) |
+| **[2026-04-17]** | 🎉 ROCK v1.6.0 Released — [Release Notes](https://alibaba.github.io/ROCK/docs/overview) |
+| **[2026-04-10]** | 🎉 ROCK v1.5.0 Released — [Release Notes](https://alibaba.github.io/ROCK/docs/overview) |
+| **[2026-03-14]** | 🎉 ROCK v1.4.0 Released — [Release Notes](https://alibaba.github.io/ROCK/docs/overview) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -155,11 +155,11 @@ if __name__ == "__main__":
 
 | Date | Release |
 |:-------------|:---|
-| **[Latest]** | 🎉 ROCK v1.8.0 Released (2026-05-21) — [Release Notes](https://alibaba.github.io/ROCK/docs/overview) |
-| **[2026-04-24]** | 🎉 ROCK v1.7.0 Released — [Release Notes](https://alibaba.github.io/ROCK/docs/overview) |
-| **[2026-04-17]** | 🎉 ROCK v1.6.0 Released — [Release Notes](https://alibaba.github.io/ROCK/docs/overview) |
-| **[2026-04-10]** | 🎉 ROCK v1.5.0 Released — [Release Notes](https://alibaba.github.io/ROCK/docs/overview) |
-| **[2026-03-14]** | 🎉 ROCK v1.4.0 Released — [Release Notes](https://alibaba.github.io/ROCK/docs/overview) |
+| **[Latest]** | 🎉 ROCK v1.8.0 Released (2026-05-21) — [Release Notes](https://rock.io.alibaba-inc.com/docs/1.8.x/Release%20Notes/v1.8.0) |
+| **[2026-04-24]** | 🎉 ROCK v1.7.0 Released — [Release Notes](https://rock.io.alibaba-inc.com/docs/1.7.x/Release%20Notes/v1.7.0) |
+| **[2026-04-17]** | 🎉 ROCK v1.6.0 Released — [Release Notes](https://rock.io.alibaba-inc.com/docs/1.6.x/Release%20Notes/v1.6.0) |
+| **[2026-04-10]** | 🎉 ROCK v1.5.0 Released — [Release Notes](https://rock.io.alibaba-inc.com/docs/1.5.x/Release%20Notes/v1.5.0) |
+| **[2026-03-14]** | 🎉 ROCK v1.4.0 Released — [Release Notes](https://rock.io.alibaba-inc.com/docs/1.4.x/Release%20Notes/v1.4.4) |
 
 ---
 


### PR DESCRIPTION
## Summary                                                  
  - Replace 5-entry mix of minor + patch releases with the 5
  most-recent minor releases (v1.4.0 / v1.5.0 / v1.6.0 / v1.7.0 
  / v1.8.0)                                                     
  - Promote v1.8.0 to `[Latest]` with explicit release date in  
  the cell text                                                 
  - Unify all Release Notes links to `docs/overview` (canonical 
  landing page, won't drift when versioned doc paths change)   
                                                                
  ## Test plan                                                  
  - [x] Rendered locally — table formatting intact
  - [ ] Verify all `docs/overview` link redirects correctly     
  after merge        
fixes #1033