### PR TITLE
chore(deps): drop uuid and move jinja2 to admin extras #1052

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 dependencies = [
     # Core dependencies needed by all modules
     "httpx",
-    "uuid",
     "anyio",
     "build",
     "opentelemetry-api",
@@ -26,7 +25,6 @@ dependencies = [
     "rich",
     "oss2",
     "pyyaml",
-    "jinja2",
     "tzdata",
 ]
 
@@ -52,6 +50,7 @@ admin = [
     "fakeredis[json]",
     "kubernetes>=35.0.0",  # For K8S operator support
     "aiolimiter>=1.2.1",  # For rate limiting
+    "jinja2",
 ]
 
 rocklet = [

--- a/requirements_admin.txt
+++ b/requirements_admin.txt
@@ -542,8 +542,6 @@ urllib3==2.5.0
     #   botocore
     #   kubernetes
     #   requests
-uuid==1.30
-    # via rl-rock
 uvicorn==0.38.0
     # via rl-rock
 virtualenv==20.35.4

--- a/requirements_sandbox_actor.txt
+++ b/requirements_sandbox_actor.txt
@@ -361,8 +361,6 @@ tzlocal==5.3.1
     # via apscheduler
 urllib3==2.5.0
     # via requests
-uuid==1.30
-    # via rl-rock
 yarl==1.22.0
     # via aiohttp
 zipp==3.23.0

--- a/uv.lock
+++ b/uv.lock
@@ -4271,13 +4271,12 @@ wheels = [
 
 [[package]]
 name = "rl-rock"
-version = "1.8.0"
+version = "1.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
     { name = "build" },
     { name = "httpx" },
-    { name = "jinja2" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-exporter-prometheus" },
@@ -4289,7 +4288,6 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "tzdata" },
-    { name = "uuid" },
 ]
 
 [package.optional-dependencies]
@@ -4306,6 +4304,7 @@ admin = [
     { name = "fakeredis", extra = ["json"] },
     { name = "fastapi" },
     { name = "gem-llm", marker = "sys_platform != 'win32'" },
+    { name = "jinja2" },
     { name = "kubernetes" },
     { name = "nacos-sdk-python" },
     { name = "numpy" },
@@ -4333,6 +4332,7 @@ all = [
     { name = "fakeredis", extra = ["json"] },
     { name = "fastapi" },
     { name = "gem-llm" },
+    { name = "jinja2" },
     { name = "kubernetes" },
     { name = "nacos-sdk-python" },
     { name = "numpy" },
@@ -4420,7 +4420,7 @@ requires-dist = [
     { name = "gem-llm", marker = "extra == 'sandbox-actor'", specifier = ">=0.1.0" },
     { name = "httpx" },
     { name = "httpx", marker = "extra == 'model-service'" },
-    { name = "jinja2" },
+    { name = "jinja2", marker = "extra == 'admin'" },
     { name = "kubernetes", marker = "extra == 'admin'", specifier = ">=35.0.0" },
     { name = "nacos-sdk-python", marker = "extra == 'admin'", specifier = ">=0.1.14" },
     { name = "nacos-sdk-python", marker = "extra == 'sandbox-actor'", specifier = ">=0.1.14" },
@@ -4453,7 +4453,6 @@ requires-dist = [
     { name = "swebench", marker = "extra == 'model-service'" },
     { name = "twisted", marker = "sys_platform != 'win32' and extra == 'rocklet'" },
     { name = "tzdata" },
-    { name = "uuid" },
     { name = "uvicorn", marker = "extra == 'model-service'" },
     { name = "uvicorn", marker = "extra == 'rocklet'" },
     { name = "websockets", marker = "extra == 'admin'", specifier = ">=15.0.1" },
@@ -5105,12 +5104,6 @@ sdist = { url = "https://mirrors.aliyun.com/pypi/packages/15/22/9ee70a2574a4f459
 wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc" },
 ]
-
-[[package]]
-name = "uuid"
-version = "1.30"
-source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/ce/63/f42f5aa951ebf2c8dac81f77a8edcc1c218640a2a35a03b9ff2d4aa64c3d/uuid-1.30.tar.gz", hash = "sha256:1f87cc004ac5120466f36c5beae48b4c48cc411968eed0eaecd3da82aa96193f" }
 
 [[package]]
 name = "uvicorn"


### PR DESCRIPTION
## Changes

- Remove the unnecessary `uuid` dependency. `uuid` on PyPI resolves to `uuid==1.30`, a 2007 pre-stdlib backport that shadows the standard library `uuid` module when installed. Python 3.10+ ships `uuid` in stdlib, and the codebase only uses `uuid.uuid4()`, which is identical in both, so the dependency adds no value and only causes prod-vs-dev divergence (`requirements_*.txt` was pulling `uuid==1.30` into admin / sandbox-actor images while local `uv sync` ran on stdlib).
- Move `jinja2` from the core dependencies to the `admin` optional extras. `jinja2` is only used by the K8s template loader, so SDK / rocklet consumers should not have to install it.
- Re-export `requirements_admin.txt` and `requirements_sandbox_actor.txt` so production images no longer install `uuid==1.30`.

## Code Changes

- `pyproject.toml`: drop `"uuid"` from core deps; move `"jinja2"` from core deps into `[project.optional-dependencies].admin`.
- `requirements_admin.txt`: regenerated; `uuid==1.30 # via rl-rock` line removed.
- `requirements_sandbox_actor.txt`: regenerated; `uuid==1.30 # via rl-rock` line removed.
- `uv.lock`: regenerated to reflect the dependency changes (drop `uuid`, relocate `jinja2` under the `admin` extra).

No source code under `rock/` or `tests/` is changed — `uuid.uuid4()` is the only `uuid` API used and behaves identically on stdlib.

## Related Issue

refs #1052