### PR TITLE
fix(rocklet): pass sandbox_id in body to /execute and /read_file (#1065)

### DIFF
--- a/rock/admin/scheduler/task_base.py
+++ b/rock/admin/scheduler/task_base.py
@@ -192,7 +192,7 @@ class BaseTask(ABC):
         status = await self.get_task_status(runtime)
         if status is None or not status.pid:
             return
-        if await runtime.check_pid_exists(status.pid):
+        if await runtime.check_pid_exists(status.pid, sandbox_id="scheduler-task"):
             kill_cmd = f"pkill -9 -P {status.pid}; kill -9 {status.pid}"
             await runtime.execute(Command(command=kill_cmd, shell=True, sandbox_id="scheduler-task"))
             logger.info(f"[{self.type}] killed pid {status.pid} on worker[{ip}]")
@@ -230,7 +230,7 @@ class BaseTask(ABC):
 
         # Check if process is still running
         if status.pid and status.status == TaskStatusEnum.RUNNING:
-            pid_exists = await runtime.check_pid_exists(status.pid)
+            pid_exists = await runtime.check_pid_exists(status.pid, sandbox_id="scheduler-task")
             if pid_exists:
                 return False  # Process still running, skip
         if status.pid is None and status.status == TaskStatusEnum.FAILED:

--- a/rock/sandbox/operator/ray.py
+++ b/rock/sandbox/operator/ray.py
@@ -200,7 +200,7 @@ class RayOperator(AbstractOperator):
         find_file_rsp = await HttpUtils.post(
             url=execute_url,
             headers=headers,
-            data={"command": ["ls", service_status_path]},
+            data={"command": ["ls", service_status_path], "sandbox_id": sandbox_id},
             read_timeout=60,
         )
 
@@ -211,7 +211,7 @@ class RayOperator(AbstractOperator):
         response: dict = await HttpUtils.post(
             url=read_file_url,
             headers=headers,
-            data={"path": service_status_path},
+            data={"path": service_status_path, "sandbox_id": sandbox_id},
             read_timeout=60,
         )
         if response.get("content"):

--- a/rock/sandbox/remote_sandbox.py
+++ b/rock/sandbox/remote_sandbox.py
@@ -249,13 +249,18 @@ class RemoteSandboxRuntime(AbstractSandbox):
             msg += traceback.format_exc()
             return {}
 
-    async def check_pid_exists(self, pid: int) -> bool:
-        """Check if a process exists on the remote host."""
+    async def check_pid_exists(self, pid: int, sandbox_id: str) -> bool:
+        """Check if a process exists on the remote host.
+
+        ``sandbox_id`` satisfies the rocklet's NonBlankStr contract on
+        ``SandboxCommand`` (PR #985) and shows up in the rocklet access log
+        for tracing -- pass the caller's own context value.
+        """
         result = await self.execute(
             Command(
                 command=f"kill -0 {pid} 2>/dev/null && echo 'exists' || echo 'not_exists'",
                 shell=True,
-                sandbox_id="scheduler-task",
+                sandbox_id=sandbox_id,
             )
         )
         return result.stdout.strip() == "exists"

--- a/rock/sandbox/remote_sandbox.py
+++ b/rock/sandbox/remote_sandbox.py
@@ -252,7 +252,11 @@ class RemoteSandboxRuntime(AbstractSandbox):
     async def check_pid_exists(self, pid: int) -> bool:
         """Check if a process exists on the remote host."""
         result = await self.execute(
-            Command(command=f"kill -0 {pid} 2>/dev/null && echo 'exists' || echo 'not_exists'", shell=True)
+            Command(
+                command=f"kill -0 {pid} 2>/dev/null && echo 'exists' || echo 'not_exists'",
+                shell=True,
+                sandbox_id="scheduler-task",
+            )
         )
         return result.stdout.strip() == "exists"
 

--- a/tests/unit/sandbox/operator/test_ray_operator_get_remote_status.py
+++ b/tests/unit/sandbox/operator/test_ray_operator_get_remote_status.py
@@ -1,0 +1,57 @@
+"""Regression tests for RayOperator.get_remote_status request shape.
+
+PR #985 added ``NonBlankStr sandbox_id`` to ``SandboxCommand`` and
+``SandboxReadFileRequest`` in ``rock/admin/proto/request.py``. The rocklet's
+``/execute`` and ``/read_file`` endpoints deserialise into those models, so
+the request body must carry ``sandbox_id`` -- passing it only in the HTTP
+header (the pre-985 behaviour) now triggers 422 Unprocessable Entity from
+the rocklet, which bubbles up through ``get_status_v2`` as
+``Failed to get status``.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from rock.sandbox.operator.ray import RayOperator
+
+
+@pytest.fixture
+def operator() -> RayOperator:
+    return RayOperator(ray_service=MagicMock(), runtime_config=MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_get_remote_status_passes_sandbox_id_to_execute_body(operator: RayOperator):
+    sandbox_id = "sb-abc"
+    host_ip = "10.0.0.1"
+    with patch("rock.sandbox.operator.ray.HttpUtils.post", new=AsyncMock()) as mock_post:
+        # exit_code == 2 short-circuits before /read_file is called.
+        mock_post.return_value = {"exit_code": 2}
+        await operator.get_remote_status(sandbox_id, host_ip)
+
+    assert mock_post.call_count == 1
+    kwargs = mock_post.call_args.kwargs
+    assert "/execute" in kwargs["url"]
+    assert kwargs["data"].get("sandbox_id") == sandbox_id, (
+        "rocklet /execute requires sandbox_id in body (NonBlankStr); header-only sandbox_id triggers 422"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_remote_status_passes_sandbox_id_to_read_file_body(operator: RayOperator):
+    sandbox_id = "sb-abc"
+    host_ip = "10.0.0.1"
+    with patch("rock.sandbox.operator.ray.HttpUtils.post", new=AsyncMock()) as mock_post:
+        mock_post.side_effect = [
+            {"exit_code": 0},  # ls succeeded -> proceed to read_file
+            {"content": ""},  # empty content path
+        ]
+        await operator.get_remote_status(sandbox_id, host_ip)
+
+    assert mock_post.call_count == 2
+    read_file_kwargs = mock_post.call_args_list[1].kwargs
+    assert "/read_file" in read_file_kwargs["url"]
+    assert read_file_kwargs["data"].get("sandbox_id") == sandbox_id, (
+        "rocklet /read_file requires sandbox_id in body (NonBlankStr); header-only sandbox_id triggers 422"
+    )

--- a/tests/unit/sandbox/test_remote_sandbox_check_pid_exists.py
+++ b/tests/unit/sandbox/test_remote_sandbox_check_pid_exists.py
@@ -1,0 +1,29 @@
+"""Regression test for RemoteSandboxRuntime.check_pid_exists.
+
+PR #985 added ``NonBlankStr sandbox_id`` to ``SandboxCommand``. Constructing
+``Command(command=..., shell=True)`` without ``sandbox_id`` now raises
+``pydantic.ValidationError`` at construction time, breaking the scheduler's
+non-idempotent task cleanup path (``task_base.cleanup_on_worker`` ->
+``runtime.check_pid_exists``).
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from rock.actions import CommandResponse
+from rock.sandbox.remote_sandbox import RemoteSandboxRuntime
+
+
+@pytest.mark.asyncio
+async def test_check_pid_exists_constructs_command_with_non_blank_sandbox_id():
+    runtime = RemoteSandboxRuntime(host="http://127.0.0.1", port=22555)
+    runtime.execute = AsyncMock(return_value=CommandResponse(exit_code=0, stdout="exists\n", stderr=""))
+
+    # If Command construction raises ValidationError, this call will propagate it.
+    assert await runtime.check_pid_exists(1234) is True
+
+    cmd_arg = runtime.execute.call_args.args[0]
+    assert cmd_arg.sandbox_id and cmd_arg.sandbox_id.strip(), (
+        "SandboxCommand.sandbox_id is NonBlankStr; check_pid_exists must construct it with a non-blank placeholder"
+    )

--- a/tests/unit/sandbox/test_remote_sandbox_check_pid_exists.py
+++ b/tests/unit/sandbox/test_remote_sandbox_check_pid_exists.py
@@ -1,9 +1,9 @@
 """Regression test for RemoteSandboxRuntime.check_pid_exists.
 
-PR #985 added ``NonBlankStr sandbox_id`` to ``SandboxCommand``. Constructing
-``Command(command=..., shell=True)`` without ``sandbox_id`` now raises
-``pydantic.ValidationError`` at construction time, breaking the scheduler's
-non-idempotent task cleanup path (``task_base.cleanup_on_worker`` ->
+PR #985 added ``NonBlankStr sandbox_id`` to ``SandboxCommand``, so the
+caller-supplied ``sandbox_id`` must reach the wire request -- otherwise
+construction raises ``pydantic.ValidationError`` (breaking the scheduler's
+non-idempotent task cleanup path ``task_base.cleanup_on_worker`` ->
 ``runtime.check_pid_exists``).
 """
 
@@ -16,14 +16,11 @@ from rock.sandbox.remote_sandbox import RemoteSandboxRuntime
 
 
 @pytest.mark.asyncio
-async def test_check_pid_exists_constructs_command_with_non_blank_sandbox_id():
+async def test_check_pid_exists_forwards_sandbox_id_to_command():
     runtime = RemoteSandboxRuntime(host="http://127.0.0.1", port=22555)
     runtime.execute = AsyncMock(return_value=CommandResponse(exit_code=0, stdout="exists\n", stderr=""))
 
-    # If Command construction raises ValidationError, this call will propagate it.
-    assert await runtime.check_pid_exists(1234) is True
+    assert await runtime.check_pid_exists(1234, sandbox_id="scheduler-task") is True
 
     cmd_arg = runtime.execute.call_args.args[0]
-    assert cmd_arg.sandbox_id and cmd_arg.sandbox_id.strip(), (
-        "SandboxCommand.sandbox_id is NonBlankStr; check_pid_exists must construct it with a non-blank placeholder"
-    )
+    assert cmd_arg.sandbox_id == "scheduler-task"


### PR DESCRIPTION
fixes #1065

## Summary

PR #985 added `NonBlankStr` to `SandboxCommand.sandbox_id` and `SandboxReadFileRequest.sandbox_id`. Two internal call sites were missed:

- **`rock/sandbox/operator/ray.py:170-186`** (`get_remote_status`) — POSTed to rocklet `/execute` and `/read_file` with `sandbox_id` only in the HTTP header. Rocklet now rejects body with 422, surfacing in SDK as `Failed to get status: ... '422 Unprocessable Entity' for url 'http://<host>:22555/execute'` whenever Nacos `GET_STATUS_SWITCH` is on.
- **`rock/sandbox/remote_sandbox.py:252-257`** (`check_pid_exists`) — built `SandboxCommand(...)` without `sandbox_id`, raising `pydantic.ValidationError` at construction time. Breaks `task_base.cleanup_on_worker` for non-idempotent scheduler tasks (docuum / ImageCleanup).

## Fix

- Add `sandbox_id` to both rocklet HTTP bodies in `get_remote_status`.
- Pass `sandbox_id="scheduler-task"` to `Command(...)` in `check_pid_exists`, matching the placeholder convention PR #985 already established in `rock/admin/scheduler/task_base.py`.
- Audited the rest of the repo (HTTP callers, model construction, scheduler tasks, SDK, tests) — no other regressions.

## Test plan

- [x] `tests/unit/sandbox/operator/test_ray_operator_get_remote_status.py` — pins down that `sandbox_id` lives in the body of both `/execute` and `/read_file`.
- [x] `tests/unit/sandbox/test_remote_sandbox_check_pid_exists.py` — verifies `SandboxCommand` construction with non-blank `sandbox_id` and that `check_pid_exists` returns correctly.
- [x] Broader `tests/unit/sandbox/` + `tests/unit/admin/scheduler/` — 401 passed (5 unrelated docker-fixture timeouts on Redis/Postgres containers, env-only).
- [x] `ruff check` + `ruff format` — clean.

## Follow-up (not in this PR)

`rock/rocklet/server.py` does not register `request_validation_exception_handler`, so rocklet-side 422 responses are raw FastAPI JSON instead of the project `RockResponse(Failed)` envelope. Worth adding for envelope consistency on future drifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)