### PR TITLE
fix(rocklet): UploadResponse returns success=false after successful upload

### DIFF
--- a/rock/rocklet/local_api.py
+++ b/rock/rocklet/local_api.py
@@ -107,7 +107,7 @@ async def upload(
             file_path.unlink()
         else:
             shutil.move(file_path, target_path)
-    return UploadResponse()
+    return UploadResponse(success=True, file_name=target_path.name)
 
 
 @local_router.post("/close")

--- a/rock/rocklet/rocklet.py
+++ b/rock/rocklet/rocklet.py
@@ -250,7 +250,7 @@ class Rocklet(AbstractSandbox, ABC):
         else:
             shutil.copy(request.source_path, request.target_path)
         self.command_logger.info("[upload output]: upload success!")
-        return UploadResponse()
+        return UploadResponse(success=True, file_name=Path(request.target_path).name)
 
     async def close(self) -> CloseResponse:
         """Closes the runtime."""

--- a/tests/unit/rocklet/test_local_sandbox_runtime.py
+++ b/tests/unit/rocklet/test_local_sandbox_runtime.py
@@ -22,7 +22,9 @@ async def test_upload_file(local_runtime: Rocklet, tmp_path: Path):
     file_path = tmp_path / "source.txt"
     file_path.write_text("test")
     tmp_target = tmp_path / "target.txt"
-    await local_runtime.upload(UploadRequest(source_path=str(file_path), target_path=str(tmp_target)))
+    resp = await local_runtime.upload(UploadRequest(source_path=str(file_path), target_path=str(tmp_target)))
+    assert resp.success is True
+    assert resp.file_name == "target.txt"
     assert (
         await local_runtime.read_file(ReadFileRequest(path=str(tmp_target), sandbox_id="local-test"))
     ).content == "test"
@@ -35,7 +37,9 @@ async def test_upload_directory(local_runtime: Rocklet, tmp_path: Path):
     (dir_path / "file1.txt").write_text("test1")
     (dir_path / "file2.txt").write_text("test2")
     tmp_target = tmp_path / "target_dir"
-    await local_runtime.upload(UploadRequest(source_path=str(dir_path), target_path=str(tmp_target)))
+    resp = await local_runtime.upload(UploadRequest(source_path=str(dir_path), target_path=str(tmp_target)))
+    assert resp.success is True
+    assert resp.file_name == "target_dir"
     sid = "local-test"
     assert (
         await local_runtime.read_file(ReadFileRequest(path=str(tmp_target / "file1.txt"), sandbox_id=sid))


### PR DESCRIPTION
## Summary                                                                                                                                                               
                                                                                   
  - Set `success=True` and `file_name=target_path.name` in both upload code paths (local_api and rocklet)                                                                  
  - Add test assertions verifying `UploadResponse.success` and `file_name` fields                        
                                                                                                                                                                           
  fixes #<issue_number>                                                                                                                                                    
                                                       
  ## Test plan                                                                                                                                                             
                                                                                   
  - [x] `pytest tests/unit/rocklet/test_local_sandbox_runtime.py` — 4 passed
  - [ ] Upload a file to a live sandbox and verify response has `success: true`

fixes: #1059