### PR TITLE
chore(deps): pin oss2>=2.19.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pydantic",
     "python-multipart",
     "rich",
-    "oss2",
+    "oss2>=2.19.1",
     "pyyaml",
     "jinja2",
     "tzdata",

--- a/uv.lock
+++ b/uv.lock
@@ -4280,7 +4280,7 @@ wheels = [
 
 [[package]]
 name = "rl-rock"
-version = "1.8.0"
+version = "1.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
@@ -4440,7 +4440,7 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-exporter-prometheus" },
     { name = "opentelemetry-sdk" },
-    { name = "oss2" },
+    { name = "oss2", specifier = ">=2.19.1" },
     { name = "pexpect", marker = "sys_platform != 'win32' and extra == 'rocklet'" },
     { name = "pip", marker = "extra == 'admin'" },
     { name = "psutil", marker = "extra == 'model-service'" },


### PR DESCRIPTION
解决 oss2 版本问题，默认安装 2.1.1，部分 API 不兼容：
<img width="1996" height="920" alt="image" src="https://github.com/user-attachments/assets/e0788b82-b097-4e84-bb8d-01accbde1f5f" />

closes #1049 