### PR TITLE
chore(ci): run admin+network tests only on push, skip on PRs

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -54,3 +54,10 @@ jobs:
       run: |
         echo "🔐 Running admin tests..."
         uv run pytest -n auto -m "need_admin" --reruns 1
+
+    # Temporarily disabled, see #1039
+    # - name: Run tests need admin and network
+    #   if: success()
+    #   run: |
+    #     echo "🔐 Running admin and network tests..."
+    #     uv run pytest -n auto -m "need_admin_and_network" --reruns 1

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -55,9 +55,9 @@ jobs:
         echo "🔐 Running admin tests..."
         uv run pytest -n auto -m "need_admin" --reruns 1
 
-    # Temporarily disabled, see #1039
-    # - name: Run tests need admin and network
-    #   if: success()
-    #   run: |
-    #     echo "🔐 Running admin and network tests..."
-    #     uv run pytest -n auto -m "need_admin_and_network" --reruns 1
+    # Only run after merge into master / release/v1.0 (push event), not on PRs. See #1039
+    - name: Run tests need admin and network
+      if: success() && github.event_name == 'push'
+      run: |
+        echo "🔐 Running admin and network tests..."
+        uv run pytest -n auto -m "need_admin_and_network" --reruns 1

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -54,9 +54,3 @@ jobs:
       run: |
         echo "🔐 Running admin tests..."
         uv run pytest -n auto -m "need_admin" --reruns 1
-
-    - name: Run tests need admin and network
-      if: success()
-      run: |
-        echo "🔐 Running admin and network tests..."
-        uv run pytest -n auto -m "need_admin_and_network" --reruns 1


### PR DESCRIPTION
## Summary
- Gate the `Run tests need admin and network` step on `github.event_name == 'push'`
- PR/pull_request runs skip this step; it runs only after merge into `master` / `release/v1.0`
- Reduces PR feedback time while keeping post-merge coverage

fixes #1039

## Test plan
- [ ] On this PR: the `Run tests need admin and network` step is skipped
- [ ] After merge to master: the step runs and the remaining 3 phases (fast / ray / admin) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)