### PR TITLE
refactor(meta-store): add Redis-merge semantics to archive and filter alive-key fields

### DIFF
--- a/rock/actions/sandbox/sandbox_info.py
+++ b/rock/actions/sandbox/sandbox_info.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing import Any, TypedDict
 
 from rock.actions.sandbox.response import State
 from rock.deployments.status import PhaseStatus
@@ -26,3 +26,16 @@ class SandboxInfo(TypedDict, total=False):
     start_time: str
     stop_time: str
     extended_params: dict[str, str]
+
+
+_SANDBOX_INFO_KEYS = frozenset(SandboxInfo.__annotations__.keys())
+
+
+def pick_sandbox_info_fields(data: dict[str, Any]) -> "SandboxInfo":
+    """Return a dict containing only keys declared in :class:`SandboxInfo`.
+
+    Used by ``SandboxMetaStore`` to keep DB-only columns (e.g. ``spec`` /
+    ``status``, surfaced by ``SandboxRecord.to_dict()`` on the DB-fallback
+    read path) out of the Redis alive key.
+    """
+    return {k: v for k, v in data.items() if k in _SANDBOX_INFO_KEYS}  # type: ignore[return-value]

--- a/rock/sandbox/sandbox_manager.py
+++ b/rock/sandbox/sandbox_manager.py
@@ -182,12 +182,10 @@ class SandboxManager(BaseManager):
         sm = await self._get_current_statemachine(sandbox_id)
         if sm is None:
             logger.info(f"stop dangling sandbox {sandbox_id}")
-            sandbox_info: SandboxInfo = {"state": State.STOPPED}
             try:
                 await self._operator.stop(sandbox_id, reason=reason)
             except ValueError as e:
                 logger.error(f"ray get actor, actor {sandbox_id} not exist", exc_info=e)
-            await self._meta_store.archive(sandbox_id, sandbox_info)
         elif sm.current_state.value == State.STOPPED:
             await sm.send("stop_noop", sandbox_id=sandbox_id)
         else:

--- a/rock/sandbox/sandbox_meta_store.py
+++ b/rock/sandbox/sandbox_meta_store.py
@@ -11,7 +11,7 @@ from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 
 from rock.actions.sandbox.response import State
-from rock.actions.sandbox.sandbox_info import SandboxInfo
+from rock.actions.sandbox.sandbox_info import SandboxInfo, pick_sandbox_info_fields
 from rock.admin.core.redis_key import alive_sandbox_key, timeout_sandbox_key
 from rock.admin.core.sandbox_table import SandboxTable
 from rock.admin.metrics.decorator import monitor_metastore_operation
@@ -71,8 +71,13 @@ class SandboxMetaStore:
         deployment_config:
             ``DockerDeploymentConfig`` snapshot written once to the ``spec`` DB column.
             Redis does not store this.
+
+        The Redis payload is filtered to keys declared in ``SandboxInfo`` so any
+        DB-only fields the caller may carry (e.g. ``spec`` / ``status`` from a
+        prior DB-fallback read) cannot leak into the alive key.
         """
-        await self._redis.json_set(alive_sandbox_key(sandbox_id), "$", sandbox_info)
+        redis_payload = pick_sandbox_info_fields(sandbox_info)
+        await self._redis.json_set(alive_sandbox_key(sandbox_id), "$", redis_payload)
         if timeout_info is not None:
             await self._redis.json_set(timeout_sandbox_key(sandbox_id), "$", timeout_info)
 
@@ -80,9 +85,16 @@ class SandboxMetaStore:
 
     @monitor_metastore_operation
     async def update(self, sandbox_id: str, sandbox_info: SandboxInfo) -> None:
-        """Merge *sandbox_info* into the existing Redis alive key and await DB update."""
+        """Merge *sandbox_info* into the existing Redis alive key and await DB update.
+
+        The Redis-side merge uses only keys declared in ``SandboxInfo``; DB-only
+        fields like ``spec`` / ``status`` are dropped so they don't pollute the
+        alive key. The DB write keeps the full dict — the DB layer has its own
+        column-based filtering.
+        """
+        redis_payload = pick_sandbox_info_fields(sandbox_info)
         current = await self._redis.json_get(alive_sandbox_key(sandbox_id), "$")
-        merged: dict[str, Any] = {**(current[0] if current else {}), **sandbox_info}
+        merged: dict[str, Any] = {**(current[0] if current else {}), **redis_payload}
         await self._redis.json_set(alive_sandbox_key(sandbox_id), "$", merged)
 
         await self._db.update(sandbox_id, sandbox_info)
@@ -96,20 +108,20 @@ class SandboxMetaStore:
         await self._db.delete(sandbox_id)
 
     @monitor_metastore_operation
-    async def archive(self, sandbox_id: str, final_info: SandboxInfo) -> None:
-        """Persist final state to DB, then remove sandbox from Redis.
+    async def archive(self, sandbox_id: str, final_info: SandboxInfo | None = None) -> None:
+        """Snapshot Redis state to DB, then evict Redis keys.
 
-        Unlike ``delete``, the DB record is preserved and updated with
-        ``final_info`` (e.g. ``stop_time``, ``state``).  Use this when a
-        sandbox has finished its lifecycle and the final state should be
-        queryable from the DB.
+        Reads the current alive-key from Redis, merges *final_info* on top
+        (e.g. ``stop_time``, ``state``), persists the result to the DB, and
+        then deletes the Redis alive + timeout keys.
 
         The DB write is awaited before the Redis keys are deleted so that
-        the final state is always durably stored before the alive key
-        disappears.  If the DB write fails the exception propagates and
-        Redis cleanup is skipped.
+        the snapshot is always durably stored before the cache disappears.
         """
