### PR TITLE
chore(deps): bump oss2 minimum version to >=2.19.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pydantic",
     "python-multipart",
     "rich",
-    "oss2",
+    "oss2>=2.19.1",
     "pyyaml",
     "jinja2",
     "tzdata",

--- a/uv.lock
+++ b/uv.lock
@@ -4280,7 +4280,7 @@ wheels = [
 
 [[package]]
 name = "rl-rock"
-version = "1.8.0"
+version = "1.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
@@ -4440,7 +4440,7 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-exporter-prometheus" },
     { name = "opentelemetry-sdk" },
-    { name = "oss2" },
+    { name = "oss2", specifier = ">=2.19.1" },
     { name = "pexpect", marker = "sys_platform != 'win32' and extra == 'rocklet'" },
     { name = "pip", marker = "extra == 'admin'" },
     { name = "psutil", marker = "extra == 'model-service'" },


### PR DESCRIPTION
解决 oss2 版本问题，默认会安装 2.1.1，部分API 会出现兼容问题
<img width="1964" height="932" alt="image" src="https://github.com/user-attachments/assets/f83ab3ba-d749-4919-afd2-3a0d54d994a8" />


#closs 1049