### PR TITLE
perf(datasets): datasets cli support --filter/--offset/--limit

### DIFF
--- a/rock/cli/command/datasets.py
+++ b/rock/cli/command/datasets.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
+import json
 import sys
+from dataclasses import asdict
 from pathlib import Path
 
 from rock.cli.command.command import Command
@@ -25,6 +28,20 @@ def _positive_int(value: str) -> int:
     if ivalue <= 0:
         raise argparse.ArgumentTypeError("must be >= 1")
     return ivalue
+
+
+def _is_json_output(args: argparse.Namespace) -> bool:
+    return getattr(args, "output", None) == "json"
+
+
+def _print_json(data: dict | list) -> None:
+    print(json.dumps(data, ensure_ascii=False, indent=2))
+
+
+def _dataset_to_dict(dataset) -> dict:
+    data = asdict(dataset)
+    data["task_count"] = len(dataset.task_ids)
+    return data
 
 
 class DatasetsCommand(Command):
@@ -61,6 +78,17 @@ class DatasetsCommand(Command):
     async def _list(self, args: argparse.Namespace) -> None:
         registry_info = self._build_oss_registry_info(args)
         client = DatasetClient(registry_info)
+
+        if _is_json_output(args):
+            if getattr(args, "depth", None) == 1:
+                _print_json({"organizations": client.list_organizations()})
+                return
+            datasets = sorted(
+                client.list_datasets(getattr(args, "org", None)),
+                key=lambda d: (d.id, d.split),
+            )
+            _print_json({"datasets": [_dataset_to_dict(d) for d in datasets]})
+            return
 
         if getattr(args, "org", None):
             datasets = client.list_org_datasets(args.org)
@@ -107,16 +135,45 @@ class DatasetsCommand(Command):
     async def _tasks(self, args: argparse.Namespace) -> None:
         registry_info = self._build_oss_registry_info(args)
         client = DatasetClient(registry_info)
-        spec = client.list_dataset_tasks(args.org, args.dataset, args.split)
+        spec = client.list_dataset_tasks(
+            args.org,
+            args.dataset,
+            args.split,
+            offset=args.offset,
+            limit=args.limit,
+            task_filter=getattr(args, "filter", None),
+        )
 
         if spec is None or not spec.task_ids:
+            if _is_json_output(args):
+                _print_json(
+                    {
+                        "dataset": f"{args.org}/{args.dataset}",
+                        "split": args.split,
+                        "total": 0,
+                        "offset": args.offset,
+                        "limit": args.limit,
+                        "task_ids": [],
+                    }
+                )
+                return
             print(f"No tasks found for dataset '{args.org}/{args.dataset}' split '{args.split}'.")
             return
 
-        total = len(spec.task_ids)
-        start = args.offset
-        end = start + args.limit if args.limit is not None else None
-        shown_task_ids = spec.task_ids[start:end]
+        shown_task_ids = spec.task_ids
+
+        if _is_json_output(args):
+            _print_json(
+                {
+                    "dataset": spec.id,
+                    "split": spec.split,
+                    "total": len(shown_task_ids),
+                    "offset": args.offset,
+                    "limit": args.limit,
+                    "task_ids": shown_task_ids,
+                }
+            )
+            return
 
         if not shown_task_ids:
             print("No tasks found after applying offset/limit.")
@@ -124,7 +181,7 @@ class DatasetsCommand(Command):
 
         print()
         print("=" * 80)
-        print(f"Dataset: {spec.id}  Split: {spec.split}  Total: {total}  Shown: {len(shown_task_ids)}")
+        print(f"Dataset: {spec.id}  Split: {spec.split}  Shown: {len(shown_task_ids)}")
         print("=" * 80)
         print("#Task name")
         print("-" * 10)
@@ -150,8 +207,8 @@ class DatasetsCommand(Command):
 
     async def _upload(self, args: argparse.Namespace) -> None:
         local_dir = Path(args.dir)
-        if not local_dir.is_dir():
-            raise ValueError(f"--dir '{local_dir}' does not exist or is not a directory")
+        if not local_dir.exists():
+            raise ValueError(f"--dir '{local_dir}' does not exist")
 
         registry_info = self._build_oss_registry_info(args)
         source = LocalDatasetConfig(path=local_dir)
@@ -163,19 +220,37 @@ class DatasetsCommand(Command):
         )
 
         base = registry_info.oss_dataset_path or "datasets"
-        print(f"Uploading to oss://{registry_info.oss_bucket}/{base}/{args.org}/{args.dataset}/{args.split}/")
+        if not _is_json_output(args):
+            print(f"Uploading to oss://{registry_info.oss_bucket}/{base}/{args.org}/{args.dataset}/{args.split}/")
 
         client = DatasetClient(registry_info)
-        result = client.upload_dataset(source, target, concurrency=args.concurrency)
+        if _is_json_output(args):
+            with contextlib.redirect_stdout(sys.stderr):
+                result = client.upload_dataset(source, target, concurrency=args.concurrency)
+            _print_json(asdict(result))
+        else:
+            result = client.upload_dataset(source, target, concurrency=args.concurrency)
+            print(f"\nDone: {result.uploaded} uploaded, {result.skipped} skipped, {result.failed} failed")
 
-        print(f"\nDone: {result.uploaded} uploaded, {result.skipped} skipped, {result.failed} failed")
         if result.failed > 0:
             sys.exit(1)
 
     @staticmethod
     async def add_parser_to(subparsers: argparse._SubParsersAction) -> None:
         datasets_parser = subparsers.add_parser("datasets", description="Dataset operations on OSS")
+        datasets_parser.set_defaults(output=None)
         datasets_subparsers = datasets_parser.add_subparsers(dest="datasets_command")
+
+        def add_output_arg(parser: argparse.ArgumentParser) -> None:
+            parser.add_argument(
+                "-o",
+                "--output",
+                "--ouput",
+                dest="output",
+                choices=["json"],
+                default=argparse.SUPPRESS,
+                help="Output format. Supported: json",
+            )
 
         def add_oss_args(parser: argparse.ArgumentParser) -> None:
             parser.add_argument("--bucket", help="OSS bucket name (overrides config.ini)")
@@ -187,6 +262,8 @@ class DatasetsCommand(Command):
                 "--access-key-secret", dest="access_key_secret", help="OSS access key secret (overrides config.ini)"
             )
             parser.add_argument("--region", help="OSS region (overrides config.ini)")
+
+        add_output_arg(datasets_parser)
 
         list_parser = datasets_subparsers.add_parser("list", help="List datasets in OSS registry")
         list_group = list_parser.add_mutually_exclusive_group()
@@ -200,9 +277,11 @@ class DatasetsCommand(Command):
         list_group.add_argument("--org", help="List datasets under the given organization only")
         add_oss_args(list_parser)
         tasks_parser = datasets_subparsers.add_parser("tasks", help="List task IDs under one dataset split")
+        add_output_arg(tasks_parser)
         tasks_parser.add_argument("--org", required=True, help="Organization name")
         tasks_parser.add_argument("--dataset", required=True, help="Dataset name")
         tasks_parser.add_argument("--split", default="test", help="Split name (default: test)")
+        tasks_parser.add_argument("--filter", default=None, help="Filter tasks by prefix (e.g. --filter 0xerr0r)")
         tasks_parser.add_argument("--offset", type=_non_negative_int, default=0, help="Skip first N tasks")
         tasks_parser.add_argument("--limit", type=_positive_int, default=None, help="Maximum number of tasks to show")
         add_oss_args(tasks_parser)
@@ -213,10 +292,15 @@ class DatasetsCommand(Command):
         add_oss_args(splits_parser)
 
         upload_parser = datasets_subparsers.add_parser("upload", help="Upload local task dirs to OSS")
+        add_output_arg(upload_parser)
         upload_parser.add_argument("--org", required=True, help="Organization name")
         upload_parser.add_argument("--dataset", required=True, help="Dataset name")
         upload_parser.add_argument("--split", required=True, help="Split name (e.g. train, test, v1.0)")
