### PR TITLE
feat(archive): define storage interfaces with S3, OSS, and Registry V2 implementations

### DIFF
--- a/rock/config.py
+++ b/rock/config.py
@@ -153,6 +153,49 @@ class OssConfig:
 
 
 @dataclass
+class ArchiveDirStorageConfig:
+    type: str = "oss"
+    endpoint: str = ""
+    bucket: str = ""
+    access_key_id: str = ""
+    access_key_secret: str = ""
+    region: str = ""
+
+
+@dataclass
+class ArchiveAcrConfig:
+    registry_url: str = ""
+    username: str = ""
+    password: str = ""
+    namespace: str = "sandbox_archive"
+
+
+@dataclass
+class ArchiveConfig:
+    dir_storage: ArchiveDirStorageConfig = field(default_factory=ArchiveDirStorageConfig)
+    acr: ArchiveAcrConfig = field(default_factory=ArchiveAcrConfig)
+    scan_interval_sec: int = 30
+    timeout_sec: int = 1800
+    max_retries: int = 3
+    prefix: str = "rock-archives/"
+
+    def __post_init__(self):
+        if isinstance(self.dir_storage, dict):
+            self.dir_storage = ArchiveDirStorageConfig(**self.dir_storage)
+        if isinstance(self.acr, dict):
+            self.acr = ArchiveAcrConfig(**self.acr)
+
+
+@dataclass
+class SandboxLifecycleConfig:
+    archive: ArchiveConfig = field(default_factory=ArchiveConfig)
+
+    def __post_init__(self):
+        if isinstance(self.archive, dict):
+            self.archive = ArchiveConfig(**self.archive)
+
+
+@dataclass
 class ProxyServiceConfig:
     timeout: float = 180.0
     max_connections: int = 500
@@ -348,6 +391,7 @@ class RockConfig:
     redis: RedisConfig = field(default_factory=RedisConfig)
     sandbox_config: SandboxConfig = field(default_factory=SandboxConfig)
     oss: OssConfig = field(default_factory=OssConfig)
+    lifecycle: SandboxLifecycleConfig = field(default_factory=SandboxLifecycleConfig)
     runtime: RuntimeConfig = field(default_factory=RuntimeConfig)
     proxy_service: ProxyServiceConfig = field(default_factory=ProxyServiceConfig)
     scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
@@ -401,6 +445,8 @@ class RockConfig:
             kwargs["sandbox_config"] = SandboxConfig(**config["sandbox_config"])
         if "oss" in config:
             kwargs["oss"] = OssConfig(**config["oss"])
+        if "lifecycle" in config:
+            kwargs["lifecycle"] = SandboxLifecycleConfig(**config["lifecycle"])
         if "runtime" in config:
             kwargs["runtime"] = RuntimeConfig(**config["runtime"])
         if "proxy_service" in config:

--- a/rock/sandbox/archive/abstract.py
+++ b/rock/sandbox/archive/abstract.py
@@ -1,0 +1,57 @@
+from abc import ABC, abstractmethod
+
+
+class AbstractDirStorage(ABC):
+    """Directory-level archive storage.
+
+    Caller passes a local directory path; the storage implementation
+    decides compression format and upload strategy internally.
+    """
+
+    @abstractmethod
+    async def upload_dir(self, local_dir: str, key: str) -> None:
+        """Pack and upload local_dir to key. Raises FileNotFoundError if local_dir missing."""
+
+    @abstractmethod
+    async def download_to_dir(self, key: str, local_dir: str) -> None:
+        """Download key and restore to local_dir.
+
+        Raises FileNotFoundError if key missing, FileExistsError if local_dir exists.
+        """
+
+    @abstractmethod
+    async def delete(self, key: str) -> bool:
+        """Delete key. Returns False if not found."""
+
+    @abstractmethod
+    async def exists(self, key: str) -> bool:
+        """Check if key exists."""
+
+
+class AbstractImageStorage(ABC):
+    """Container image archive storage.
+
+    push_from_local / pull_to_local must run on the node owning the image
+    (node-local docker daemon). exists / delete are registry HTTP API calls.
+    """
+
+    @property
+    @abstractmethod
+    def registry_url(self) -> str:
+        """Registry endpoint (no scheme), e.g. 'localhost:5000'."""
+
+    @abstractmethod
+    async def push_from_local(self, local_image_tag: str, remote_image_ref: str) -> None:
+        """Tag local image and push to registry."""
+
+    @abstractmethod
+    async def pull_to_local(self, remote_image_ref: str) -> None:
+        """Pull image from registry to local daemon. Raises RuntimeError if not found."""
+
+    @abstractmethod
+    async def delete(self, image_ref: str) -> bool:
+        """Delete manifest from registry via V2 HTTP API. Returns False if 404."""
+
+    @abstractmethod
+    async def exists(self, image_ref: str) -> bool:
+        """HEAD manifest via V2 HTTP API."""

