### PR TITLE
fix: unify archive_prefix default to `rock-archives/` for config and CLI

### DIFF
--- a/rock/cli/command/storage.py
+++ b/rock/cli/command/storage.py
@@ -91,10 +91,10 @@ class StorageCommand(Command):
         get_p.add_argument(
             "--archive-prefix",
             dest="archive_prefix",
-            default="",
+            default="rock-archives/",
             help=(
                 "OSS key prefix used at archive time (must match admin's "
-                "sandbox_config.log.archive_prefix, e.g. 'rock-archives/')."
+                "sandbox_config.log.archive_prefix). Default: 'rock-archives/'."
             ),
         )
         get_p.add_argument(

--- a/rock/config.py
+++ b/rock/config.py
@@ -63,11 +63,10 @@ class SandboxLogConfig:
     bucket / credentials still belong to OssConfig.primary.
     """
 
-    archive_prefix: str = ""
+    archive_prefix: str = "rock-archives/"
     """OSS object key prefix under OssConfig.primary.bucket for sandbox-log
-    archives. Empty (default) means each deployment's YAML must opt-in
-    explicitly to a value matching its OSS bucket lifecycle rule (e.g.
-    "rock-archives/")."""
+    archives. The canonical default ``rock-archives/`` ensures all clusters
+    write to a unified namespace. Override only for migration scenarios."""
 
     keep_days_before_archive: int = 3
     """Days to wait after sandbox stop before archiving. Gives operators


### PR DESCRIPTION
## Summary

- Change `SandboxLogConfig.archive_prefix` default from `""` to `"rock-archives/"` so new deployments that omit the field in YAML still write to the correct namespace.
- Change `rock storage get` CLI `--archive-prefix` default from `""` to `"rock-archives/"` so downloads match the admin write path without requiring users to pass the flag manually.

## Motivation

All internal deployment YAMLs already explicitly set `archive_prefix: "rock-archives/"`, but the code defaults were still empty string. This caused two issues:

1. Users running `rock storage get sb-xxx` without `--archive-prefix` got `NOT FOUND` because the CLI looked in the wrong OSS path.
2. Any new cluster or Nacos hot-reload that omitted `archive_prefix` would silently write archives to the bucket root, creating a split between `sandbox-logs/` and `rock-archives/sandbox-logs/`.

## Changes

| File | Change |
|------|--------|
| `rock/config.py` | `archive_prefix: str = ""` → `"rock-archives/"` |
| `rock/cli/command/storage.py` | `--archive-prefix` default `""` → `"rock-archives/"` |

## Test Plan

- [x] All 41 existing unit tests pass (test_archive_command, test_storage, test_sandbox_log_archive_task)
- [ ] Verify `rock storage get <sandbox_id>` downloads successfully without `--archive-prefix` flag against a real cluster
- [ ] Confirm existing deployments with explicit YAML `archive_prefix: "rock-archives/"` are unaffected (explicit value overrides default)

fixes #1086 