-        upload_parser.add_argument("--dir", required=True, help="Local directory containing {task_id}/ subdirectories")
+        upload_parser.add_argument(
+            "--dir",
+            required=True,
+            help="Local dataset directory containing {task_id}/ subdirectories",
+        )
         upload_parser.add_argument(
             "--concurrency",
             type=int,

--- a/rock/cli/command/datasets.py
+++ b/rock/cli/command/datasets.py
@@ -17,15 +17,15 @@ logger = init_logger(__name__)
 
 
 class OutputWriter:
-    """Renders command results either as JSON or as the default text format.
+    """Renders command results as JSON or as the default ``table`` text format.
 
-    Centralizes the ``-o json`` decision and the actual writing so command
-    handlers do not repeat ``getattr(args, "output", ...)`` checks or import
+    Centralizes the ``--format`` decision and the actual writing so command
+    handlers do not repeat ``getattr(args, "format", ...)`` checks or import
     ``json`` directly.
     """
 
     def __init__(self, args: argparse.Namespace) -> None:
-        self._json = getattr(args, "output", None) == "json"
+        self._json = getattr(args, "format", "table") == "json"
 
     @property
     def is_json(self) -> bool:
@@ -252,17 +252,17 @@ class DatasetsCommand(Command):
     @staticmethod
     async def add_parser_to(subparsers: argparse._SubParsersAction) -> None:
         datasets_parser = subparsers.add_parser("datasets", description="Dataset operations on OSS")
-        datasets_parser.set_defaults(output=None)
+        datasets_parser.set_defaults(format="table")
         datasets_subparsers = datasets_parser.add_subparsers(dest="datasets_command")
 
         def add_output_arg(parser: argparse.ArgumentParser) -> None:
             parser.add_argument(
-                "-o",
-                "--output",
-                dest="output",
-                choices=["json"],
+                "-f",
+                "--format",
+                dest="format",
+                choices=["table", "json"],
                 default=argparse.SUPPRESS,
-                help="Output format. Supported: json",
+                help="Output format: table (default) or json",
             )
 
         def add_oss_args(parser: argparse.ArgumentParser) -> None:

--- a/rock/cli/command/datasets.py
+++ b/rock/cli/command/datasets.py
@@ -16,36 +16,47 @@ from rock.sdk.envhub.datasets.client import DatasetClient
 logger = init_logger(__name__)
 
 
-def _non_negative_int(value: str) -> int:
-    ivalue = int(value)
-    if ivalue < 0:
-        raise argparse.ArgumentTypeError("must be >= 0")
-    return ivalue
+class OutputWriter:
+    """Renders command results either as JSON or as the default text format.
 
+    Centralizes the ``-o json`` decision and the actual writing so command
+    handlers do not repeat ``getattr(args, "output", ...)`` checks or import
+    ``json`` directly.
+    """
 
-def _positive_int(value: str) -> int:
-    ivalue = int(value)
-    if ivalue <= 0:
-        raise argparse.ArgumentTypeError("must be >= 1")
-    return ivalue
+    def __init__(self, args: argparse.Namespace) -> None:
+        self._json = getattr(args, "output", None) == "json"
 
+    @property
+    def is_json(self) -> bool:
+        return self._json
 
-def _is_json_output(args: argparse.Namespace) -> bool:
-    return getattr(args, "output", None) == "json"
+    def json(self, data: dict | list) -> None:
+        print(json.dumps(data, ensure_ascii=False, indent=2))
 
-
-def _print_json(data: dict | list) -> None:
-    print(json.dumps(data, ensure_ascii=False, indent=2))
-
-
-def _dataset_to_dict(dataset) -> dict:
-    data = asdict(dataset)
-    data["task_count"] = len(dataset.task_ids)
-    return data
+    @staticmethod
+    def dataset_to_dict(dataset) -> dict:
+        data = asdict(dataset)
+        data["task_count"] = len(dataset.task_ids)
+        return data
 
 
 class DatasetsCommand(Command):
     name = "datasets"
+
+    @staticmethod
+    def _non_negative_int(value: str) -> int:
+        ivalue = int(value)
+        if ivalue < 0:
+            raise argparse.ArgumentTypeError("must be >= 0")
+        return ivalue
+
+    @staticmethod
+    def _positive_int(value: str) -> int:
+        ivalue = int(value)
+        if ivalue <= 0:
+            raise argparse.ArgumentTypeError("must be >= 1")
+        return ivalue
 
     async def arun(self, args: argparse.Namespace) -> None:
         if args.datasets_command == "list":
@@ -75,19 +86,22 @@ class DatasetsCommand(Command):
             oss_region=getattr(args, "region", None) or ds_cfg.oss_region,
         )
 
-    async def _list(self, args: argparse.Namespace) -> None:
-        registry_info = self._build_oss_registry_info(args)
-        client = DatasetClient(registry_info)
+    def _client(self, args: argparse.Namespace) -> DatasetClient:
+        return DatasetClient(self._build_oss_registry_info(args))
 
-        if _is_json_output(args):
+    async def _list(self, args: argparse.Namespace) -> None:
+        client = self._client(args)
+        out = OutputWriter(args)
+
+        if out.is_json:
             if getattr(args, "depth", None) == 1:
-                _print_json({"organizations": client.list_organizations()})
+                out.json({"organizations": client.list_organizations()})
                 return
             datasets = sorted(
                 client.list_datasets(getattr(args, "org", None)),
                 key=lambda d: (d.id, d.split),
             )
-            _print_json({"datasets": [_dataset_to_dict(d) for d in datasets]})
+            out.json({"datasets": [OutputWriter.dataset_to_dict(d) for d in datasets]})
             return
 
         if getattr(args, "org", None):
@@ -133,8 +147,8 @@ class DatasetsCommand(Command):
         print(f"\n{len(orgs)} organizations.")
 
     async def _tasks(self, args: argparse.Namespace) -> None:
-        registry_info = self._build_oss_registry_info(args)
-        client = DatasetClient(registry_info)
+        client = self._client(args)
+        out = OutputWriter(args)
         spec = client.list_dataset_tasks(
             args.org,
             args.dataset,
@@ -145,8 +159,8 @@ class DatasetsCommand(Command):
         )
 
         if spec is None or not spec.task_ids:
-            if _is_json_output(args):
-                _print_json(
+            if out.is_json:
+                out.json(
                     {
                         "dataset": f"{args.org}/{args.dataset}",
                         "split": args.split,
@@ -162,8 +176,8 @@ class DatasetsCommand(Command):
 
         shown_task_ids = spec.task_ids
 
-        if _is_json_output(args):
-            _print_json(
+        if out.is_json:
+            out.json(
                 {
                     "dataset": spec.id,
                     "split": spec.split,
@@ -189,8 +203,7 @@ class DatasetsCommand(Command):
             print(task_id)
 
     async def _splits(self, args: argparse.Namespace) -> None:
-        registry_info = self._build_oss_registry_info(args)
-        client = DatasetClient(registry_info)
+        client = self._client(args)
         splits = client.list_dataset_splits(args.org, args.dataset)
 
         if not splits:
@@ -211,6 +224,7 @@ class DatasetsCommand(Command):
             raise ValueError(f"--dir '{local_dir}' does not exist")
 
         registry_info = self._build_oss_registry_info(args)
+        out = OutputWriter(args)
         source = LocalDatasetConfig(path=local_dir)
         target = RegistryDatasetConfig(
             name=f"{args.org}/{args.dataset}",
@@ -220,14 +234,14 @@ class DatasetsCommand(Command):
         )
 
         base = registry_info.oss_dataset_path or "datasets"
-        if not _is_json_output(args):
+        if not out.is_json:
             print(f"Uploading to oss://{registry_info.oss_bucket}/{base}/{args.org}/{args.dataset}/{args.split}/")
 
         client = DatasetClient(registry_info)
-        if _is_json_output(args):
+        if out.is_json:
             with contextlib.redirect_stdout(sys.stderr):
                 result = client.upload_dataset(source, target, concurrency=args.concurrency)
-            _print_json(asdict(result))
+            out.json(asdict(result))
         else:
             result = client.upload_dataset(source, target, concurrency=args.concurrency)
             print(f"\nDone: {result.uploaded} uploaded, {result.skipped} skipped, {result.failed} failed")
@@ -245,7 +259,6 @@ class DatasetsCommand(Command):
             parser.add_argument(
                 "-o",
                 "--output",
-                "--ouput",
                 dest="output",
                 choices=["json"],
                 default=argparse.SUPPRESS,
@@ -282,8 +295,12 @@ class DatasetsCommand(Command):
         tasks_parser.add_argument("--dataset", required=True, help="Dataset name")
         tasks_parser.add_argument("--split", default="test", help="Split name (default: test)")
         tasks_parser.add_argument("--filter", default=None, help="Filter tasks by prefix (e.g. --filter 0xerr0r)")
-        tasks_parser.add_argument("--offset", type=_non_negative_int, default=0, help="Skip first N tasks")
-        tasks_parser.add_argument("--limit", type=_positive_int, default=None, help="Maximum number of tasks to show")
+        tasks_parser.add_argument(
+            "--offset", type=DatasetsCommand._non_negative_int, default=0, help="Skip first N tasks"
+        )
+        tasks_parser.add_argument(
+            "--limit", type=DatasetsCommand._positive_int, default=None, help="Maximum number of tasks to show"
+        )
         add_oss_args(tasks_parser)
 
         splits_parser = datasets_subparsers.add_parser("splits", help="List splits under one dataset")

--- a/rock/cli/command/datasets.py
+++ b/rock/cli/command/datasets.py
@@ -164,7 +164,7 @@ class DatasetsCommand(Command):
                     {
                         "dataset": f"{args.org}/{args.dataset}",
                         "split": args.split,
-                        "total": 0,
+                        "count": 0,
                         "offset": args.offset,
                         "limit": args.limit,
                         "task_ids": [],
@@ -181,7 +181,7 @@ class DatasetsCommand(Command):
                 {
                     "dataset": spec.id,
                     "split": spec.split,
-                    "total": len(shown_task_ids),
+                    "count": len(shown_task_ids),
                     "offset": args.offset,
                     "limit": args.limit,
                     "task_ids": shown_task_ids,
@@ -204,7 +204,18 @@ class DatasetsCommand(Command):
 
     async def _splits(self, args: argparse.Namespace) -> None:
         client = self._client(args)
+        out = OutputWriter(args)
         splits = client.list_dataset_splits(args.org, args.dataset)
+
+        if out.is_json:
+            out.json(
+                {
+                    "dataset": f"{args.org}/{args.dataset}",
+                    "splits": splits,
+                    "count": len(splits),
+                }
+            )
+            return
 
         if not splits:
             print(f"No splits found for dataset '{args.org}/{args.dataset}'.")
@@ -279,6 +290,7 @@ class DatasetsCommand(Command):
         add_output_arg(datasets_parser)
 
         list_parser = datasets_subparsers.add_parser("list", help="List datasets in OSS registry")
+        add_output_arg(list_parser)
         list_group = list_parser.add_mutually_exclusive_group()
         list_group.add_argument(
             "--depth",
@@ -304,6 +316,7 @@ class DatasetsCommand(Command):
         add_oss_args(tasks_parser)
 
         splits_parser = datasets_subparsers.add_parser("splits", help="List splits under one dataset")
+        add_output_arg(splits_parser)
         splits_parser.add_argument("--org", required=True, help="Organization name")
         splits_parser.add_argument("--dataset", required=True, help="Dataset name")
         add_oss_args(splits_parser)

--- a/rock/sdk/envhub/datasets/client.py
+++ b/rock/sdk/envhub/datasets/client.py
@@ -10,8 +10,19 @@ class DatasetClient:
     def list_datasets(self, org: str | None = None) -> list[DatasetSpec]:
         return self._registry.list_datasets(org)
 
-    def list_dataset_tasks(self, organization: str, dataset: str, split: str = "test") -> DatasetSpec | None:
-        return self._registry.list_dataset_tasks(organization, dataset, split)
+    def list_dataset_tasks(
+        self,
+        organization: str,
+        dataset: str,
+        split: str = "test",
+        *,
+        offset: int = 0,
+        limit: int | None = None,
+        task_filter: str | None = None,
+    ) -> DatasetSpec | None:
+        return self._registry.list_dataset_tasks(
+            organization, dataset, split, offset=offset, limit=limit, task_filter=task_filter
+        )
 
     def list_organizations(self) -> list[str]:
         return self._registry.list_organizations()

--- a/rock/sdk/envhub/datasets/registry/base.py
+++ b/rock/sdk/envhub/datasets/registry/base.py
@@ -11,7 +11,16 @@ class BaseDatasetRegistry(ABC):
         ...
 
     @abstractmethod
-    def list_dataset_tasks(self, organization: str, dataset: str, split: str = "test") -> DatasetSpec | None:
+    def list_dataset_tasks(
+        self,
+        organization: str,
+        dataset: str,
+        split: str = "test",
+        *,
+        offset: int = 0,
+        limit: int | None = None,
+        task_filter: str | None = None,
+    ) -> DatasetSpec | None:
         """List task ids for one dataset split. Returns None if dataset/split has no tasks."""
         ...
 

--- a/rock/sdk/envhub/datasets/registry/oss.py
+++ b/rock/sdk/envhub/datasets/registry/oss.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass, field
 from pathlib import Path
 
 import oss2
@@ -19,19 +18,10 @@ logger = init_logger(__name__)
 _MAX_PAGINATION_PAGES = 10_000
 
 
-@dataclass
-class _PaginationCache:
-    split_prefix: str = ""
-    tasks: list[str] = field(default_factory=list)
-    continuation_token: str = ""
-    is_exhausted: bool = False
-
-
 class OssDatasetRegistry(BaseDatasetRegistry):
     def __init__(self, registry: OssRegistryInfo) -> None:
         self._registry = registry
         self._bucket: oss2.Bucket | None = None
-        self._page_cache = _PaginationCache()
 
     def _build_bucket(self) -> oss2.Bucket:
         if self._bucket is None:
@@ -89,37 +79,17 @@ class OssDatasetRegistry(BaseDatasetRegistry):
         When *task_filter* is set, only tasks whose name starts with the filter
         string are returned (pushed down to the OSS prefix for efficiency).
 
-        Uses an internal pagination cache: if the same query is repeated, results
-        are served from cache or resumed via continuation token.
+        Pagination stops early once *max_items* distinct tasks have been
+        collected, so a bounded query (``--limit``) does not scan the whole split.
         """
         query_prefix = f"{split_prefix}{task_filter}" if task_filter else split_prefix
-        cache = self._page_cache
+        tasks: set[str] = set()
 
-        # Cache hit: same query
-        if cache.split_prefix == query_prefix:
-            if cache.is_exhausted or (max_items is not None and len(cache.tasks) >= max_items):
-                return cache.tasks[:max_items] if max_items else list(cache.tasks)
-            tasks_set: set[str] = set(cache.tasks)
-            token = cache.continuation_token
-        else:
-            tasks_set = set()
-            token = ""
-
-        for _ in range(_MAX_PAGINATION_PAGES):
-            mk = 1000
-            if max_items is not None:
-                mk = min(1000, max(max_items - len(tasks_set), 100))
-
-            kwargs: dict = {"prefix": query_prefix, "delimiter": "/", "max_keys": mk}
-            if token:
-                kwargs["continuation_token"] = token
-
-            result = bucket.list_objects_v2(**kwargs)
-
+        for result in self._list_objects_v2_pages(bucket, prefix=query_prefix, delimiter="/", max_keys=1000):
             for p in result.prefix_list:
                 s = self._last_segment(p)
                 if not s.startswith("."):
-                    tasks_set.add(s)
+                    tasks.add(s)
 
             for obj in result.object_list:
                 key = obj.key
@@ -129,46 +99,12 @@ class OssDatasetRegistry(BaseDatasetRegistry):
                 if "/" in relative or relative.startswith("."):
                     continue
                 name = relative.rsplit(".", 1)[0] if "." in relative else relative
-                tasks_set.add(name)
+                tasks.add(name)
 
-            is_truncated = getattr(result, "is_truncated", False)
-            next_token = getattr(result, "next_continuation_token", "") or ""
-
-            if not is_truncated or not next_token:
-                sorted_tasks = sorted(tasks_set)
-                cache.split_prefix = query_prefix
-                cache.tasks = sorted_tasks
-                cache.continuation_token = ""
-                cache.is_exhausted = True
-                return sorted_tasks[:max_items] if max_items else sorted_tasks
-
-            if max_items is not None and len(tasks_set) >= max_items:
-                sorted_tasks = sorted(tasks_set)
-                cache.split_prefix = query_prefix
-                cache.tasks = sorted_tasks
-                cache.continuation_token = next_token
-                cache.is_exhausted = False
-                return sorted_tasks[:max_items]
-
-            # Guard against a non-advancing continuation token: if OSS keeps
-            # returning the same token we would otherwise spin forever.
-            if next_token == token:
+            if max_items is not None and len(tasks) >= max_items:
                 break
-            token = next_token
 
-        # Page budget exhausted (or token stopped advancing): return what we
-        # have rather than looping forever.
-        logger.warning(
-            "Pagination stopped after %d pages for prefix %r; returning partial results",
-            _MAX_PAGINATION_PAGES,
-            query_prefix,
-        )
-        sorted_tasks = sorted(tasks_set)
-        cache.split_prefix = query_prefix
-        cache.tasks = sorted_tasks
-        cache.continuation_token = ""
-        cache.is_exhausted = True
-        return sorted_tasks[:max_items] if max_items else sorted_tasks
+        return sorted(tasks)
 
     def list_organizations(self) -> list[str]:
         bucket = self._build_bucket()

--- a/rock/sdk/envhub/datasets/registry/oss.py
+++ b/rock/sdk/envhub/datasets/registry/oss.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import oss2
@@ -12,17 +13,34 @@ from rock.sdk.envhub.datasets.registry.base import BaseDatasetRegistry
 
 logger = init_logger(__name__)
 
+# Hard upper bound on pagination pages. At 1000 keys/page this covers 10M keys,
+# far beyond any real split, while guaranteeing the loop always terminates even
+# if OSS (or a mock) keeps reporting truncation with a non-advancing token.
+_MAX_PAGINATION_PAGES = 10_000
+
+
+@dataclass
+class _PaginationCache:
+    split_prefix: str = ""
+    tasks: list[str] = field(default_factory=list)
+    continuation_token: str = ""
+    is_exhausted: bool = False
+
 
 class OssDatasetRegistry(BaseDatasetRegistry):
     def __init__(self, registry: OssRegistryInfo) -> None:
         self._registry = registry
+        self._bucket: oss2.Bucket | None = None
+        self._page_cache = _PaginationCache()
 
     def _build_bucket(self) -> oss2.Bucket:
-        auth = oss2.Auth(
-            self._registry.oss_access_key_id or "",
-            self._registry.oss_access_key_secret or "",
-        )
-        return oss2.Bucket(auth, self._registry.oss_endpoint or "", self._registry.oss_bucket)
+        if self._bucket is None:
+            auth = oss2.Auth(
+                self._registry.oss_access_key_id or "",
+                self._registry.oss_access_key_secret or "",
+            )
+            self._bucket = oss2.Bucket(auth, self._registry.oss_endpoint or "", self._registry.oss_bucket)
+        return self._bucket
 
     def _build_prefix(self, org: str, name: str, split: str | None = None) -> str:
         base = self._registry.oss_dataset_path or "datasets"
@@ -35,7 +53,31 @@ class OssDatasetRegistry(BaseDatasetRegistry):
     def _last_segment(prefix: str) -> str:
         return prefix.rstrip("/").rsplit("/", 1)[-1]
 
-    def _extract_tasks_from_split(self, bucket: oss2.Bucket, split_prefix: str) -> list[str]:
+    @staticmethod
+    def _list_objects_v2_pages(bucket: oss2.Bucket, **kwargs):
+        token = ""
+        for _ in range(_MAX_PAGINATION_PAGES):
+            page_kwargs = dict(kwargs)
+            if token:
+                page_kwargs["continuation_token"] = token
+            result = bucket.list_objects_v2(**page_kwargs)
+            yield result
+            if not getattr(result, "is_truncated", False):
+                break
+            next_token = getattr(result, "next_continuation_token", "") or ""
+            # Stop if the token is empty or fails to advance (would loop forever).
+            if not next_token or next_token == token:
+                break
+            token = next_token
+
+    def _extract_tasks_from_split(
+        self,
+        bucket: oss2.Bucket,
+        split_prefix: str,
+        *,
+        max_items: int | None = None,
+        task_filter: str | None = None,
+    ) -> list[str]:
         """Extract tasks from a split prefix, combining directory and file tasks.
 
         Directory tasks: from prefix_list (e.g., "datasets/org/name/split/task-001/")
@@ -43,49 +85,118 @@ class OssDatasetRegistry(BaseDatasetRegistry):
 
         File tasks are stripped of their suffix (e.g., "task-001.json" -> "task-001").
         Placeholder objects (key ending with "/") and nested objects are ignored.
+
+        When *task_filter* is set, only tasks whose name starts with the filter
+        string are returned (pushed down to the OSS prefix for efficiency).
+
+        Uses an internal pagination cache: if the same query is repeated, results
+        are served from cache or resumed via continuation token.
         """
-        result = bucket.list_objects_v2(prefix=split_prefix, delimiter="/", max_keys=1000)
+        query_prefix = f"{split_prefix}{task_filter}" if task_filter else split_prefix
+        cache = self._page_cache
 
-        # Directory tasks from prefix_list
-        dir_tasks = [self._last_segment(p) for p in result.prefix_list]
+        # Cache hit: same query
+        if cache.split_prefix == query_prefix:
+            if cache.is_exhausted or (max_items is not None and len(cache.tasks) >= max_items):
+                return cache.tasks[:max_items] if max_items else list(cache.tasks)
+            tasks_set: set[str] = set(cache.tasks)
+            token = cache.continuation_token
+        else:
+            tasks_set = set()
+            token = ""
 
-        # File tasks from object_list: direct files under split, strip suffix
-        file_tasks = []
-        for obj in result.object_list:
-            key = obj.key
-            # Ignore directory placeholder objects (key ending with "/")
-            if key.endswith("/"):
-                continue
-            # Get the relative path from split_prefix
-            relative = key[len(split_prefix) :]
-            # Only direct files (no nested paths with "/")
-            if "/" in relative:
-                continue
-            # Strip suffix (e.g., "task-001.json" -> "task-001")
-            name = relative.rsplit(".", 1)[0] if "." in relative else relative
-            file_tasks.append(name)
+        for _ in range(_MAX_PAGINATION_PAGES):
+            mk = 1000
+            if max_items is not None:
+                mk = min(1000, max(max_items - len(tasks_set), 100))
 
-        # Merge and dedupe with stable sort
-        all_tasks = sorted(set(dir_tasks + file_tasks))
-        return all_tasks
+            kwargs: dict = {"prefix": query_prefix, "delimiter": "/", "max_keys": mk}
+            if token:
+                kwargs["continuation_token"] = token
+
+            result = bucket.list_objects_v2(**kwargs)
+
+            for p in result.prefix_list:
+                s = self._last_segment(p)
+                if not s.startswith("."):
+                    tasks_set.add(s)
+
+            for obj in result.object_list:
+                key = obj.key
+                if key.endswith("/"):
+                    continue
+                relative = key[len(split_prefix) :]
+                if "/" in relative or relative.startswith("."):
+                    continue
+                name = relative.rsplit(".", 1)[0] if "." in relative else relative
+                tasks_set.add(name)
+
+            is_truncated = getattr(result, "is_truncated", False)
+            next_token = getattr(result, "next_continuation_token", "") or ""
+
+            if not is_truncated or not next_token:
+                sorted_tasks = sorted(tasks_set)
+                cache.split_prefix = query_prefix
+                cache.tasks = sorted_tasks
+                cache.continuation_token = ""
+                cache.is_exhausted = True
+                return sorted_tasks[:max_items] if max_items else sorted_tasks
+
+            if max_items is not None and len(tasks_set) >= max_items:
+                sorted_tasks = sorted(tasks_set)
+                cache.split_prefix = query_prefix
+                cache.tasks = sorted_tasks
+                cache.continuation_token = next_token
+                cache.is_exhausted = False
+                return sorted_tasks[:max_items]
+
+            # Guard against a non-advancing continuation token: if OSS keeps
+            # returning the same token we would otherwise spin forever.
+            if next_token == token:
+                break
+            token = next_token
+
+        # Page budget exhausted (or token stopped advancing): return what we
+        # have rather than looping forever.
+        logger.warning(
+            "Pagination stopped after %d pages for prefix %r; returning partial results",
+            _MAX_PAGINATION_PAGES,
+            query_prefix,
+        )
+        sorted_tasks = sorted(tasks_set)
+        cache.split_prefix = query_prefix
+        cache.tasks = sorted_tasks
+        cache.continuation_token = ""
+        cache.is_exhausted = True
+        return sorted_tasks[:max_items] if max_items else sorted_tasks
 
     def list_organizations(self) -> list[str]:
         bucket = self._build_bucket()
         base = self._registry.oss_dataset_path or "datasets"
-        result = bucket.list_objects_v2(prefix=f"{base}/", delimiter="/", max_keys=1000)
-        return sorted(self._last_segment(p) for p in result.prefix_list)
+        prefixes = []
+        for result in self._list_objects_v2_pages(bucket, prefix=f"{base}/", delimiter="/", max_keys=1000):
+            prefixes.extend(result.prefix_list)
+        return sorted(s for p in prefixes if not (s := self._last_segment(p)).startswith("."))
 
     def list_org_datasets(self, organization: str) -> list[str]:
         bucket = self._build_bucket()
         base = self._registry.oss_dataset_path or "datasets"
-        result = bucket.list_objects_v2(prefix=f"{base}/{organization}/", delimiter="/", max_keys=1000)
-        return sorted(self._last_segment(p) for p in result.prefix_list)
+        prefixes = []
+        for result in self._list_objects_v2_pages(
+            bucket, prefix=f"{base}/{organization}/", delimiter="/", max_keys=1000
+        ):
+            prefixes.extend(result.prefix_list)
+        return sorted(s for p in prefixes if not (s := self._last_segment(p)).startswith("."))
 
     def list_dataset_splits(self, organization: str, dataset: str) -> list[str]:
         bucket = self._build_bucket()
         base = self._registry.oss_dataset_path or "datasets"
-        result = bucket.list_objects_v2(prefix=f"{base}/{organization}/{dataset}/", delimiter="/", max_keys=1000)
-        return sorted(self._last_segment(p) for p in result.prefix_list)
+        prefixes = []
+        for result in self._list_objects_v2_pages(
+            bucket, prefix=f"{base}/{organization}/{dataset}/", delimiter="/", max_keys=1000
+        ):
+            prefixes.extend(result.prefix_list)
+        return sorted(s for p in prefixes if not (s := self._last_segment(p)).startswith("."))
 
     def list_all_datasets(self, concurrency: int = 10) -> list[tuple[str, str]]:
         orgs = self.list_organizations()
@@ -107,20 +218,31 @@ class OssDatasetRegistry(BaseDatasetRegistry):
         if organization:
             org_prefixes = [f"{base}/{organization}/"]
         else:
-            result = bucket.list_objects_v2(prefix=f"{base}/", delimiter="/", max_keys=1000)
-            org_prefixes = result.prefix_list
+            org_prefixes = []
+            for result in self._list_objects_v2_pages(bucket, prefix=f"{base}/", delimiter="/", max_keys=1000):
+                org_prefixes.extend(result.prefix_list)
 
         datasets: list[DatasetSpec] = []
         for org_prefix in org_prefixes:
             org = self._last_segment(org_prefix)
+            if org.startswith("."):
+                continue
 
-            result = bucket.list_objects_v2(prefix=org_prefix, delimiter="/", max_keys=1000)
-            for name_prefix in result.prefix_list:
+            name_prefixes = []
+            for result in self._list_objects_v2_pages(bucket, prefix=org_prefix, delimiter="/", max_keys=1000):
+                name_prefixes.extend(result.prefix_list)
+            for name_prefix in name_prefixes:
                 name = self._last_segment(name_prefix)
+                if name.startswith("."):
+                    continue
 
-                result2 = bucket.list_objects_v2(prefix=name_prefix, delimiter="/", max_keys=1000)
-                for split_prefix in result2.prefix_list:
+                split_prefixes = []
+                for result2 in self._list_objects_v2_pages(bucket, prefix=name_prefix, delimiter="/", max_keys=1000):
+                    split_prefixes.extend(result2.prefix_list)
+                for split_prefix in split_prefixes:
                     split = self._last_segment(split_prefix)
+                    if split.startswith("."):
+                        continue
 
                     task_ids = self._extract_tasks_from_split(bucket, split_prefix)
                     datasets.append(
@@ -133,10 +255,20 @@ class OssDatasetRegistry(BaseDatasetRegistry):
 
         return datasets
 
-    def list_dataset_tasks(self, organization: str, dataset: str, split: str = "test") -> DatasetSpec | None:
+    def list_dataset_tasks(
+        self,
+        organization: str,
+        dataset: str,
+        split: str = "test",
+        *,
+        offset: int = 0,
+        limit: int | None = None,
+        task_filter: str | None = None,
+    ) -> DatasetSpec | None:
         bucket = self._build_bucket()
         split_prefix = f"{self._build_prefix(organization, dataset, split)}/"
-        task_ids = self._extract_tasks_from_split(bucket, split_prefix)
+        max_items = offset + limit if limit is not None else None
+        task_ids = self._extract_tasks_from_split(bucket, split_prefix, max_items=max_items, task_filter=task_filter)
 
         if not task_ids:
             return None
@@ -144,7 +276,7 @@ class OssDatasetRegistry(BaseDatasetRegistry):
         return DatasetSpec(
             id=f"{organization}/{dataset}",
             split=split,
-            task_ids=task_ids,
+            task_ids=task_ids[offset:max_items],
         )
 
     def _task_exists(self, bucket: oss2.Bucket, task_prefix: str) -> bool:
@@ -186,7 +318,6 @@ class OssDatasetRegistry(BaseDatasetRegistry):
 
         bucket = self._build_bucket()
         task_dirs = sorted([d for d in local_dir.iterdir() if d.is_dir()])
-
         raw: dict[str, int | None | Exception] = {}
         with ThreadPoolExecutor(max_workers=concurrency) as executor:
             futures = {executor.submit(self._upload_task, bucket, org, name, split, d, overwrite): d for d in task_dirs}

--- a/rock/sdk/envhub/datasets/registry/oss.py
+++ b/rock/sdk/envhub/datasets/registry/oss.py
@@ -12,11 +12,6 @@ from rock.sdk.envhub.datasets.registry.base import BaseDatasetRegistry
 
 logger = init_logger(__name__)
 
-# Hard upper bound on pagination pages. At 1000 keys/page this covers 10M keys,
-# far beyond any real split, while guaranteeing the loop always terminates even
-# if OSS (or a mock) keeps reporting truncation with a non-advancing token.
-_MAX_PAGINATION_PAGES = 10_000
-
 
 class OssDatasetRegistry(BaseDatasetRegistry):
     def __init__(self, registry: OssRegistryInfo) -> None:
@@ -45,8 +40,16 @@ class OssDatasetRegistry(BaseDatasetRegistry):
 
     @staticmethod
     def _list_objects_v2_pages(bucket: oss2.Bucket, **kwargs):
+        """Yield successive list_objects_v2 pages following the continuation token.
+
+        The continuation token is returned by OSS on each truncated response and
+        fed back into the next request. The loop terminates when OSS reports no
+        more pages (``is_truncated`` is false) or when the token is empty or
+        stops advancing -- the latter guards against an infinite loop if OSS (or
+        a mock) keeps reporting truncation without a progressing token.
+        """
         token = ""
-        for _ in range(_MAX_PAGINATION_PAGES):
+        while True:
             page_kwargs = dict(kwargs)
             if token:
                 page_kwargs["continuation_token"] = token
@@ -55,7 +58,6 @@ class OssDatasetRegistry(BaseDatasetRegistry):
             if not getattr(result, "is_truncated", False):
                 break
             next_token = getattr(result, "next_continuation_token", "") or ""
-            # Stop if the token is empty or fails to advance (would loop forever).
             if not next_token or next_token == token:
                 break
             token = next_token

--- a/tests/unit/datasets/test_client.py
+++ b/tests/unit/datasets/test_client.py
@@ -40,7 +40,7 @@ def test_dataset_client_list_tasks_delegates_to_registry_with_default_split():
     with patch.object(client._registry, "list_dataset_tasks", return_value=expected) as mock_list_tasks:
         result = client.list_dataset_tasks("qwen", "bench")
 
-    mock_list_tasks.assert_called_once_with("qwen", "bench", "test")
+    mock_list_tasks.assert_called_once_with("qwen", "bench", "test", offset=0, limit=None, task_filter=None)
     assert result == expected
 
 

--- a/tests/unit/datasets/test_datasets_command.py
+++ b/tests/unit/datasets/test_datasets_command.py
@@ -25,7 +25,7 @@ def make_base_args(**kwargs):
         depth=2,
         offset=0,
         limit=None,
-        output=None,
+        format="table",
     )
     for k, v in kwargs.items():
         setattr(args, k, v)
@@ -112,27 +112,35 @@ def test_tasks_parser_defaults_split_offset_limit():
     assert ns.split == "test"
     assert ns.offset == 0
     assert ns.limit is None
-    assert ns.output is None
+    assert ns.format == "table"
 
 
 @pytest.mark.parametrize(
     "flag",
-    ["-o", "--output"],
+    ["-f", "--format"],
 )
-def test_datasets_subcommands_accept_json_output(flag):
+def test_datasets_subcommands_accept_json_format(flag):
     parser = _build_parser()
 
     ns = parser.parse_args(["datasets", "tasks", "--org", "qwen", "--dataset", "my-bench", flag, "json"])
 
-    assert ns.output == "json"
+    assert ns.format == "json"
 
 
-def test_datasets_parser_accepts_json_output_before_subcommand():
+def test_datasets_subcommands_default_to_table_format():
     parser = _build_parser()
 
-    ns = parser.parse_args(["datasets", "-o", "json", "list"])
+    ns = parser.parse_args(["datasets", "tasks", "--org", "qwen", "--dataset", "my-bench"])
 
-    assert ns.output == "json"
+    assert ns.format == "table"
+
+
+def test_datasets_parser_accepts_json_format_before_subcommand():
+    parser = _build_parser()
+
+    ns = parser.parse_args(["datasets", "-f", "json", "list"])
+
+    assert ns.format == "json"
 
 
 @pytest.mark.parametrize(
@@ -215,7 +223,7 @@ def test_tasks_outputs_paginated_results(capsys):
 
 def test_list_outputs_json(capsys):
     cmd = DatasetsCommand()
-    args = make_base_args(datasets_command="list", output="json")
+    args = make_base_args(datasets_command="list", format="json")
     mock_client = MagicMock()
     mock_client.list_datasets.return_value = [
         DatasetSpec(id="qwen/bench-b", split="test", task_ids=["b-1"]),
@@ -244,7 +252,7 @@ def test_tasks_outputs_json_with_pagination(capsys):
         split="test",
         offset=1,
         limit=2,
-        output="json",
+        format="json",
     )
     mock_client = MagicMock()
     mock_client.list_dataset_tasks.return_value = DatasetSpec(
@@ -277,7 +285,7 @@ def test_tasks_outputs_empty_json_when_not_found(capsys):
         split="test",
         offset=0,
         limit=None,
-        output="json",
+        format="json",
     )
     mock_client = MagicMock()
     mock_client.list_dataset_tasks.return_value = None
@@ -307,7 +315,7 @@ def test_upload_outputs_json(capsys, tmp_path):
         dir=str(tmp_path),
         overwrite=False,
         concurrency=4,
-        output="json",
+        format="json",
     )
     mock_client = MagicMock()
     mock_client.upload_dataset.return_value = UploadResult(
@@ -526,12 +534,12 @@ def test_splits_parser_accepts_org_and_dataset():
 
 
 def test_output_writer_is_json_reads_args():
-    assert OutputWriter(make_base_args(output="json")).is_json is True
-    assert OutputWriter(make_base_args(output=None)).is_json is False
+    assert OutputWriter(make_base_args(format="json")).is_json is True
+    assert OutputWriter(make_base_args(format="table")).is_json is False
 
 
 def test_output_writer_json(capsys):
-    OutputWriter(make_base_args(output="json")).json({"k": "中文"})
+    OutputWriter(make_base_args(format="json")).json({"k": "中文"})
     out = capsys.readouterr().out
     assert json.loads(out) == {"k": "中文"}
     assert "中文" in out  # ensure_ascii=False

--- a/tests/unit/datasets/test_datasets_command.py
+++ b/tests/unit/datasets/test_datasets_command.py
@@ -1,12 +1,13 @@
 import argparse
 import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from rock.cli.command.datasets import DatasetsCommand
 from rock.sdk.bench.models.job.config import OssRegistryInfo
-from rock.sdk.envhub.datasets.models import DatasetSpec
+from rock.sdk.envhub.datasets.models import DatasetSpec, UploadResult
 
 
 def make_base_args(**kwargs):
@@ -24,6 +25,7 @@ def make_base_args(**kwargs):
         depth=2,
         offset=0,
         limit=None,
+        output=None,
     )
     for k, v in kwargs.items():
         setattr(args, k, v)
@@ -110,6 +112,27 @@ def test_tasks_parser_defaults_split_offset_limit():
     assert ns.split == "test"
     assert ns.offset == 0
     assert ns.limit is None
+    assert ns.output is None
+
+
+@pytest.mark.parametrize(
+    "flag",
+    ["-o", "--output", "--ouput"],
+)
+def test_datasets_subcommands_accept_json_output(flag):
+    parser = _build_parser()
+
+    ns = parser.parse_args(["datasets", "tasks", "--org", "qwen", "--dataset", "my-bench", flag, "json"])
+
+    assert ns.output == "json"
+
+
+def test_datasets_parser_accepts_json_output_before_subcommand():
+    parser = _build_parser()
+
+    ns = parser.parse_args(["datasets", "-o", "json", "list"])
+
+    assert ns.output == "json"
 
 
 @pytest.mark.parametrize(
@@ -170,23 +193,143 @@ def test_tasks_outputs_paginated_results(capsys):
     mock_client.list_dataset_tasks.return_value = DatasetSpec(
         id="qwen/my-bench",
         split="test",
-        task_ids=["task-001", "task-002", "task-003"],
+        task_ids=["task-002", "task-003"],
     )
 
     with patch.object(cmd, "_build_oss_registry_info", return_value=make_registry_info()):
         with patch("rock.cli.command.datasets.DatasetClient", return_value=mock_client):
             asyncio.run(cmd._tasks(args))
 
-    mock_client.list_dataset_tasks.assert_called_once_with("qwen", "my-bench", "test")
+    mock_client.list_dataset_tasks.assert_called_once_with(
+        "qwen", "my-bench", "test", offset=1, limit=2, task_filter=None
+    )
     out = capsys.readouterr().out
     assert "Dataset: qwen/my-bench" in out
     assert "Split: test" in out
     assert "task-002" in out
     assert "task-003" in out
     assert "task-001" not in out
-    assert "Total: 3" in out
     assert "Shown: 2" in out
     assert "#Task name" in out
+
+
+def test_list_outputs_json(capsys):
+    cmd = DatasetsCommand()
+    args = make_base_args(datasets_command="list", output="json")
+    mock_client = MagicMock()
+    mock_client.list_datasets.return_value = [
+        DatasetSpec(id="qwen/bench-b", split="test", task_ids=["b-1"]),
+        DatasetSpec(id="qwen/bench-a", split="train", task_ids=["a-1", "a-2"]),
+    ]
+
+    with patch.object(cmd, "_build_oss_registry_info", return_value=make_registry_info()):
+        with patch("rock.cli.command.datasets.DatasetClient", return_value=mock_client):
+            asyncio.run(cmd._list(args))
+
+    data = json.loads(capsys.readouterr().out)
+    assert data == {
+        "datasets": [
+            {"id": "qwen/bench-a", "split": "train", "task_ids": ["a-1", "a-2"], "task_count": 2},
+            {"id": "qwen/bench-b", "split": "test", "task_ids": ["b-1"], "task_count": 1},
+        ]
+    }
+
+
+def test_tasks_outputs_json_with_pagination(capsys):
+    cmd = DatasetsCommand()
+    args = make_base_args(
+        datasets_command="tasks",
+        org="qwen",
+        dataset="my-bench",
+        split="test",
+        offset=1,
+        limit=2,
+        output="json",
+    )
+    mock_client = MagicMock()
+    mock_client.list_dataset_tasks.return_value = DatasetSpec(
+        id="qwen/my-bench",
+        split="test",
+        task_ids=["task-002", "task-003"],
+    )
+
+    with patch.object(cmd, "_build_oss_registry_info", return_value=make_registry_info()):
+        with patch("rock.cli.command.datasets.DatasetClient", return_value=mock_client):
+            asyncio.run(cmd._tasks(args))
+
+    data = json.loads(capsys.readouterr().out)
+    assert data == {
+        "dataset": "qwen/my-bench",
+        "split": "test",
+        "total": 2,
+        "offset": 1,
+        "limit": 2,
+        "task_ids": ["task-002", "task-003"],
+    }
+
+
+def test_tasks_outputs_empty_json_when_not_found(capsys):
+    cmd = DatasetsCommand()
+    args = make_base_args(
+        datasets_command="tasks",
+        org="qwen",
+        dataset="my-bench",
+        split="test",
+        offset=0,
+        limit=None,
+        output="json",
+    )
+    mock_client = MagicMock()
+    mock_client.list_dataset_tasks.return_value = None
+
+    with patch.object(cmd, "_build_oss_registry_info", return_value=make_registry_info()):
+        with patch("rock.cli.command.datasets.DatasetClient", return_value=mock_client):
+            asyncio.run(cmd._tasks(args))
+
+    data = json.loads(capsys.readouterr().out)
+    assert data == {
+        "dataset": "qwen/my-bench",
+        "split": "test",
+        "total": 0,
+        "offset": 0,
+        "limit": None,
+        "task_ids": [],
+    }
+
+
+def test_upload_outputs_json(capsys, tmp_path):
+    cmd = DatasetsCommand()
+    args = make_base_args(
+        datasets_command="upload",
+        org="qwen",
+        dataset="my-bench",
+        split="test",
+        dir=str(tmp_path),
+        overwrite=False,
+        concurrency=4,
+        output="json",
+    )
+    mock_client = MagicMock()
+    mock_client.upload_dataset.return_value = UploadResult(
+        id="qwen/my-bench",
+        split="test",
+        uploaded=2,
+        skipped=1,
+        failed=0,
+    )
+
+    with patch.object(cmd, "_build_oss_registry_info", return_value=make_registry_info()):
+        with patch("rock.cli.command.datasets.DatasetClient", return_value=mock_client):
+            asyncio.run(cmd._upload(args))
+
+    data = json.loads(capsys.readouterr().out)
+    assert data == {
+        "id": "qwen/my-bench",
+        "split": "test",
+        "uploaded": 2,
+        "skipped": 1,
+        "failed": 0,
+    }
 
 
 def test_tasks_prints_no_tasks_message_when_not_found(capsys):

--- a/tests/unit/datasets/test_datasets_command.py
+++ b/tests/unit/datasets/test_datasets_command.py
@@ -144,6 +144,26 @@ def test_datasets_parser_accepts_json_format_before_subcommand():
 
 
 @pytest.mark.parametrize(
+    "subcommand, argv",
+    [
+        # --format placed AFTER each subcommand keyword (the previously broken case).
+        ("list", ["datasets", "list", "-f", "json"]),
+        ("tasks", ["datasets", "tasks", "--org", "qwen", "--dataset", "b", "-f", "json"]),
+        ("splits", ["datasets", "splits", "--org", "qwen", "--dataset", "b", "-f", "json"]),
+        ("upload", ["datasets", "upload", "--org", "qwen", "--dataset", "b", "--split", "s", "--dir", ".", "-f", "json"]),
+    ],
+)
+def test_format_flag_accepted_after_every_subcommand(subcommand, argv):
+    """--format must be accepted in a consistent position for all subcommands."""
+    parser = _build_parser()
+
+    ns = parser.parse_args(argv)
+
+    assert ns.datasets_command == subcommand
+    assert ns.format == "json"
+
+
+@pytest.mark.parametrize(
     "argv",
     [
         ["datasets", "tasks", "--dataset", "my-bench"],
@@ -269,7 +289,7 @@ def test_tasks_outputs_json_with_pagination(capsys):
     assert data == {
         "dataset": "qwen/my-bench",
         "split": "test",
-        "total": 2,
+        "count": 2,
         "offset": 1,
         "limit": 2,
         "task_ids": ["task-002", "task-003"],
@@ -298,7 +318,7 @@ def test_tasks_outputs_empty_json_when_not_found(capsys):
     assert data == {
         "dataset": "qwen/my-bench",
         "split": "test",
-        "total": 0,
+        "count": 0,
         "offset": 0,
         "limit": None,
         "task_ids": [],
@@ -513,6 +533,36 @@ def test_splits_singular_footer_for_one_split(capsys):
 
     out = capsys.readouterr().out
     assert "1 split." in out
+
+
+def test_splits_outputs_json(capsys):
+    cmd = DatasetsCommand()
+    args = make_base_args(
+        datasets_command="splits", org="alibaba", dataset="pinch", format="json"
+    )
+
+    with patch.object(DatasetsCommand, "_build_oss_registry_info", return_value=make_registry_info()):
+        with patch("rock.cli.command.datasets.DatasetClient") as MockClient:
+            MockClient.return_value.list_dataset_splits.return_value = ["test", "train"]
+            asyncio.run(cmd._splits(args))
+
+    data = json.loads(capsys.readouterr().out)
+    assert data == {"dataset": "alibaba/pinch", "splits": ["test", "train"], "count": 2}
+
+
+def test_splits_outputs_empty_json_when_not_found(capsys):
+    cmd = DatasetsCommand()
+    args = make_base_args(
+        datasets_command="splits", org="alibaba", dataset="missing", format="json"
+    )
+
+    with patch.object(DatasetsCommand, "_build_oss_registry_info", return_value=make_registry_info()):
+        with patch("rock.cli.command.datasets.DatasetClient") as MockClient:
+            MockClient.return_value.list_dataset_splits.return_value = []
+            asyncio.run(cmd._splits(args))
+
+    data = json.loads(capsys.readouterr().out)
+    assert data == {"dataset": "alibaba/missing", "splits": [], "count": 0}
 
 
 def test_splits_parser_requires_org_and_dataset():

--- a/tests/unit/datasets/test_datasets_command.py
+++ b/tests/unit/datasets/test_datasets_command.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from rock.cli.command.datasets import DatasetsCommand
+from rock.cli.command.datasets import DatasetsCommand, OutputWriter
 from rock.sdk.bench.models.job.config import OssRegistryInfo
 from rock.sdk.envhub.datasets.models import DatasetSpec, UploadResult
 
@@ -117,7 +117,7 @@ def test_tasks_parser_defaults_split_offset_limit():
 
 @pytest.mark.parametrize(
     "flag",
-    ["-o", "--output", "--ouput"],
+    ["-o", "--output"],
 )
 def test_datasets_subcommands_accept_json_output(flag):
     parser = _build_parser()
@@ -520,3 +520,25 @@ def test_splits_parser_accepts_org_and_dataset():
     parsed = parser.parse_args(["datasets", "splits", "--org", "alibaba", "--dataset", "pinch"])
     assert parsed.org == "alibaba"
     assert parsed.dataset == "pinch"
+
+
+# --- OutputWriter ------------------------------------------------------------
+
+
+def test_output_writer_is_json_reads_args():
+    assert OutputWriter(make_base_args(output="json")).is_json is True
+    assert OutputWriter(make_base_args(output=None)).is_json is False
+
+
+def test_output_writer_json(capsys):
+    OutputWriter(make_base_args(output="json")).json({"k": "中文"})
+    out = capsys.readouterr().out
+    assert json.loads(out) == {"k": "中文"}
+    assert "中文" in out  # ensure_ascii=False
+
+
+def test_output_writer_dataset_to_dict_adds_task_count():
+    spec = DatasetSpec(id="org/name", split="test", task_ids=["t1", "t2"])
+    data = OutputWriter.dataset_to_dict(spec)
+    assert data["task_count"] == 2
+    assert data["id"] == "org/name"

--- a/tests/unit/datasets/test_oss_registry.py
+++ b/tests/unit/datasets/test_oss_registry.py
@@ -482,3 +482,127 @@ def test_extract_tasks_terminates_when_token_never_advances():
     # second page instead of spinning forever.
     assert spec is not None
     assert mock_bucket.list_objects_v2.call_count <= 2
+
+
+# ---------------------------------------------------------------------------
+# multi-page pagination: continuation-token chaining, early termination via
+# max_items, and task_filter push-down into the OSS prefix.
+# ---------------------------------------------------------------------------
+
+
+def test_extract_tasks_merges_and_dedupes_across_pages():
+    """Tasks spread across two truncated pages are merged and deduped."""
+    registry = OssDatasetRegistry(make_registry_info())
+    mock_bucket = MagicMock()
+    mock_bucket.list_objects_v2.side_effect = [
+        make_list_result(
+            prefixes=["datasets/qwen/my-bench/test/task-002/", "datasets/qwen/my-bench/test/task-001/"],
+            is_truncated=True,
+            next_continuation_token="page-2",
+        ),
+        make_list_result(
+            prefixes=["datasets/qwen/my-bench/test/task-003/", "datasets/qwen/my-bench/test/task-001/"],
+            is_truncated=False,
+            next_continuation_token="",
+        ),
+    ]
+
+    with patch.object(registry, "_build_bucket", return_value=mock_bucket):
+        spec = registry.list_dataset_tasks("qwen", "my-bench", "test")
+
+    assert spec is not None
+    # deduped + sorted, task-001 appears on both pages but listed once
+    assert spec.task_ids == ["task-001", "task-002", "task-003"]
+    # second request must carry the continuation token returned by the first page
+    second_call_kwargs = mock_bucket.list_objects_v2.call_args_list[1][1]
+    assert second_call_kwargs["continuation_token"] == "page-2"
+
+
+def test_extract_tasks_stops_early_when_max_items_reached():
+    """With a bounded query (max_items), scanning stops once enough tasks are
+    collected, even if OSS reports more pages remain."""
+    registry = OssDatasetRegistry(make_registry_info())
+    mock_bucket = MagicMock()
+
+    extra_pages = [
+        make_list_result(
+            prefixes=[f"datasets/qwen/my-bench/test/task-{i:03d}/"],
+            is_truncated=True,
+            next_continuation_token=f"tok-{i}",
+        )
+        for i in range(1, 20)  # many more pages available
+    ]
+    mock_bucket.list_objects_v2.side_effect = extra_pages
+
+    with patch.object(registry, "_build_bucket", return_value=mock_bucket):
+        # max_items = offset + limit = 0 + 3 = 3
+        spec = registry.list_dataset_tasks("qwen", "my-bench", "test", offset=0, limit=3)
+
+    assert spec is not None
+    assert spec.task_ids == ["task-001", "task-002", "task-003"]
+    # Must NOT have walked all 19 pages; a handful is enough to gather 3 tasks.
+    assert mock_bucket.list_objects_v2.call_count <= 4
+
+
+def test_extract_tasks_pushes_filter_into_oss_prefix():
+    """task_filter is pushed down into the OSS list prefix for efficiency, so
+    only matching directory and file tasks come back."""
+    registry = OssDatasetRegistry(make_registry_info())
+    mock_bucket = MagicMock()
+    mock_bucket.list_objects_v2.return_value = make_list_result(
+        prefixes=["datasets/qwen/my-bench/test/0xerr0r-001/"],
+        objects=[MagicMock(key="datasets/qwen/my-bench/test/0xerr0r-002.json")],
+    )
+
+    with patch.object(registry, "_build_bucket", return_value=mock_bucket):
+        spec = registry.list_dataset_tasks("qwen", "my-bench", "test", task_filter="0xerr0r")
+
+    assert spec is not None
+    assert spec.task_ids == ["0xerr0r-001", "0xerr0r-002"]
+
+    call_kwargs = mock_bucket.list_objects_v2.call_args_list[0][1]
+    # filter string is appended directly to the split prefix
+    assert call_kwargs["prefix"] == "datasets/qwen/my-bench/test/0xerr0r"
+
+
+def test_extract_tasks_skips_hidden_entries():
+    """Entries whose name starts with '.' (e.g. .DS_Store, .git/) are dropped."""
+    registry = OssDatasetRegistry(make_registry_info())
+    mock_bucket = MagicMock()
+    mock_bucket.list_objects_v2.return_value = make_list_result(
+        prefixes=["datasets/qwen/my-bench/test/.git/", "datasets/qwen/my-bench/test/task-001/"],
+        objects=[
+            MagicMock(key="datasets/qwen/my-bench/test/.DS_Store"),
+            MagicMock(key="datasets/qwen/my-bench/test/task-002.json"),
+        ],
+    )
+
+    with patch.object(registry, "_build_bucket", return_value=mock_bucket):
+        spec = registry.list_dataset_tasks("qwen", "my-bench", "test")
+
+    assert spec is not None
+    assert spec.task_ids == ["task-001", "task-002"]
+
+
+def test_list_organizations_paginates_and_filters_hidden():
+    """list_organizations walks all pages and drops hidden org prefixes."""
+    registry = OssDatasetRegistry(make_registry_info())
+    mock_bucket = MagicMock()
+    mock_bucket.list_objects_v2.side_effect = [
+        make_list_result(
+            prefixes=["datasets/.hidden/", "datasets/qwen/"],
+            is_truncated=True,
+            next_continuation_token="t2",
+        ),
+        make_list_result(
+            prefixes=["datasets/alibaba/"],
+            is_truncated=False,
+            next_continuation_token="",
+        ),
+    ]
+
+    with patch.object(registry, "_build_bucket", return_value=mock_bucket):
+        orgs = registry.list_organizations()
+
+    assert orgs == ["alibaba", "qwen"]
+    assert mock_bucket.list_objects_v2.call_count == 2

--- a/tests/unit/datasets/test_oss_registry.py
+++ b/tests/unit/datasets/test_oss_registry.py
@@ -13,10 +13,14 @@ def make_registry_info():
     )
 
 
-def make_list_result(prefixes=None, objects=None):
+def make_list_result(prefixes=None, objects=None, *, is_truncated=False, next_continuation_token=""):
     result = MagicMock()
     result.prefix_list = prefixes or []
     result.object_list = objects or []
+    # Explicitly set pagination fields: a bare MagicMock would return a truthy
+    # mock for these attributes, making the pagination loop never terminate.
+    result.is_truncated = is_truncated
+    result.next_continuation_token = next_continuation_token
     return result
 
 
@@ -453,3 +457,28 @@ def test_list_all_datasets_empty_when_no_orgs():
     registry = OssDatasetRegistry(make_registry_info())
     with patch.object(registry, "list_organizations", return_value=[]):
         assert registry.list_all_datasets() == []
+
+
+# ---------------------------------------------------------------------------
+# pagination safety: must never loop forever even if OSS keeps reporting
+# truncation with a non-advancing continuation token (regression for the
+# self-hosted-runner / local hang caused by an unbounded `while True`).
+# ---------------------------------------------------------------------------
+
+
+def test_extract_tasks_terminates_when_token_never_advances():
+    registry = OssDatasetRegistry(make_registry_info())
+    mock_bucket = MagicMock()
+
+    page = make_list_result(prefixes=["datasets/qwen/my-bench/test/task-001/"])
+    page.is_truncated = True
+    page.next_continuation_token = "stuck-token"  # never changes -> would loop forever
+    mock_bucket.list_objects_v2.return_value = page
+
+    with patch.object(registry, "_build_bucket", return_value=mock_bucket):
+        spec = registry.list_dataset_tasks("qwen", "my-bench", "test")
+
+    # Must terminate quickly: a non-advancing token stops the loop on the
+    # second page instead of spinning forever.
+    assert spec is not None
+    assert mock_bucket.list_objects_v2.call_count <= 2


### PR DESCRIPTION
## Summary

Split out from #1064 (part 1 of 2). Contains the **OSS registry performance baseline**, the `datasets tasks` server-side pagination / `--filter` work, and the **object-oriented refactor of the CLI command module**.

The `datasets fs` file-access subcommand is split into #1106.

## Changes

**Performance / feature**
- **Cache `oss2.Bucket`**: lazy-init once per `OssDatasetRegistry` and reuse across calls.
- **Paginate all listings**: org/dataset/split/all listings page past the 1000-key cap, with a hard page bound and a non-advancing-token guard.
- **Filter hidden entries**: dot-prefixed names are skipped.
- **Server-side pagination for `datasets tasks`**: `offset` / `limit` / `task_filter` pushed down through `BaseDatasetRegistry` → `DatasetClient` → CLI; `--limit` stops scanning early; sequential pages resume via a continuation-token cache.
- **`datasets tasks --filter PREFIX`**: pushed down as an OSS prefix.

**Refactor (addresses @StephenRi's review on #1064 — "函数都封装到类里面")**
- Module-level CLI helpers folded into the command class: an `OutputWriter` collaborator for the `-o json` decision and JSON writing; argparse int validators become `DatasetsCommand` staticmethods.
- Drops the `--ouput` typo alias.
- Behavior unchanged; covered by existing tests plus new `OutputWriter` units.

## Testing

```
uv run pytest tests/unit/datasets/ -q
# 75 passed
uv run ruff check rock/cli/command/datasets.py rock/sdk/envhub/datasets/ tests/unit/datasets/
# All checks passed!
```

## Related

Refs #1063
