### PR TITLE
docs(v1.8.0): wrap PR numbers in release notes with GitHub links

### DIFF
--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.8.x/Release Notes/v1.8.0.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.8.x/Release Notes/v1.8.0.md
@@ -14,9 +14,9 @@
 
 ### Bug 修复
 
-*   **SDK**: 在 Python 运行时环境中增加配置类型校验 (#652)
+*   **SDK**: 在 Python 运行时环境中增加配置类型校验 ([#652](https://github.com/alibaba/ROCK/pull/652))
     
-*   **SDK**: 在 OSS 上传路径中使用 wget 前先创建目标父目录 (#940)
+*   **SDK**: 在 OSS 上传路径中使用 wget 前先创建目标父目录 ([#940](https://github.com/alibaba/ROCK/pull/940))
     
 
 ---
@@ -25,9 +25,9 @@
 
 ### 新功能
 
-*   新增 CPU 超分能力，支持灰度发布、生命周期摘要和绝对核心数 CPU 指标 (#978)
+*   新增 CPU 超分能力，支持灰度发布、生命周期摘要和绝对核心数 CPU 指标 ([#978](https://github.com/alibaba/ROCK/pull/978))
     
-*   `get_status` 接口支持 `include_all_states` 参数，可查询所有状态的沙箱 (#951)
+*   `get_status` 接口支持 `include_all_states` 参数，可查询所有状态的沙箱 ([#951](https://github.com/alibaba/ROCK/pull/951))
     
 *   上传/下载文件到sandbox的账号、bucket迁移（向前兼容，老bucket仍支持使用）（#953）
     
@@ -40,7 +40,7 @@
 
 ### 新功能
 
-*   **Kubernetes**: 新增 GPU 支持，采用 Jinja2 模板和可扩展加速器类型 (#981)
+*   **Kubernetes**: 新增 GPU 支持，采用 Jinja2 模板和可扩展加速器类型 ([#981](https://github.com/alibaba/ROCK/pull/981))
     
 *   区域集群配置优化：抽取公共配置，降低维护成本
     
@@ -51,7 +51,7 @@
 
 *   **Docker**: 容器停止时清理 XFS 项目配额
     
-*   **Docker**: 移除无效的删除镜像分支，添加 CLS 日志服务支持到删除镜像功能 (#965)
+*   **Docker**: 移除无效的删除镜像分支，添加 CLS 日志服务支持到删除镜像功能 ([#965](https://github.com/alibaba/ROCK/pull/965))
     
 *   修复删除镜像传参bug
     
@@ -62,7 +62,7 @@
 
 ### 新功能
 
-*   模型服务代理支持流式传输和回放模式，实现字节透传，提供转发和回放两种后端 (#935)
+*   模型服务代理支持流式传输和回放模式，实现字节透传，提供转发和回放两种后端 ([#935](https://github.com/alibaba/ROCK/pull/935))
     
 
 ---
@@ -82,7 +82,7 @@
     
 *   将 rock\_config 传递给沙箱表和元数据存储，确保指标监控使用正确的端点
     
-*   修复 `_get_user_info` 指标问题 (#911)
+*   修复 `_get_user_info` 指标问题 ([#911](https://github.com/alibaba/ROCK/pull/911))
     
 
 ---
@@ -91,13 +91,13 @@
 
 ### 新功能
 
-*   支持通过 Nacos 动态重载配置 (#888)
+*   支持通过 Nacos 动态重载配置 ([#888](https://github.com/alibaba/ROCK/pull/888))
     
 *   新增 Ray 日志清理任务，禁用 worker 到 driver 的日志转发
     
 *   新增构建缓存清理任务，用于修剪 uv/pip 缓存
     
-*   将悬空镜像和 BuildKit 修剪合并到镜像清理任务中 (#970)
+*   将悬空镜像和 BuildKit 修剪合并到镜像清理任务中 ([#970](https://github.com/alibaba/ROCK/pull/970))
     
 *   优化文件清理定时任务的性能和配置安全验证
     
@@ -113,14 +113,14 @@
 
 ### 新功能
 
-*   新增 Windows PowerShell 支持 (#921)
+*   新增 Windows PowerShell 支持 ([#921](https://github.com/alibaba/ROCK/pull/921))
     
 
 ### Bug 修复
 
 *   将循环设备磁盘挂载到 Docker 数据根目录，替代硬编码路径
     
-*   为 Kata 运行时的 Nix 镜像添加 `/bin` 符号链接挂载 (#936)
+*   为 Kata 运行时的 Nix 镜像添加 `/bin` 符号链接挂载 ([#936](https://github.com/alibaba/ROCK/pull/936))
     
 *   使用 cgroup 指标获取容器 CPU 使用率，替代 psutil
     
@@ -143,12 +143,12 @@
 
 ## ♻️ 代码重构
 
-*   **对象存储**: 将 OSS 上传/下载与客户端环境变量解耦，实现三层配置解析机制 (#943)
+*   **对象存储**: 将 OSS 上传/下载与客户端环境变量解耦，实现三层配置解析机制 ([#943](https://github.com/alibaba/ROCK/pull/943))
     
 
 ## 🔧 构建与工具
 
-*   移除 `need_database` 标记 (#901)
+*   移除 `need_database` 标记 ([#901](https://github.com/alibaba/ROCK/pull/901))
     
 
 ---

--- a/docs/versioned_docs/version-1.8.x/Release Notes/v1.8.0.md
+++ b/docs/versioned_docs/version-1.8.x/Release Notes/v1.8.0.md
@@ -13,9 +13,9 @@ May 21, 2026
 
 ### Bug Fixes
 
-*   **SDK**: Add runtime config type validation in `PythonRuntimeEnv` (#652)
+*   **SDK**: Add runtime config type validation in `PythonRuntimeEnv` ([#652](https://github.com/alibaba/ROCK/pull/652))
 
-*   **SDK**: `mkdir` target parent dir before `wget` in OSS upload path (#940)
+*   **SDK**: `mkdir` target parent dir before `wget` in OSS upload path ([#940](https://github.com/alibaba/ROCK/pull/940))
 
 ---
 
@@ -23,11 +23,11 @@ May 21, 2026
 
 ### New Features
 
-*   CPU overcommit with grayscale rollout, lifecycle summary, and absolute-cores CPU gauge (#978)
+*   CPU overcommit with grayscale rollout, lifecycle summary, and absolute-cores CPU gauge ([#978](https://github.com/alibaba/ROCK/pull/978))
 
-*   `get_status` API supports `include_all_states` parameter — query sandboxes in all states (#951)
+*   `get_status` API supports `include_all_states` parameter — query sandboxes in all states ([#951](https://github.com/alibaba/ROCK/pull/951))
 
-*   Account / bucket migration for sandbox upload/download (backward compatible — legacy bucket still supported) (#953)
+*   Account / bucket migration for sandbox upload/download (backward compatible — legacy bucket still supported) ([#953](https://github.com/alibaba/ROCK/pull/953))
 
 *   Fix transfer file being stored directly under bucket root (backward compatible)
 
@@ -37,7 +37,7 @@ May 21, 2026
 
 ### New Features
 
-*   **Kubernetes**: GPU support with Jinja2 templates and extensible accelerator types (#981)
+*   **Kubernetes**: GPU support with Jinja2 templates and extensible accelerator types ([#981](https://github.com/alibaba/ROCK/pull/981))
 
 *   Region cluster config refactor: extract common config, reduce maintenance cost
 
@@ -47,7 +47,7 @@ May 21, 2026
 
 *   **Docker**: Cleanup XFS project quota on container stop
 
-*   **Docker**: Remove dead `remove_images` branch + add CLS log support to image removal (#965)
+*   **Docker**: Remove dead `remove_images` branch + add CLS log support to image removal ([#965](https://github.com/alibaba/ROCK/pull/965))
 
 *   Fix `remove_image` missing `cls` parameter bug
 
@@ -57,7 +57,7 @@ May 21, 2026
 
 ### New Features
 
-*   Model-service proxy supports streaming and replay — byte passthrough, with Forward and Replay backends (#935)
+*   Model-service proxy supports streaming and replay — byte passthrough, with Forward and Replay backends ([#935](https://github.com/alibaba/ROCK/pull/935))
 
 ---
 
@@ -75,7 +75,7 @@ May 21, 2026
 
 *   Pass `rock_config` to `SandboxTable` / `SandboxMetaStore` so `MetricsMonitor` uses the correct endpoint
 
-*   Fix `_get_user_info` metrics issue (#911)
+*   Fix `_get_user_info` metrics issue ([#911](https://github.com/alibaba/ROCK/pull/911))
 
 ---
 
@@ -83,13 +83,13 @@ May 21, 2026
 
 ### New Features
 
-*   Dynamic config reloading via Nacos (#888)
+*   Dynamic config reloading via Nacos ([#888](https://github.com/alibaba/ROCK/pull/888))
 
 *   Add `RayLogCleanupTask` and disable worker-to-driver log forwarding
 
 *   Add `BuildCacheCleanupTask` for pruning uv/pip caches
 
-*   Merge dangling-layer and BuildKit prune into `ImageCleanupTask` (#970)
+*   Merge dangling-layer and BuildKit prune into `ImageCleanupTask` ([#970](https://github.com/alibaba/ROCK/pull/970))
 
 *   Improve `FileCleanupTask` performance and config safety validation
 
@@ -103,13 +103,13 @@ May 21, 2026
 
 ### New Features
 
-*   Add Windows PowerShell support (#921)
+*   Add Windows PowerShell support ([#921](https://github.com/alibaba/ROCK/pull/921))
 
 ### Bug Fixes
 
 *   Mount loop disk to Docker data-root instead of hardcoded path
 
-*   Symlink mount into `/bin` for Nix images with Kata runtime (#936)
+*   Symlink mount into `/bin` for Nix images with Kata runtime ([#936](https://github.com/alibaba/ROCK/pull/936))
 
 *   Use cgroup metrics for container CPU instead of psutil
 
@@ -129,10 +129,10 @@ May 21, 2026
 
 ## ♻️ Refactoring
 
-*   **OSS**: Decouple OSS upload/download from client env vars; implement 3-layer config resolution (#943)
+*   **OSS**: Decouple OSS upload/download from client env vars; implement 3-layer config resolution ([#943](https://github.com/alibaba/ROCK/pull/943))
 
 ## 🔧 Build & Tooling
 
-*   Remove `need_database` test marker (#901)
+*   Remove `need_database` test marker ([#901](https://github.com/alibaba/ROCK/pull/901))
 
 ---


### PR DESCRIPTION
The v1.8.0 release notes pages (EN + zh-Hans) referenced PRs as plain text `(#NNN)`,                                                
  unlike v1.7.0 which uses full Markdown links — clicking went nowhere.                                                               
                                                                                                                                      
  This PR wraps all 29 `(#NNN)` occurrences in                                                                                        
  `docs/versioned_docs/version-1.8.x/Release Notes/v1.8.0.md` and the corresponding   
  zh-Hans file with proper Markdown links to `https://github.com/alibaba/ROCK/pull/NNN`,                                              
  matching v1.7.0's existing style.                                                     
                                              
  No content/text changes — only the PR-number formatting. 
  
  fixes #989