### PR TITLE
Fix exclude_dirs not working for empty directory cleanup 

### DIFF
--- a/rock/admin/scheduler/tasks/file_cleanup_task.py
+++ b/rock/admin/scheduler/tasks/file_cleanup_task.py
@@ -198,34 +198,56 @@ class FileCleanupTask(BaseTask):
         return f'-name "{value}"'
 
     @staticmethod
+    def _build_not_path_pattern(value: str, target_dir: str, is_dir: bool) -> str:
+        """Build a -not -path pattern for a single exclusion value.
+
+        Args:
+            value: The exclusion value (plain name, relative path, or absolute path)
+            target_dir: The target directory for resolving relative paths
+            is_dir: If True, also exclude descendants (*/pattern/*)
+
+        Returns:
+            A string of -not -path expressions
+        """
+        if value.startswith("/"):
+            pattern = value.rstrip("/")
+        elif "/" in value:
+            normalized = value.lstrip("./").strip("/")
+            pattern = f"{target_dir.rstrip('/')}/{normalized}"
+        else:
+            pattern = f"*/{value}"
+
+        expr = f'-not -path "{pattern}"'
+        if is_dir:
+            expr += f' -not -path "{pattern}/*"'
+        return expr
+
+    @staticmethod
     def _build_exclude_expr(dir_config: "TargetDirConfig") -> str:
         """Build the find exclusion expression for directories and files.
 
-        Supports both name-based and path-based exclusions. Values containing '/'
-        are treated as relative paths under target_dir and matched via -path.
-        Plain names are matched via -name.
+        NOTE: -delete implies -depth (GNU find documented behavior), which
+        disables -prune. We use -not -path filtering instead.
 
         Args:
             dir_config: The target directory configuration with its exclusions
 
         Returns:
-            A string of find prune/exclude expressions, or empty string if nothing to exclude.
+            A string of -not -path exclusion expressions, or empty string if nothing to exclude.
         """
         parts = []
         target_dir = dir_config.path
 
         for exclude_dir in dir_config.exclude_dirs:
-            match_expr = FileCleanupTask._build_match_expr(exclude_dir, target_dir)
-            parts.append(f"{match_expr} -prune")
+            parts.append(FileCleanupTask._build_not_path_pattern(exclude_dir, target_dir, is_dir=True))
 
         for exclude_file in dir_config.exclude_files:
-            match_expr = FileCleanupTask._build_match_expr(exclude_file, target_dir)
-            parts.append(f"{match_expr} -prune")
+            parts.append(FileCleanupTask._build_not_path_pattern(exclude_file, target_dir, is_dir=False))
 
         if not parts:
             return ""
 
