### PR TITLE
Fix docuum not restarting due to PID/TID reuse in check_pid_exists  

### DIFF
--- a/rock/admin/scheduler/task_base.py
+++ b/rock/admin/scheduler/task_base.py
@@ -70,10 +70,12 @@ class BaseTask(ABC):
         type: str,
         interval_seconds: int,
         idempotency: IdempotencyType = IdempotencyType.IDEMPOTENT,
+        process_name: str | None = None,
     ):
         self.type = type
         self.interval_seconds = interval_seconds
         self.idempotency = idempotency
+        self.process_name = process_name
         self.status_file_path = f"{env_vars.ROCK_SCHEDULER_STATUS_DIR}/{type}_status.json"
         self._executor = ThreadPoolExecutor(max_workers=100)
 
@@ -192,7 +194,7 @@ class BaseTask(ABC):
         status = await self.get_task_status(runtime)
         if status is None or not status.pid:
             return
-        if await runtime.check_pid_exists(status.pid, sandbox_id="scheduler-task"):
+        if await runtime.check_pid_exists(status.pid, sandbox_id="scheduler-task", process_name=self.process_name):
             kill_cmd = f"pkill -9 -P {status.pid}; kill -9 {status.pid}"
             await runtime.execute(Command(command=kill_cmd, shell=True, sandbox_id="scheduler-task"))
             logger.info(f"[{self.type}] killed pid {status.pid} on worker[{ip}]")
@@ -230,7 +232,9 @@ class BaseTask(ABC):
 
         # Check if process is still running
         if status.pid and status.status == TaskStatusEnum.RUNNING:
-            pid_exists = await runtime.check_pid_exists(status.pid, sandbox_id="scheduler-task")
+            pid_exists = await runtime.check_pid_exists(
+                status.pid, sandbox_id="scheduler-task", process_name=self.process_name
+            )
             if pid_exists:
                 return False  # Process still running, skip
         if status.pid is None and status.status == TaskStatusEnum.FAILED:

--- a/rock/admin/scheduler/tasks/image_cleanup_task.py
+++ b/rock/admin/scheduler/tasks/image_cleanup_task.py
@@ -47,6 +47,7 @@ class ImageCleanupTask(BaseTask):
             type="image_cleanup",
             interval_seconds=interval_seconds,
             idempotency=IdempotencyType.NON_IDEMPOTENT,
+            process_name="docuum",
         )
         self.disk_threshold = disk_threshold
         self.image_whitelist = image_whitelist or []

--- a/rock/sandbox/remote_sandbox.py
+++ b/rock/sandbox/remote_sandbox.py
@@ -249,16 +249,30 @@ class RemoteSandboxRuntime(AbstractSandbox):
             msg += traceback.format_exc()
             return {}
 
-    async def check_pid_exists(self, pid: int, sandbox_id: str) -> bool:
+    async def check_pid_exists(self, pid: int, sandbox_id: str, process_name: str | None = None) -> bool:
         """Check if a process exists on the remote host.
 
         ``sandbox_id`` satisfies the rocklet's NonBlankStr contract on
         ``SandboxCommand`` (PR #985) and shows up in the rocklet access log
         for tracing -- pass the caller's own context value.
+
+        When ``process_name`` is given, the check also verifies that the
+        process at ``pid`` matches the expected name via /proc/<pid>/cmdline.
+        This guards against PID reuse (another process or a thread of
+        another process occupying the same PID/TID after the original
+        process exited).
         """