--- a/rock/sandbox/archive/oss_storage.py
+++ b/rock/sandbox/archive/oss_storage.py
@@ -1,0 +1,128 @@
+import asyncio
+import os
+import shutil
+import tempfile
+
+import oss2
+
+from rock.sandbox.archive.abstract import AbstractDirStorage
+
+
+class OssDirStorage(AbstractDirStorage):
+    """OSS Access Point directory storage using oss2 SDK + AuthV4."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        bucket: str,
+        access_key_id: str,
+        access_key_secret: str,
+        region: str = "cn-hangzhou",
+    ):
+        self._endpoint = endpoint
+        self._bucket = bucket
+        self._access_key_id = access_key_id
+        self._access_key_secret = access_key_secret
+        self._region = region
+
+    @property
+    def client_config(self) -> dict:
+        return {
+            "type": "oss",
+            "endpoint": self._endpoint,
+            "bucket": self._bucket,
+            "access_key_id": self._access_key_id,
+            "access_key_secret": self._access_key_secret,
+            "region": self._region,
+        }
+
+    def _make_bucket(self) -> oss2.Bucket:
+        auth = oss2.AuthV4(self._access_key_id, self._access_key_secret)
+        return oss2.Bucket(auth, self._endpoint, self._bucket, region=self._region)
+
+    async def upload_dir(self, local_dir: str, key: str) -> None:
+        if not os.path.isdir(local_dir):
+            raise FileNotFoundError(f"Directory not found: {local_dir}")
+
+        parent = os.path.dirname(os.path.abspath(local_dir))
+        basename = os.path.basename(os.path.abspath(local_dir))
+
+        tmp_tar = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as f:
+                tmp_tar = f.name
+
+            proc = await asyncio.create_subprocess_exec(
+                "tar",
+                "-czf",
+                tmp_tar,
+                "-C",
+                parent,
+                basename,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await proc.communicate()
+            if proc.returncode != 0:
+                raise RuntimeError(f"tar failed: {stderr.decode()}")
+
+            bucket = self._make_bucket()
+            await asyncio.to_thread(oss2.resumable_upload, bucket, key, tmp_tar)
+        finally:
+            if tmp_tar and os.path.exists(tmp_tar):
+                os.unlink(tmp_tar)
+
+    async def download_to_dir(self, key: str, local_dir: str) -> None:
+        if os.path.exists(local_dir):
+            raise FileExistsError(f"Target directory already exists: {local_dir}")
+
+        parent = os.path.dirname(os.path.abspath(local_dir))
+        basename = os.path.basename(os.path.abspath(local_dir))
+        os.makedirs(parent, exist_ok=True)
+
+        tmp_tar = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as f:
+                tmp_tar = f.name
+
+            bucket = self._make_bucket()
+            try:
+                await asyncio.to_thread(bucket.get_object_to_file, key, tmp_tar)
+            except oss2.exceptions.NoSuchKey:
+                raise FileNotFoundError(f"Key not found: {key}")
+
+            proc = await asyncio.create_subprocess_exec(
+                "tar",
+                "-xzf",
+                tmp_tar,
+                "-C",
+                parent,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await proc.communicate()
+            if proc.returncode != 0:
+                raise RuntimeError(f"tar extract failed: {stderr.decode()}")
+
+            extracted = os.path.join(parent, basename)
+            if not os.path.isdir(extracted):
+                entries = os.listdir(parent)
+                raise RuntimeError(f"Expected directory '{basename}' after extraction, got: {entries}")
+        except Exception:
+            if os.path.exists(local_dir):
+                shutil.rmtree(local_dir, ignore_errors=True)
+            raise
+        finally:
+            if tmp_tar and os.path.exists(tmp_tar):
+                os.unlink(tmp_tar)
+
+    async def delete(self, key: str) -> bool:
+        bucket = self._make_bucket()
+        if not await asyncio.to_thread(bucket.object_exists, key):
+            return False
+        await asyncio.to_thread(bucket.delete_object, key)
+        return True
+
+    async def exists(self, key: str) -> bool:
+        bucket = self._make_bucket()
+        return await asyncio.to_thread(bucket.object_exists, key)

--- a/rock/sandbox/archive/registry_v2.py
+++ b/rock/sandbox/archive/registry_v2.py
@@ -1,0 +1,198 @@
+import asyncio
+import base64
+import os
+import re
+import shutil
+import tempfile
+from urllib.parse import urlparse
+
+import httpx
+
+from rock.sandbox.archive.abstract import AbstractImageStorage
+
+
+class DockerRegistryV2ImageStorage(AbstractImageStorage):
+    """Docker Registry V2 image storage using docker CLI + HTTP API.
+
+    Supports both authenticated (username/password) and unauthenticated registries.
+    """
+
+    def __init__(self, registry_url: str, username: str | None = None, password: str | None = None):
+        self._registry_url = registry_url
+        self._username = username
+        self._password = password
+
+    @property
+    def _has_auth(self) -> bool:
+        return self._username is not None and self._password is not None
+
+    @property
+    def registry_url(self) -> str:
+        return self._registry_url
+
+    @property
+    def client_config(self) -> dict:
+        cfg = {"registry_url": self._registry_url}
+        if self._has_auth:
+            cfg["username"] = self._username
+            cfg["password"] = self._password
+        return cfg
+
+    async def push_from_local(self, local_image_tag: str, remote_image_ref: str) -> None:
+        async with self._docker_auth() as env:
+            await self._docker_cmd("docker", "tag", local_image_tag, remote_image_ref)
+            try:
+                await self._docker_cmd("docker", "push", remote_image_ref, env=env)
+            finally:
+                await self._docker_cmd("docker", "rmi", remote_image_ref, check=False)
+
+    async def pull_to_local(self, remote_image_ref: str) -> None:
+        async with self._docker_auth() as env:
+            await self._docker_cmd("docker", "pull", remote_image_ref, env=env)
+
+    async def delete(self, image_ref: str) -> bool:
+        registry, name, tag = self._parse_ref(image_ref)
+        base_url = await self._registry_base_url(registry)
+        accept = "application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json"
+        async with httpx.AsyncClient() as client:
+            auth_headers = await self._resolve_auth_headers(client, base_url, name)
+            if not auth_headers:
+                return False
+
+            resp = await client.get(
+                f"{base_url}/v2/{name}/manifests/{tag}",
+                headers={**auth_headers, "Accept": accept},
+            )
+            if resp.status_code != 200:
+                return False
+            digest = resp.headers.get("Docker-Content-Digest")
+            if not digest:
+                return False
+
+            resp = await client.delete(f"{base_url}/v2/{name}/manifests/{digest}", headers=auth_headers)
+            return resp.status_code in (200, 202)
+
+    async def _resolve_auth_headers(self, client: httpx.AsyncClient, base_url: str, repo_name: str) -> dict | None:
+        """Negotiate auth with the registry and return headers for subsequent requests."""
+        challenge = await client.get(f"{base_url}/v2/")
+        www_auth = challenge.headers.get("Www-Authenticate", "")
+
+        if www_auth.lower().startswith("basic"):
+            creds = base64.b64encode(f"{self._username}:{self._password}".encode()).decode()
+            return {"Authorization": f"Basic {creds}"}
+
+        m = re.search(r'realm="([^"]+)"', www_auth)
+        realm = m.group(1) if m else None
+        m = re.search(r'service="([^"]+)"', www_auth)
+        service = m.group(1) if m else None
+        if not realm or not service:
+            return None
+
+        token_resp = await client.get(
+            realm,
+            params={"service": service, "scope": f"repository:{repo_name}:pull,push,delete"},
+            auth=(self._username, self._password),
+        )
+        if token_resp.status_code != 200:
+            return None
+        token = token_resp.json().get("token")
+        if not token:
+            return None
+        return {"Authorization": f"Bearer {token}"}
+
+    async def exists(self, image_ref: str) -> bool:
+        async with self._docker_auth() as env:
+            try:
+                await self._docker_cmd("docker", "manifest", "inspect", "--insecure", image_ref, env=env)
+                return True
+            except RuntimeError:
+                return False
+
+    def _docker_auth(self):
+        return _DockerAuthContext(self) if self._has_auth else _NoAuthContext()
+
+    @staticmethod
+    async def _registry_base_url(registry: str) -> str:
+        """Return the base URL (with scheme) for a registry host:port."""
+        async with httpx.AsyncClient() as client:
+            try:
+                resp = await client.get(f"https://{registry}/v2/", timeout=3)
+                if resp.status_code in (200, 401):
+                    return f"https://{registry}"
+            except (httpx.ConnectError, httpx.ConnectTimeout):
+                pass
+        return f"http://{registry}"
+
+    @staticmethod
+    def _parse_ref(image_ref: str) -> tuple[str, str, str]:
+        """Parse 'registry/repo/name:tag' into (registry, name, tag)."""
+        if "://" in image_ref:
+            parsed = urlparse(image_ref)
+            image_ref = parsed.netloc + parsed.path
+
+        parts = image_ref.split("/", 1)
+        if len(parts) < 2:
+            raise ValueError(f"Invalid image ref: {image_ref}")
+        registry = parts[0]
+        name_tag = parts[1]
+
+        if ":" in name_tag.split("/")[-1]:
+            last_colon = name_tag.rfind(":")
+            name = name_tag[:last_colon]
+            tag = name_tag[last_colon + 1 :]
+        else:
+            name = name_tag
+            tag = "latest"
+
+        return registry, name, tag
+
+    @staticmethod
+    async def _docker_cmd(*args: str, check: bool = True, env: dict | None = None, stdin_data: bytes | None = None):
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            stdin=asyncio.subprocess.PIPE if stdin_data else None,
+            env=env,
+        )
+        stdout, stderr = await proc.communicate(input=stdin_data)
+        if check and proc.returncode != 0:
+            raise RuntimeError(f"{' '.join(args)} failed (rc={proc.returncode}): {stderr.decode()}")
+
+
+class _DockerAuthContext:
+    """Context manager that creates isolated DOCKER_CONFIG and performs docker login."""
+
+    def __init__(self, storage: DockerRegistryV2ImageStorage):
+        self._storage = storage
+        self._tmpdir = None
+
+    async def __aenter__(self) -> dict:
+        self._tmpdir = tempfile.mkdtemp()
+        env = os.environ.copy()
+        env["DOCKER_CONFIG"] = self._tmpdir
+        await DockerRegistryV2ImageStorage._docker_cmd(
+            "docker",
+            "login",
+            self._storage._registry_url,
+            "--username",
+            self._storage._username,
+            "--password-stdin",
+            env=env,
+            stdin_data=self._storage._password.encode(),
+        )
+        return env
+
+    async def __aexit__(self, *args):
+        if self._tmpdir:
+            shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+
+class _NoAuthContext:
+    """No-op context manager for unauthenticated registries."""
+
+    async def __aenter__(self) -> None:
+        return None
+
+    async def __aexit__(self, *args):
+        pass

--- a/rock/sandbox/archive/s3_storage.py
+++ b/rock/sandbox/archive/s3_storage.py
@@ -1,0 +1,142 @@
+import asyncio
+import os
+import shutil
+import tempfile
+
+import boto3
+from botocore.exceptions import ClientError
+
+from rock.sandbox.archive.abstract import AbstractDirStorage
+
+
+class S3DirStorage(AbstractDirStorage):
+    """S3-compatible directory storage (works with MinIO and OSS S3 endpoint)."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        bucket: str,
+        access_key_id: str,
+        access_key_secret: str,
+        region: str = "us-east-1",
+    ):
+        self._endpoint = endpoint
+        self._bucket = bucket
+        self._access_key_id = access_key_id
+        self._access_key_secret = access_key_secret
+        self._region = region
+
+    @property
+    def client_config(self) -> dict:
+        return {
+            "type": "s3",
+            "endpoint": self._endpoint,
+            "bucket": self._bucket,
+            "access_key_id": self._access_key_id,
+            "access_key_secret": self._access_key_secret,
+            "region": self._region,
+        }
+
+    def _make_client(self):
+        return boto3.client(
+            "s3",
+            endpoint_url=self._endpoint,
+            aws_access_key_id=self._access_key_id,
+            aws_secret_access_key=self._access_key_secret,
+            region_name=self._region,
+        )
+
+    async def upload_dir(self, local_dir: str, key: str) -> None:
+        if not os.path.isdir(local_dir):
+            raise FileNotFoundError(f"Directory not found: {local_dir}")
+
+        parent = os.path.dirname(os.path.abspath(local_dir))
+        basename = os.path.basename(os.path.abspath(local_dir))
+
+        tmp_tar = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as f:
+                tmp_tar = f.name
+
+            proc = await asyncio.create_subprocess_exec(
+                "tar",
+                "-czf",
+                tmp_tar,
+                "-C",
+                parent,
+                basename,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await proc.communicate()
+            if proc.returncode != 0:
+                raise RuntimeError(f"tar failed: {stderr.decode()}")
+
+            client = self._make_client()
+            await asyncio.to_thread(client.upload_file, tmp_tar, self._bucket, key)
+        finally:
+            if tmp_tar and os.path.exists(tmp_tar):
+                os.unlink(tmp_tar)
+
+    async def download_to_dir(self, key: str, local_dir: str) -> None:
+        if os.path.exists(local_dir):
+            raise FileExistsError(f"Target directory already exists: {local_dir}")
+
+        parent = os.path.dirname(os.path.abspath(local_dir))
+        basename = os.path.basename(os.path.abspath(local_dir))
+        os.makedirs(parent, exist_ok=True)
+
+        tmp_tar = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as f:
+                tmp_tar = f.name
+
+            client = self._make_client()
+            try:
+                await asyncio.to_thread(client.download_file, self._bucket, key, tmp_tar)
+            except ClientError as e:
+                if e.response["Error"]["Code"] == "404":
+                    raise FileNotFoundError(f"Key not found: {key}")
+                raise
+
+            proc = await asyncio.create_subprocess_exec(
+                "tar",
+                "-xzf",
+                tmp_tar,
+                "-C",
+                parent,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await proc.communicate()
+            if proc.returncode != 0:
+                raise RuntimeError(f"tar extract failed: {stderr.decode()}")
+
+            extracted = os.path.join(parent, basename)
+            if not os.path.isdir(extracted):
+                entries = os.listdir(parent)
+                raise RuntimeError(f"Expected directory '{basename}' after extraction, got: {entries}")
+        except Exception:
+            if os.path.exists(local_dir):
+                shutil.rmtree(local_dir, ignore_errors=True)
+            raise
+        finally:
+            if tmp_tar and os.path.exists(tmp_tar):
+                os.unlink(tmp_tar)
+
+    async def delete(self, key: str) -> bool:
+        if not await self.exists(key):
+            return False
+        client = self._make_client()
+        await asyncio.to_thread(client.delete_object, Bucket=self._bucket, Key=key)
+        return True
+
+    async def exists(self, key: str) -> bool:
+        client = self._make_client()
+        try:
+            await asyncio.to_thread(client.head_object, Bucket=self._bucket, Key=key)
+            return True
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "404":
+                return False
+            raise


### PR DESCRIPTION
close #1085 

### Overview

This change introduces the storage abstraction layer for sandbox archiving. It defines interfaces and implementations for two storage backends:

- **Dir storage** (OSS / S3): stores sandbox log directories as `.tar.gz` objects
- **Image storage** (Docker Registry V2 / ACR): stores sandbox container snapshots as OCI images

No behavioral changes to the sandbox lifecycle — this is pure infrastructure that the archive lifecycle feature builds on.

## Configuration Structure

Archive storage is configured under `lifecycle.archive` in the ROCK YAML config:

```yaml
lifecycle:
  archive:
    enabled: true
    prefix: "rock-archives/"         # OSS key prefix for dir archives
    dir_storage:
      type: "oss"                    # "oss" or "s3"
      endpoint: "https://oss-cn-hangzhou.aliyuncs.com"
      bucket: "rock-sandbox-archive"
      access_key_id: "..."
      access_key_secret: "..."
      region: "cn-hangzhou"
    acr:
      registry_url: "rock-acr.cr.aliyuncs.com"
      username: "..."
      password: "..."
      namespace: "sandbox_archive"   # ACR namespace for archived images
```

## Storage Interfaces

### AbstractDirStorage

Abstract base for directory archive storage. Implementations: `OssDirStorage`, `S3DirStorage`.

| Method | Description |
|---|---|
| `upload_dir(local_path, key)` | Tar + gzip a local directory, upload to `key` |
| `download_to_dir(key, local_path)` | Download from `key`, extract to local directory |
| `exists(key)` | Check if object exists |
| `delete(key)` | Delete object |
| `client_config` (property) | Dict of connection params, passed to remote actors |

### AbstractImageStorage

Abstract base for container image storage. Implementation: `DockerRegistryV2ImageStorage`.

| Method | Description |
|---|---|
| `push_from_local(local_tag, ref)` | Tag + push a local docker image to registry |
| `pull_to_local(ref)` | Pull an image from registry to local docker |
| `exists(ref)` | Check if image/tag exists in registry |
| `delete(ref)` | Delete image/tag from registry |
| `client_config` (property) | Dict of connection params, passed to remote actors |

## Naming Convention

Archive artifacts use deterministic names based solely on `sandbox_id` — no timestamps, no version suffixes. Each sandbox has exactly one archive; re-archiving overwrites the same key/ref.

| Storage | Format | Example |
|---|---|---|
| OSS / S3 key | `{prefix}{sandbox_id}.tar.gz` | `rock-archives/sbx-abc123.tar.gz` |
| ACR image ref | `{registry}/{namespace}/sandbox_archived:{sandbox_id}` | `rock-acr.cr.aliyuncs.com/sandbox_archive/sandbox_archived:sbx-abc123` |

Generated by two pure functions in `rock/sandbox/archive/_constants.py`:

```python
def dir_archive_key(sandbox_id: str, prefix: str) -> str:
    return f"{prefix}{sandbox_id}.tar.gz"

def image_ref(sandbox_id: str, registry_url: str, namespace: str) -> str:
    return f"{registry_url}/{namespace}/sandbox_archived:{sandbox_id}"
```

## Implementation Notes

### Registry V2 push/pull

`DockerRegistryV2ImageStorage` uses `docker tag` + `docker push` / `docker pull` via subprocess, not the Registry HTTP API directly. This keeps auth handling simple (reuse docker CLI credential flow) and avoids layer-level complexity.

### OSS vs S3

Both `OssDirStorage` and `S3DirStorage` implement the same `AbstractDirStorage` interface. The OSS implementation uses `oss2` SDK; the S3 implementation uses `boto3`. The `type` field in config selects which to instantiate. S3 is used in local/test environments (MinIO), OSS in production.

### Actor-side instantiation

Storage objects are not serializable across Ray actor boundaries. Instead, `client_config` dicts are passed to remote actors, which instantiate their own storage clients locally. This avoids pickling issues and keeps credentials off the Ray object store.