-        return "\\( " + " -o ".join(parts) + " \\) -o "
+        return " ".join(parts) + " "
 
     def _build_cleanup_command(self, dir_config: TargetDirConfig) -> str:
         """Build the shell command for cleaning up files in a single directory.
@@ -253,19 +275,9 @@ class FileCleanupTask(BaseTask):
         size_find_expr = f"-size +{size_bytes}c"
         exclude_expr = self._build_exclude_expr(dir_config)
 
-        # Build directory exclusion for empty dir cleanup.
-        # NOTE: -depth disables -prune (GNU find documented behavior), so we
-        # use -not -path to filter out excluded dirs and their descendants.
         dir_exclude_not_parts = []
         for exclude_dir in dir_config.exclude_dirs:
-            if exclude_dir.startswith("/"):
-                pattern = exclude_dir.rstrip("/")
-            elif "/" in exclude_dir:
-                normalized = exclude_dir.lstrip("./").strip("/")
-                pattern = f"{target_dir.rstrip('/')}/{normalized}"
-            else:
-                pattern = f"*/{exclude_dir}"
-            dir_exclude_not_parts.append(f'-not -path "{pattern}" -not -path "{pattern}/*"')
+            dir_exclude_not_parts.append(self._build_not_path_pattern(exclude_dir, target_dir, is_dir=True))
         dir_exclude_expr = " ".join(dir_exclude_not_parts) + " " if dir_exclude_not_parts else ""
 
         # Step 1: Delete files (with exclusions) older than max_age_mins OR exceeding max_file_size

--- a/rock/admin/scheduler/tasks/file_cleanup_task.py
+++ b/rock/admin/scheduler/tasks/file_cleanup_task.py
@@ -253,14 +253,20 @@ class FileCleanupTask(BaseTask):
         size_find_expr = f"-size +{size_bytes}c"
         exclude_expr = self._build_exclude_expr(dir_config)
 
-        # Build directory exclusion for empty dir cleanup
-        dir_exclude_parts = []
+        # Build directory exclusion for empty dir cleanup.
+        # NOTE: -depth disables -prune (GNU find documented behavior), so we
+        # use -not -path to filter out excluded dirs and their descendants.
+        dir_exclude_not_parts = []
         for exclude_dir in dir_config.exclude_dirs:
-            match_expr = self._build_match_expr(exclude_dir, target_dir)
-            dir_exclude_parts.append(match_expr)
-        dir_exclude_expr = ""
-        if dir_exclude_parts:
-            dir_exclude_expr = "\\( " + " -o ".join(dir_exclude_parts) + " \\) -prune -o "
+            if exclude_dir.startswith("/"):
+                pattern = exclude_dir.rstrip("/")
+            elif "/" in exclude_dir:
+                normalized = exclude_dir.lstrip("./").strip("/")
+                pattern = f"{target_dir.rstrip('/')}/{normalized}"
+            else:
+                pattern = f"*/{exclude_dir}"
+            dir_exclude_not_parts.append(f'-not -path "{pattern}" -not -path "{pattern}/*"')
+        dir_exclude_expr = " ".join(dir_exclude_not_parts) + " " if dir_exclude_not_parts else ""
 
         # Step 1: Delete files (with exclusions) older than max_age_mins OR exceeding max_file_size
         # Step 2: Remove empty directories (bottom-up with -depth, excluding configured dirs)

--- a/tests/unit/admin/scheduler/test_file_cleanup_task.py
+++ b/tests/unit/admin/scheduler/test_file_cleanup_task.py
@@ -147,31 +147,69 @@ class TestBuildCleanupCommand:
         assert "-size +524288000c" in cmd
 
     def test_command_with_exclude_dirs(self):
+        """Regression: -delete implies -depth which disables -prune; must use -not -path."""
         dir_cfg = TargetDirConfig(path="/data/cache", exclude_dirs=["keep_me"])
         task = self._new_task(target_dirs=[dir_cfg])
         cmd = task._build_cleanup_command(dir_cfg)
-        # Step 1 (file deletion) still uses -prune (no -depth there)
-        assert '-name "keep_me" -prune' in cmd
+        assert "-prune" not in cmd
+        assert '-not -path "*/keep_me"' in cmd
+        assert '-not -path "*/keep_me/*"' in cmd
 
     def test_command_with_exclude_files(self):
         dir_cfg = TargetDirConfig(path="/data/cache", exclude_files=["important.log"])
         task = self._new_task(target_dirs=[dir_cfg])
         cmd = task._build_cleanup_command(dir_cfg)
-        assert '-name "important.log" -prune' in cmd
+        assert "-prune" not in cmd
+        assert '-not -path "*/important.log"' in cmd
 
-    def test_empty_dir_cleanup_uses_not_path_instead_of_prune(self):
-        """Regression: -depth disables -prune, so empty-dir cleanup must use -not -path."""
+    def test_command_no_prune_anywhere(self):
+        """Since both -delete (Step 1) and -depth (Step 2) disable -prune,
+        no generated command should ever contain -prune."""
+        dir_cfg = TargetDirConfig(
+            path="/data/logs",
+            exclude_dirs=["docker"],
+            exclude_files=["docuum.log", "./rocklet.log"],
+        )
+        task = self._new_task(target_dirs=[dir_cfg])
+        cmd = task._build_cleanup_command(dir_cfg)
+        assert "-prune" not in cmd
+
+    def test_step1_exclude_dirs_plain_name(self):
         dir_cfg = TargetDirConfig(path="/data/logs", exclude_dirs=["docker"])
         task = self._new_task(target_dirs=[dir_cfg])
         cmd = task._build_cleanup_command(dir_cfg)
-        # The second find (empty-dir cleanup) must NOT use -prune (it has -depth)
+        parts = cmd.split(";")
+        file_find = [p for p in parts if "-type f" in p][0]
+        assert '-not -path "*/docker"' in file_find
+        assert '-not -path "*/docker/*"' in file_find
+
+    def test_step1_exclude_dirs_absolute_path(self):
+        dir_cfg = TargetDirConfig(path="/data/logs", exclude_dirs=["/data/logs/special"])
+        task = self._new_task(target_dirs=[dir_cfg])
+        cmd = task._build_cleanup_command(dir_cfg)
+        parts = cmd.split(";")
+        file_find = [p for p in parts if "-type f" in p][0]
+        assert '-not -path "/data/logs/special"' in file_find
+        assert '-not -path "/data/logs/special/*"' in file_find
+
+    def test_step1_exclude_files_relative_path(self):
+        dir_cfg = TargetDirConfig(path="/data/logs", exclude_files=["./rocklet.log"])
+        task = self._new_task(target_dirs=[dir_cfg])
+        cmd = task._build_cleanup_command(dir_cfg)
+        parts = cmd.split(";")
+        file_find = [p for p in parts if "-type f" in p][0]
+        assert '-not -path "/data/logs/rocklet.log"' in file_find
+
+    def test_step2_exclude_dirs_plain_name(self):
+        dir_cfg = TargetDirConfig(path="/data/logs", exclude_dirs=["docker"])
+        task = self._new_task(target_dirs=[dir_cfg])
+        cmd = task._build_cleanup_command(dir_cfg)
         parts = cmd.split(";")
         empty_dir_find = [p for p in parts if "-type d -empty -delete" in p][0]
-        assert "-prune" not in empty_dir_find
         assert '-not -path "*/docker"' in empty_dir_find
         assert '-not -path "*/docker/*"' in empty_dir_find
 
-    def test_empty_dir_cleanup_exclude_absolute_path(self):
+    def test_step2_exclude_dirs_absolute_path(self):
         dir_cfg = TargetDirConfig(path="/data/logs", exclude_dirs=["/data/logs/special"])
         task = self._new_task(target_dirs=[dir_cfg])
         cmd = task._build_cleanup_command(dir_cfg)
@@ -180,7 +218,7 @@ class TestBuildCleanupCommand:
         assert '-not -path "/data/logs/special"' in empty_dir_find
         assert '-not -path "/data/logs/special/*"' in empty_dir_find
 
-    def test_empty_dir_cleanup_exclude_relative_path(self):
+    def test_step2_exclude_dirs_relative_path(self):
         dir_cfg = TargetDirConfig(path="/data/logs", exclude_dirs=["./sub/dir"])
         task = self._new_task(target_dirs=[dir_cfg])
         cmd = task._build_cleanup_command(dir_cfg)

--- a/tests/unit/admin/scheduler/test_file_cleanup_task.py
+++ b/tests/unit/admin/scheduler/test_file_cleanup_task.py
@@ -150,6 +150,7 @@ class TestBuildCleanupCommand:
         dir_cfg = TargetDirConfig(path="/data/cache", exclude_dirs=["keep_me"])
         task = self._new_task(target_dirs=[dir_cfg])
         cmd = task._build_cleanup_command(dir_cfg)
+        # Step 1 (file deletion) still uses -prune (no -depth there)
         assert '-name "keep_me" -prune' in cmd
 
     def test_command_with_exclude_files(self):
@@ -157,6 +158,36 @@ class TestBuildCleanupCommand:
         task = self._new_task(target_dirs=[dir_cfg])
         cmd = task._build_cleanup_command(dir_cfg)
         assert '-name "important.log" -prune' in cmd
+
+    def test_empty_dir_cleanup_uses_not_path_instead_of_prune(self):
+        """Regression: -depth disables -prune, so empty-dir cleanup must use -not -path."""
+        dir_cfg = TargetDirConfig(path="/data/logs", exclude_dirs=["docker"])
+        task = self._new_task(target_dirs=[dir_cfg])
+        cmd = task._build_cleanup_command(dir_cfg)
+        # The second find (empty-dir cleanup) must NOT use -prune (it has -depth)
+        parts = cmd.split(";")
+        empty_dir_find = [p for p in parts if "-type d -empty -delete" in p][0]
+        assert "-prune" not in empty_dir_find
+        assert '-not -path "*/docker"' in empty_dir_find
+        assert '-not -path "*/docker/*"' in empty_dir_find
+
+    def test_empty_dir_cleanup_exclude_absolute_path(self):
+        dir_cfg = TargetDirConfig(path="/data/logs", exclude_dirs=["/data/logs/special"])
+        task = self._new_task(target_dirs=[dir_cfg])
+        cmd = task._build_cleanup_command(dir_cfg)
+        parts = cmd.split(";")
+        empty_dir_find = [p for p in parts if "-type d -empty -delete" in p][0]
+        assert '-not -path "/data/logs/special"' in empty_dir_find
+        assert '-not -path "/data/logs/special/*"' in empty_dir_find
+
+    def test_empty_dir_cleanup_exclude_relative_path(self):
+        dir_cfg = TargetDirConfig(path="/data/logs", exclude_dirs=["./sub/dir"])
+        task = self._new_task(target_dirs=[dir_cfg])
+        cmd = task._build_cleanup_command(dir_cfg)
+        parts = cmd.split(";")
+        empty_dir_find = [p for p in parts if "-type d -empty -delete" in p][0]
+        assert '-not -path "/data/logs/sub/dir"' in empty_dir_find
+        assert '-not -path "/data/logs/sub/dir/*"' in empty_dir_find
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
 Summary                                                                                                                                                                                                            
  
  - Fix FileCleanupTask empty-directory cleanup ignoring exclude_dirs because -depth disables -prune (GNU find documented behavior)                                                                                  
  - Replace -prune with -not -path filtering in the Step 2 (empty dir) find command, which works correctly under -depth
  - Add regression tests covering plain name, absolute path, and relative path exclusion patterns                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                     
  Test plan                                                                                                                                                                                                          
                                                            
  - test_empty_dir_cleanup_uses_not_path_instead_of_prune — verifies -not -path is used instead of -prune in the empty-dir find                                                                                      
  - test_empty_dir_cleanup_exclude_absolute_path — absolute path exclusion pattern
  - test_empty_dir_cleanup_exclude_relative_path — relative path exclusion pattern                                                                                                                                   
  - All 34 existing tests pass                                                                                                                                                                                       
  - Deploy to staging and verify /data/logs/xxxx/docker/ empty subdirs survive a cleanup cycle 
  Fixes  #1071