-        await self._db.update(sandbox_id, final_info)
+        current = await self._redis.json_get(alive_sandbox_key(sandbox_id), "$")
+        merged: dict[str, Any] = {**(current[0] if current else {}), **(final_info or {})}
+        if merged:
+            await self._db.update(sandbox_id, merged)
 
         await self._redis.json_delete(alive_sandbox_key(sandbox_id))
         await self._redis.json_delete(timeout_sandbox_key(sandbox_id))

--- a/tests/unit/sandbox/test_sandbox_meta_store.py
+++ b/tests/unit/sandbox/test_sandbox_meta_store.py
@@ -147,8 +147,8 @@ class TestRemove:
 
 
 class TestArchive:
-    async def test_archive_removes_redis_and_updates_db(self, repo, redis, db):
-        """archive() should update DB first, then remove Redis keys."""
+    async def test_archive_merges_redis_and_updates_db(self, repo, redis, db):
+        """archive() should read Redis, merge final_info, write DB, then evict Redis keys."""
         await repo.create(SANDBOX_ID, SANDBOX_INFO)
         await redis.json_set(timeout_sandbox_key(SANDBOX_ID), "$", {"auto_clear_time": "30", "expire_time": "9999"})
         await asyncio.sleep(0.1)  # let the create fire-and-forget DB insert settle
@@ -169,14 +169,13 @@ class TestArchive:
         assert db_record["user_id"] == "user-1"  # original fields preserved
 
     async def test_archive_db_written_before_redis_deleted(self, repo, redis, db):
-        """DB must be durably updated before the Redis alive key is removed."""
+        """DB must be durably updated before the Redis alive key is evicted."""
         await repo.create(SANDBOX_ID, SANDBOX_INFO)
         await asyncio.sleep(0.1)
 
-        # Intercept: check DB state immediately after archive returns (no extra sleep).
         await repo.archive(SANDBOX_ID, {"state": "stopped"})
 
-        # At this point archive() has already awaited the DB write and deleted Redis.
+        # At this point archive() has already awaited the DB write and evicted Redis.
         assert await redis.json_get(alive_sandbox_key(SANDBOX_ID), "$") is None
         db_record = await db.get(SANDBOX_ID)
         assert db_record is not None

--- a/tests/unit/sandbox/test_sandbox_transitions.py
+++ b/tests/unit/sandbox/test_sandbox_transitions.py
@@ -73,18 +73,18 @@ async def mgr(mock_meta_store, mock_operator):
 
 class TestManagerStop:
     @pytest.mark.asyncio
-    async def test_stop_not_found_attempts_cleanup(self, mgr, mock_meta_store, mock_operator):
+    async def test_stop_not_found_attempts_operator_stop(self, mgr, mock_meta_store, mock_operator):
         mock_meta_store.get.return_value = None
         await mgr.stop("sb-1")
         mock_operator.stop.assert_awaited_once_with("sb-1", reason=StopReason.MANUAL)
-        mock_meta_store.archive.assert_awaited_once()
+        mock_meta_store.archive.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_stop_not_found_actor_missing_still_archives(self, mgr, mock_meta_store, mock_operator):
+    async def test_stop_not_found_actor_missing_is_silent(self, mgr, mock_meta_store, mock_operator):
         mock_meta_store.get.return_value = None
         mock_operator.stop.side_effect = ValueError("actor not found")
         await mgr.stop("sb-1")
-        mock_meta_store.archive.assert_awaited_once()
+        mock_meta_store.archive.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_stop_already_stopped_is_noop(self, mgr, mock_meta_store, mock_operator):


### PR DESCRIPTION
close #1000