### PR TITLE
chore: bump version to 1.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 authors = [{ name = "chatos@alibaba" }]
 requires-python = "<4.0,>=3.10"
 name = "rl-rock"
-version = "1.8.3"
+version = "1.9.0"
 description = "ROCK-Reinforcement Open Construction Kit"
 readme = "README.md"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -4280,7 +4280,7 @@ wheels = [
 
 [[package]]
 name = "rl-rock"
-version = "1.8.0"
+version = "1.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },

--- a/uv.lock
+++ b/uv.lock
@@ -4280,7 +4280,7 @@ wheels = [
 
 [[package]]
 name = "rl-rock"
-version = "1.8.3"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                                                 
  - Bump package version from 1.8.3 to 1.9.0 in `pyproject.toml`                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  
  ## Test plan                                                                                                                                                                                                                                                               
  - [ ] `uv sync` succeeds with new version                                                                                                                                                                                                                                  
  - [ ] `python -c "import rock; print(rock.__version__)"` outputs `1.9.0`  
  
Fixes #1077      