+        if process_name:
+            cmd = (
+                f"kill -0 {pid} 2>/dev/null "
+                f"&& cat /proc/{pid}/cmdline 2>/dev/null | tr '\\0' ' ' | grep -q '{process_name}' "
+                f"&& echo 'exists' || echo 'not_exists'"
+            )
+        else:
+            cmd = f"kill -0 {pid} 2>/dev/null && echo 'exists' || echo 'not_exists'"
         result = await self.execute(
             Command(
-                command=f"kill -0 {pid} 2>/dev/null && echo 'exists' || echo 'not_exists'",
+                command=cmd,
                 shell=True,
                 sandbox_id=sandbox_id,
             )

--- a/tests/unit/sandbox/test_remote_sandbox_check_pid_exists.py
+++ b/tests/unit/sandbox/test_remote_sandbox_check_pid_exists.py
@@ -24,3 +24,52 @@ async def test_check_pid_exists_forwards_sandbox_id_to_command():
 
     cmd_arg = runtime.execute.call_args.args[0]
     assert cmd_arg.sandbox_id == "scheduler-task"
+
+
+@pytest.mark.asyncio
+async def test_check_pid_exists_without_process_name_uses_kill_only():
+    runtime = RemoteSandboxRuntime(host="http://127.0.0.1", port=22555)
+    runtime.execute = AsyncMock(return_value=CommandResponse(exit_code=0, stdout="exists\n", stderr=""))
+
+    result = await runtime.check_pid_exists(1234, sandbox_id="scheduler-task")
+
+    assert result is True
+    cmd = runtime.execute.call_args.args[0].command
+    assert "kill -0 1234" in cmd
+    assert "/proc/" not in cmd
+
+
+@pytest.mark.asyncio
+async def test_check_pid_exists_with_process_name_verifies_cmdline():
+    runtime = RemoteSandboxRuntime(host="http://127.0.0.1", port=22555)
+    runtime.execute = AsyncMock(return_value=CommandResponse(exit_code=0, stdout="exists\n", stderr=""))
+
+    result = await runtime.check_pid_exists(8959, sandbox_id="scheduler-task", process_name="docuum")
+
+    assert result is True
+    cmd = runtime.execute.call_args.args[0].command
+    assert "kill -0 8959" in cmd
+    assert "/proc/8959/cmdline" in cmd
+    assert "docuum" in cmd
+
+
+@pytest.mark.asyncio
+async def test_check_pid_exists_with_process_name_rejects_wrong_process():
+    """PID exists but belongs to a different process (e.g. containerd thread reusing TID)."""
+    runtime = RemoteSandboxRuntime(host="http://127.0.0.1", port=22555)
+    runtime.execute = AsyncMock(return_value=CommandResponse(exit_code=0, stdout="not_exists\n", stderr=""))
+
+    result = await runtime.check_pid_exists(8959, sandbox_id="scheduler-task", process_name="docuum")
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_check_pid_exists_with_process_name_not_exists():
+    """PID does not exist at all (kill -0 fails)."""
+    runtime = RemoteSandboxRuntime(host="http://127.0.0.1", port=22555)
+    runtime.execute = AsyncMock(return_value=CommandResponse(exit_code=0, stdout="not_exists\n", stderr=""))
+
+    result = await runtime.check_pid_exists(9999, sandbox_id="scheduler-task", process_name="docuum")
+
+    assert result is False


### PR DESCRIPTION
## Summary                                                                                                                                                                                                         
                                                                                                                                                                                                                     
  - Add `process_name` parameter to `RemoteSandboxRuntime.check_pid_exists` to verify `/proc/{pid}/cmdline` matches the expected process, preventing PID/TID reuse false positives                                   
  - Add `process_name` field to `BaseTask` so non-idempotent tasks can declare their daemon name                                                                                                                     
  - Set `process_name="docuum"` in `ImageCleanupTask`                                                                                                                                                                
  - Backward compatible: existing callers without `process_name` use the original `kill -0` behavior                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                                                       
                                         
  - [x] `test_check_pid_exists_without_process_name_uses_kill_only` — backward compat                                                                                                                                
  - [x] `test_check_pid_exists_with_process_name_verifies_cmdline` — new cmdline check
  - [x] `test_check_pid_exists_with_process_name_rejects_wrong_process` — PID reuse scenario                                                                                                                         
  - [x] `test_check_pid_exists_with_process_name_not_exists` — PID gone entirely                                                                                                                                     
  - [x] All 24 related tests pass                                                                                                                                                                                    
  - [ ] Deploy to vpc-sg-b, delete status file on affected workers, verify docuum restarts and survives subsequent scheduler cycles 
  Fixes #1073 