### PR TITLE
fix(proxy): route custom ports through Rocklet instead of direct connect

### DIFF
--- a/rock/rocklet/local_api.py
+++ b/rock/rocklet/local_api.py
@@ -4,7 +4,9 @@ import tempfile
 import zipfile
 from pathlib import Path
 
-from fastapi import APIRouter, File, Form, UploadFile, WebSocket, WebSocketDisconnect
+import httpx
+from fastapi import APIRouter, File, Form, Request, Response, UploadFile, WebSocket, WebSocketDisconnect
+from fastapi.responses import JSONResponse, StreamingResponse
 
 from rock.actions import (
     CloseResponse,
@@ -271,3 +273,167 @@ async def portforward(websocket: WebSocket, port: int):
             f"ws->tcp: {ws_to_tcp_msgs} msgs, {ws_to_tcp_bytes} bytes, "
             f"tcp->ws: {tcp_to_ws_msgs} msgs, {tcp_to_ws_bytes} bytes"
         )
+
+
+# ---------------------------------------------------------------------------
+# HTTP / WebSocket proxy — forward to arbitrary ports on localhost
+# ---------------------------------------------------------------------------
+
+EXCLUDED_PROXY_HEADERS = {"host", "content-length", "transfer-encoding", "content-encoding"}
+
+
+@local_router.api_route(
+    "/proxy/{target_port}/{path:path}",
+    methods=["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"],
+)
+async def http_proxy_to_port(target_port: int, path: str, request: Request):
+    """HTTP proxy to a specific port on localhost inside the container.
+
+    Used by the admin's HTTP proxy when the caller specifies a non-default
+    target port (via Path / Header / Query).  The admin routes the request
+    to Rocklet (Port.PROXY = 22555) which then forwards it to
+    ``localhost:{target_port}`` inside the container.
+    """
+    is_valid, error_message = validate_port_forward_port(target_port)
+    if not is_valid:
+        return JSONResponse(status_code=400, content={"detail": error_message})
+
+    logger.info(f"[Proxy] HTTP proxy request: target_port={target_port}, path={path}, method={request.method}")
+
+    qs = str(request.url.query)
+    target_url = f"http://127.0.0.1:{target_port}/{path}"
+    if qs:
+        target_url += f"?{qs}"
+
+    raw_body = None
+    if request.method not in ("GET", "HEAD", "DELETE", "OPTIONS"):
+        raw_body = await request.body()
+
+    filtered_headers = {k: v for k, v in request.headers.items() if k.lower() not in EXCLUDED_PROXY_HEADERS}
+
+    client = httpx.AsyncClient(timeout=httpx.Timeout(None))
+    try:
+        resp = await client.send(
+            client.build_request(
+                method=request.method,
+                url=target_url,
+                headers=filtered_headers,
+                content=raw_body,
+                timeout=120,
+            ),
+            stream=True,
+        )
+    except Exception as e:
+        await client.aclose()
+        logger.error(f"[Proxy] HTTP proxy error: target_port={target_port}, error={e}")
+        return JSONResponse(status_code=502, content={"detail": f"Failed to connect to port {target_port}: {e}"})
+
+    content_type = resp.headers.get("content-type", "")
+    is_sse = "text/event-stream" in content_type
+    response_headers = {k: v for k, v in resp.headers.items() if k.lower() not in EXCLUDED_PROXY_HEADERS}
+
+    if is_sse:
+
+        async def event_stream():
+            try:
+                if resp.status_code >= 400:
+                    yield await resp.aread()
+                    return
+                async for chunk in resp.aiter_bytes():
+                    if chunk:
+                        yield chunk
+            finally:
+                await resp.aclose()
+                await client.aclose()
+
+        return StreamingResponse(
+            event_stream(),
+            status_code=resp.status_code,
+            media_type="text/event-stream",
+            headers=response_headers,
+        )
+
+    try:
+        raw_content = await resp.aread()
+        if "application/json" in content_type:
+            return JSONResponse(
+                status_code=resp.status_code,
+                content=resp.json(),
+                headers=response_headers,
+            )
+        return Response(
+            status_code=resp.status_code,
+            content=raw_content,
+            media_type=content_type or "application/octet-stream",
+            headers=response_headers,
+        )
+    finally:
+        await resp.aclose()
+        await client.aclose()
+
+
+@local_router.websocket("/proxy/{target_port}/{path:path}")
+async def ws_proxy_to_port(websocket: WebSocket, target_port: int, path: str = ""):
+    """WebSocket proxy to a specific port on localhost inside the container.
+
+    Used by the admin's WebSocket proxy when the caller specifies a non-default
+    target port.  The admin routes the WS connection to Rocklet which then
+    forwards it to ``localhost:{target_port}`` inside the container.
+    """
+    is_valid, error_message = validate_port_forward_port(target_port)
+    if not is_valid:
+        await websocket.close(code=1008, reason=error_message)
+        return
+
+    logger.info(f"[Proxy] WebSocket proxy request: target_port={target_port}, path={path}")
+
+    await websocket.accept()
+
+    client_subprotocols = list(getattr(websocket, "subprotocols", []) or [])
+
+    target_url = f"ws://127.0.0.1:{target_port}/{path}"
+    import websockets as websockets_lib
+
+    try:
+        async with websockets_lib.connect(
+            target_url,
+            ping_interval=None,
+            ping_timeout=None,
+            subprotocols=client_subprotocols or None,
+        ) as target_ws:
+
+            async def client_to_target():
+                while True:
+                    msg = await websocket.receive()
+                    if msg["type"] == "websocket.disconnect":
+                        break
+                    if msg.get("bytes"):
+                        await target_ws.send(msg["bytes"])
+                    elif msg.get("text"):
+                        await target_ws.send(msg["text"])
+
+            async def target_to_client():
+                async for data in target_ws:
+                    if isinstance(data, bytes):
+                        await websocket.send_bytes(data)
+                    else:
+                        await websocket.send_text(data)
+
+            done, pending = await asyncio.wait(
+                [asyncio.create_task(client_to_target()), asyncio.create_task(target_to_client())],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for task in pending:
+                task.cancel()
+    except websockets_lib.exceptions.ConnectionClosed as e:
+        logger.info(f"[Proxy] Target WS closed: target_port={target_port}, code={e.code}")
+        try:
+            await websocket.close(code=e.code, reason=e.reason or "")
+        except Exception:
+            pass
+    except Exception as e:
+        logger.error(f"[Proxy] WS proxy error: target_port={target_port}, error={e}")
+        try:
+            await websocket.close(code=1011, reason=f"Proxy error: {e}")
+        except Exception:
+            pass

--- a/rock/sandbox/service/sandbox_proxy_service.py
+++ b/rock/sandbox/service/sandbox_proxy_service.py
@@ -749,21 +749,26 @@ class SandboxProxyService:
     async def get_sandbox_websocket_url(
         self, sandbox_id: str, target_path: str | None = None, port: int | None = None
     ) -> str:
-        # if sandbox_id == "iflow-local":   # Local debugging for iflow-cli
-        #     return "ws://127.0.0.1:8090/acp"
-        # if sandbox_id == "local":   # Local debugging for general ws service
-        #     return "ws://127.0.0.1:8090/ws"
-        # Get sandbox  address based on sandbox_id
+        # Get sandbox address based on sandbox_id
         status_dicts = await self.get_service_status(sandbox_id)
         host_ip = status_dicts[0].get("host_ip")
-        if port is None:
-            service_status = ServiceStatus.from_dict(status_dicts[0])
-            port = service_status.get_mapped_port(Port.SERVER)
+        service_status = ServiceStatus.from_dict(status_dicts[0])
 
-        if target_path:
-            return f"ws://{host_ip}:{port}/{target_path}"
+        if port is None or port == Port.SERVER.value:
+            # Default: use SERVER port (8080) mapped to host
+            mapped_port = service_status.get_mapped_port(Port.SERVER)
+            if target_path:
+                return f"ws://{host_ip}:{mapped_port}/{target_path}"
+            else:
+                return f"ws://{host_ip}:{mapped_port}"
         else:
-            return f"ws://{host_ip}:{port}"
+            # Custom port: route through Rocklet (PROXY port) which lives inside the
+            # container and can reach ``localhost:{port}`` reliably.
+            rocklet_port = service_status.get_mapped_port(Port.PROXY)
+            safe_path = target_path.lstrip("/") if target_path else ""
+            url = f"ws://{host_ip}:{rocklet_port}/proxy/{port}/{safe_path}"
+            logger.info(f"[Proxy] WebSocket routing custom port {port} via Rocklet: {url}")
+            return url
 
     async def _forward_messages(self, source_ws, target_ws, direction: str):
         """Forward WebSocket messages bidirectionally.
@@ -939,11 +944,21 @@ class SandboxProxyService:
         status_list = await self.get_service_status(sandbox_id)
 
         host_ip = status_list[0].get("host_ip")
-        if port is None:
-            service_status = ServiceStatus.from_dict(status_list[0])
-            port = service_status.get_mapped_port(Port.SERVER)
+        service_status = ServiceStatus.from_dict(status_list[0])
         qs = f"?{query_string}" if query_string else ""
-        target_url = f"http://{host_ip}:{port}/{target_path}{qs}"
+        if port is None or port == Port.SERVER.value:
+            # Default behaviour: forward to the SERVER port (8080) directly via host_ip
+            mapped_port = service_status.get_mapped_port(Port.SERVER)
+            target_url = f"http://{host_ip}:{mapped_port}/{target_path}{qs}"
+        else:
+            # Custom port: route through Rocklet (PROXY port) which lives inside the
+            # container and can reach ``localhost:{port}`` reliably.  Direct
+            # ``host_ip:{custom_port}`` connections fail because arbitrary container
+            # ports are not mapped to the host.
+            rocklet_port = service_status.get_mapped_port(Port.PROXY)
+            safe_path = target_path.lstrip("/")
+            target_url = f"http://{host_ip}:{rocklet_port}/proxy/{port}/{safe_path}{qs}"
+            logger.info(f"[Proxy] Routing custom port {port} via Rocklet: {target_url}")
 
         request_headers = filter_headers(headers)
         request_kwargs: dict = {"content": body} if body else {}

--- a/tests/unit/sandbox/test_proxy_custom_port_routing.py
+++ b/tests/unit/sandbox/test_proxy_custom_port_routing.py
@@ -1,0 +1,192 @@
+"""Test that custom ports are routed through Rocklet (Port.PROXY) instead of direct connect.
+
+Regression test for the bug where http_proxy and websocket_proxy would attempt to
+connect directly to host_ip:{custom_port}, which fails because arbitrary container
+ports are not mapped to the host. The fix routes custom ports through Rocklet's
+/proxy/{port}/{path} endpoint which lives inside the container.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from rock.deployments.constants import Port
+from rock.deployments.status import ServiceStatus
+from rock.sandbox.service.sandbox_proxy_service import SandboxProxyService
+
+
+@pytest.fixture
+def mock_meta_store():
+    store = AsyncMock()
+    store.get = AsyncMock(
+        return_value={
+            "host_ip": "10.0.0.1",
+            "ports": {
+                str(Port.SSH): 22,
+                str(Port.PROXY): 22555,
+                str(Port.SERVER): 8080,
+            },
+        }
+    )
+    store.get_timeout = AsyncMock(return_value=None)
+    return store
+
+
+@pytest.fixture
+def proxy_service(mock_meta_store, tmp_path):
+    config = AsyncMock()
+    config.proxy_service.timeout = 30
+    config.proxy_service.max_connections = 100
+    config.proxy_service.max_keepalive_connections = 20
+    config.oss.access_key_id = ""
+    config.oss.access_key_secret = ""
+    config.oss.role_arn = ""
+    config.oss.endpoint = ""
+    config.oss.bucket = ""
+    config.oss.region = ""
+    config.oss.primary.access_key_id = ""
+    config.oss.primary.access_key_secret = ""
+    config.oss.primary.role_arn = ""
+    config.oss.primary.endpoint = ""
+    config.oss.primary.bucket = ""
+    config.oss.primary.region = ""
+    config.proxy_service.batch_get_status_max_count = 100
+    config.runtime.metrics_endpoint = None
+    config.runtime.user_defined_tags = {}
+    config.sandbox_config.file_transfer.prefix = None
+
+    service = SandboxProxyService.__new__(SandboxProxyService)
+    service._meta_store = mock_meta_store
+    service._rock_config = config
+    service.oss_config = config.oss
+    service.proxy_config = config.proxy_service
+    return service
+
+
+@pytest.mark.asyncio
+async def test_http_proxy_custom_port_routes_via_rocklet(proxy_service):
+    """When a custom port is specified, http_proxy should route through Rocklet."""
+    with patch("rock.sandbox.service.sandbox_proxy_service.ServiceStatus") as mock_status_cls:
+        mock_status = mock_status_cls.from_dict.return_value
+        mock_status.get_mapped_port.side_effect = lambda p: {
+            Port.SERVER: 8080,
+            Port.PROXY: 22555,
+        }[p]
+
+        # Mock httpx to capture the URL
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.json = AsyncMock(return_value={"ok": True})
+        mock_response.aread = AsyncMock(return_value=b'{"ok": true}')
+        mock_response.aclose = AsyncMock()
+
+        mock_client = AsyncMock()
+        mock_client.send = AsyncMock(return_value=mock_response)
+        mock_client.build_request = AsyncMock(return_value=mock_response)
+        mock_client.aclose = AsyncMock()
+
+        with patch("rock.sandbox.service.sandbox_proxy_service.httpx.AsyncClient", return_value=mock_client):
+            from starlette.datastructures import Headers
+
+            await proxy_service.http_proxy(
+                sandbox_id="test-sandbox",
+                target_path="api/test",
+                body=None,
+                headers=Headers({"content-type": "application/json"}),
+                method="GET",
+                port=9000,  # Custom port
+                proxy_prefix="/sandboxes/test-sandbox/proxy",
+            )
+
+        # Verify the request went to Rocklet port 22555, not direct to 9000
+        build_request_call = mock_client.build_request.call_args
+        url = build_request_call.kwargs.get("url") or build_request_call.args[1]
+        assert ":22555/" in url, f"Expected Rocklet port 22555 in URL, got: {url}"
+        assert "/proxy/9000/" in url, f"Expected /proxy/9000/ in URL, got: {url}"
+        assert ":9000/" not in url, f"Should not connect directly to port 9000: {url}"
+
+
+@pytest.mark.asyncio
+async def test_http_proxy_default_port_direct_connect(proxy_service):
+    """When no port is specified (default 8080), http_proxy should connect directly."""
+    with patch("rock.sandbox.service.sandbox_proxy_service.ServiceStatus") as mock_status_cls:
+        mock_status = mock_status_cls.from_dict.return_value
+        mock_status.get_mapped_port.side_effect = lambda p: {
+            Port.SERVER: 8080,
+            Port.PROXY: 22555,
+        }[p]
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.json = AsyncMock(return_value={"ok": True})
+        mock_response.aread = AsyncMock(return_value=b'{"ok": true}')
+        mock_response.aclose = AsyncMock()
+
+        mock_client = AsyncMock()
+        mock_client.send = AsyncMock(return_value=mock_response)
+        mock_client.build_request = AsyncMock(return_value=mock_response)
+        mock_client.aclose = AsyncMock()
+
+        with patch("rock.sandbox.service.sandbox_proxy_service.httpx.AsyncClient", return_value=mock_client):
+            from starlette.datastructures import Headers
+
+            await proxy_service.http_proxy(
+                sandbox_id="test-sandbox",
+                target_path="api/test",
+                body=None,
+                headers=Headers({"content-type": "application/json"}),
+                method="GET",
+                port=None,  # Default port
+                proxy_prefix="/sandboxes/test-sandbox/proxy",
+            )
+
+        # Verify the request went directly to port 8080
+        build_request_call = mock_client.build_request.call_args
+        url = build_request_call.kwargs.get("url") or build_request_call.args[1]
+        assert ":8080/" in url, f"Expected direct connect to port 8080, got: {url}"
+        assert "/proxy/" not in url, f"Default port should not use /proxy/ route: {url}"
+
+
+@pytest.mark.asyncio
+async def test_websocket_url_custom_port_routes_via_rocklet(proxy_service):
+    """When a custom port is specified, get_sandbox_websocket_url should route through Rocklet."""
+    with patch("rock.sandbox.service.sandbox_proxy_service.ServiceStatus") as mock_status_cls:
+        mock_status = mock_status_cls.from_dict.return_value
+        mock_status.get_mapped_port.side_effect = lambda p: {
+            Port.SERVER: 8080,
+            Port.PROXY: 22555,
+        }[p]
+
+        url = await proxy_service.get_sandbox_websocket_url(
+            sandbox_id="test-sandbox",
+            target_path="ws",
+            port=9000,  # Custom port
+        )
+
+        # Verify the URL routes through Rocklet
+        assert ":22555/" in url, f"Expected Rocklet port 22555 in URL, got: {url}"
+        assert "/proxy/9000/" in url, f"Expected /proxy/9000/ in URL, got: {url}"
+        assert ":9000/" not in url, f"Should not connect directly to port 9000: {url}"
+
+
+@pytest.mark.asyncio
+async def test_websocket_url_default_port_direct_connect(proxy_service):
+    """When no port is specified (default 8080), get_sandbox_websocket_url should connect directly."""
+    with patch("rock.sandbox.service.sandbox_proxy_service.ServiceStatus") as mock_status_cls:
+        mock_status = mock_status_cls.from_dict.return_value
+        mock_status.get_mapped_port.side_effect = lambda p: {
+            Port.SERVER: 8080,
+            Port.PROXY: 22555,
+        }[p]
+
+        url = await proxy_service.get_sandbox_websocket_url(
+            sandbox_id="test-sandbox",
+            target_path="ws",
+            port=None,  # Default port
+        )
+
+        # Verify the URL connects directly to port 8080
+        assert ":8080/" in url, f"Expected direct connect to port 8080, got: {url}"
+        assert "/proxy/" not in url, f"Default port should not use /proxy/ route: {url}"


### PR DESCRIPTION
## Problem

When users specify a custom port (not the default 8080) in HTTP or WebSocket proxy requests via Path/Header/Query parameters, the proxy attempts to connect directly to `host_ip:{custom_port}`. This fails because arbitrary container ports are not mapped to the host network.

## Root Cause

In `sandbox_proxy_service.py`:
- `http_proxy()`: When a custom port is specified, it constructs `target_url = f"http://{host_ip}:{port}/..."` directly
- `get_sandbox_websocket_url()`: Same issue for WebSocket connections

However, only the default SERVER port (8080) is mapped from container to host. Custom ports like 9000, 3000 exist inside the container but are not accessible via `host_ip:9000` from outside.

## Solution

### 1. Add proxy endpoints to Rocklet (`rock/rocklet/local_api.py`)

- `/proxy/{port}/{path}` for HTTP requests
- `/proxy/{port}/{path}` for WebSocket connections

These endpoints run inside the container on Port.PROXY (22555) and can access `localhost:{custom_port}` reliably.

### 2. Modify `sandbox_proxy_service.py` to route custom ports through Rocklet

- When port is `None` or `8080`: use direct connection (backward compatible)
- When port is custom (e.g. `9000`): route through `{rocklet_port}/proxy/{port}/{path}`

### 3. Add tests

Comprehensive tests for routing logic in `tests/unit/sandbox/test_proxy_custom_port_routing.py`.

## Impact

Users can now expose services running on arbitrary ports inside sandboxes to external clients, not just the default 8080 port. This enables scenarios like running multiple services on different ports within a single sandbox.

## Testing

- Verified routing logic with mock tests
- Tested with actual sandbox on vpc-sg-a cluster
- Default port (8080) behavior unchanged (backward compatible)
- Custom ports (9000, 3000, etc.) now route through Rocklet successfully

fixes #1092