### PR TITLE
feat(datasets): add fs subcommand to inspect and download task files (#1104)

### DIFF
--- a/rock/cli/command/datasets.py
+++ b/rock/cli/command/datasets.py
@@ -16,6 +16,49 @@ from rock.sdk.envhub.datasets.client import DatasetClient
 logger = init_logger(__name__)
 
 
+class TaskPath:
+    """A safe, normalized relative path inside a single task.
+
+    Wraps the validation rules for the user-supplied ``--path`` of the
+    ``datasets fs`` commands so a crafted value cannot escape the task root:
+
+    - absolute paths (leading ``/``) are rejected;
+    - ``..`` traversal segments are rejected;
+    - ``.`` and empty segments are dropped (``a/./b`` -> ``a/b``);
+    - backslashes are treated as ``/`` separators.
+
+    A trailing slash is preserved (or forced via ``directory=True``) so callers
+    can distinguish a directory prefix from a file path. When ``allow_empty`` is
+    set, an empty input normalizes to ``""`` (the task root) instead of raising.
+    """
+
+    def __init__(self, raw: str, *, allow_empty: bool = False, directory: bool = False) -> None:
+        text = (raw or "").replace("\\", "/")
+        if text.startswith("/"):
+            raise ValueError("relative task path must not be absolute")
+
+        parts = [p for p in text.split("/") if p and p != "."]
+        if any(p == ".." for p in parts):
+            raise ValueError("relative task path must not contain '..'")
+        if not parts:
+            if allow_empty:
+                self._value = ""
+                return
+            raise ValueError("relative task path is required")
+
+        normalized = "/".join(parts)
+        if directory or text.endswith("/"):
+            normalized += "/"
+        self._value = normalized
+
+    @property
+    def value(self) -> str:
+        return self._value
+
+    def __str__(self) -> str:
+        return self._value
+
+
 class OutputWriter:
     """Renders command results as JSON or as the default ``table`` text format.
 
@@ -33,6 +76,13 @@ class OutputWriter:
 
     def json(self, data: dict | list) -> None:
         print(json.dumps(data, ensure_ascii=False, indent=2))
+
+    def bytes(self, content: bytes) -> None:
+        """Write raw file content to stdout, falling back to binary on decode errors."""
+        try:
+            sys.stdout.write(content.decode("utf-8"))
+        except UnicodeDecodeError:
+            sys.stdout.buffer.write(content)
 
     @staticmethod
     def dataset_to_dict(dataset) -> dict:
@@ -67,6 +117,8 @@ class DatasetsCommand(Command):
             await self._splits(args)
         elif args.datasets_command == "upload":
             await self._upload(args)
+        elif args.datasets_command in ("fs", "files"):
+            await self._fs(args)
         else:
             raise ValueError(f"Unknown datasets command: {args.datasets_command}")
 
@@ -249,6 +301,103 @@ class DatasetsCommand(Command):
         if result.failed > 0:
             sys.exit(1)
 
+    async def _fs(self, args: argparse.Namespace) -> None:
+        if args.fs_command == "ls":
+            await self._fs_ls(args)
+        elif args.fs_command == "get":
+            await self._fs_get(args)
+        elif args.fs_command == "download":
+            await self._fs_download(args)
+        else:
+            raise ValueError(f"Unknown datasets fs command: {args.fs_command}")
+
+    async def _fs_ls(self, args: argparse.Namespace) -> None:
+        path = TaskPath(args.path, allow_empty=True, directory=bool(args.path)).value if args.path else ""
+        client = self._client(args)
+        out = OutputWriter(args)
+        files = client.list_task_files(args.org, args.dataset, args.split, args.task, path.rstrip("/"))
+
+        if out.is_json:
+            out.json(
+                {
+                    "dataset": f"{args.org}/{args.dataset}",
+                    "split": args.split,
+                    "task": args.task,
+                    "path": path,
+                    "files": [asdict(f) for f in files],
+                }
+            )
+            return
+
+        for file in files:
+            print(file.path)
+
+    async def _fs_get(self, args: argparse.Namespace) -> None:
+        path = TaskPath(args.path).value if args.path else None
+        client = self._client(args)
+        out = OutputWriter(args)
+        if path is None:
+            files = client.list_task_files(args.org, args.dataset, args.split, args.task, "")
+            if len(files) != 1:
+                raise ValueError("--path is required when task contains zero or multiple files")
+            path = files[0].path
+        content = client.get_task_file(args.org, args.dataset, args.split, args.task, path)
+        if content is None:
+            raise FileNotFoundError(f"Task file not found: {args.org}/{args.dataset}/{args.split}/{args.task}/{path}")
+
+        if out.is_json:
+            out.json(
+                {
+                    "dataset": f"{args.org}/{args.dataset}",
+                    "split": args.split,
+                    "task": args.task,
+                    "path": path,
+                    "content": content.decode("utf-8"),
+                }
+            )
+            return
+
+        out.bytes(content)
+
+    async def _fs_download(self, args: argparse.Namespace) -> None:
+        path = TaskPath(args.path, directory=args.path.endswith("/")).value
+        dest = Path(args.dest)
+        client = self._client(args)
+        out = OutputWriter(args)
+
+        content = client.get_task_file(args.org, args.dataset, args.split, args.task, path)
+        if content is not None:
+            target = dest / Path(path).name if dest.is_dir() else dest
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(content)
+            if out.is_json:
+                out.json({"downloaded": [str(target)]})
+            else:
+                print(str(target))
+            return
+
+        prefix = path if path.endswith("/") else f"{path}/"
+        files = client.list_task_files(args.org, args.dataset, args.split, args.task, prefix.rstrip("/"))
+        if not files:
+            raise FileNotFoundError(f"Task path not found: {args.org}/{args.dataset}/{args.split}/{args.task}/{path}")
+
+        downloaded: list[str] = []
+        for file in files:
+            file_content = client.get_task_file(args.org, args.dataset, args.split, args.task, file.path)
+            if file_content is None:
+                continue
+            relative = file.path[len(prefix) :] if file.path.startswith(prefix) else file.path
+            target = dest / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(file_content)
+            downloaded.append(str(target))
+
+        if out.is_json:
+            out.json({"downloaded": downloaded})
+        else:
+            for downloaded_path in downloaded:
+                print(downloaded_path)
+
     @staticmethod
     async def add_parser_to(subparsers: argparse._SubParsersAction) -> None:
         datasets_parser = subparsers.add_parser("datasets", description="Dataset operations on OSS")
@@ -316,7 +465,7 @@ class DatasetsCommand(Command):
         upload_parser.add_argument(
             "--dir",
             required=True,
-            help="Local dataset directory containing {task_id}/ subdirectories",
+            help="Local dataset directory containing {task_id}/ subdirectories or direct task files, or one task file",
         )
         upload_parser.add_argument(
             "--concurrency",
@@ -330,3 +479,29 @@ class DatasetsCommand(Command):
             "--overwrite", action="store_true", help="Overwrite existing tasks in OSS (default: skip)"
         )
         add_oss_args(upload_parser)
+
+        fs_parser = datasets_subparsers.add_parser("fs", aliases=["files"], help="Inspect files under one task")
+        fs_subparsers = fs_parser.add_subparsers(dest="fs_command")
+
+        def add_task_fs_args(parser: argparse.ArgumentParser) -> None:
+            parser.add_argument("--org", required=True, help="Organization name")
+            parser.add_argument("--dataset", required=True, help="Dataset name")
+            parser.add_argument("--split", default="test", help="Split name (default: test)")
+            parser.add_argument("--task", required=True, help="Task ID")
+            add_oss_args(parser)
+
+        ls_parser = fs_subparsers.add_parser("ls", help="List files under one task")
+        add_output_arg(ls_parser)
+        add_task_fs_args(ls_parser)
+        ls_parser.add_argument("--path", default="", help="Relative task directory path to list")
+
+        get_parser = fs_subparsers.add_parser("get", help="Print one task file to stdout")
+        add_output_arg(get_parser)
+        add_task_fs_args(get_parser)
+        get_parser.add_argument("--path", help="Relative task file path")
+
+        download_parser = fs_subparsers.add_parser("download", help="Download one task file or directory")
+        add_output_arg(download_parser)
+        add_task_fs_args(download_parser)
+        download_parser.add_argument("--path", required=True, help="Relative task file or directory path")
+        download_parser.add_argument("--dest", required=True, help="Local destination file or directory")

--- a/rock/sdk/envhub/datasets/client.py
+++ b/rock/sdk/envhub/datasets/client.py
@@ -1,5 +1,5 @@
 from rock.sdk.bench.models.job.config import LocalDatasetConfig, OssRegistryInfo, RegistryDatasetConfig
-from rock.sdk.envhub.datasets.models import DatasetSpec, UploadResult
+from rock.sdk.envhub.datasets.models import DatasetSpec, TaskFile, UploadResult
 from rock.sdk.envhub.datasets.registry.oss import OssDatasetRegistry
 
 
@@ -35,6 +35,14 @@ class DatasetClient:
 
     def list_dataset_splits(self, organization: str, dataset: str) -> list[str]:
         return self._registry.list_dataset_splits(organization, dataset)
+
+    def list_task_files(
+        self, organization: str, dataset: str, split: str, task_id: str, path: str = ""
+    ) -> list[TaskFile]:
+        return self._registry.list_task_files(organization, dataset, split, task_id, path)
+
+    def get_task_file(self, organization: str, dataset: str, split: str, task_id: str, path: str) -> bytes | None:
+        return self._registry.get_task_file(organization, dataset, split, task_id, path)
 
     def upload_dataset(
         self,

--- a/rock/sdk/envhub/datasets/models.py
+++ b/rock/sdk/envhub/datasets/models.py
@@ -9,6 +9,12 @@ class DatasetSpec:
 
 
 @dataclass
+class TaskFile:
+    path: str
+    size: int | None = None
+
+
+@dataclass
 class UploadResult:
     id: str  # "{organization}/{dataset_name}"
     split: str

--- a/rock/sdk/envhub/datasets/registry/base.py
+++ b/rock/sdk/envhub/datasets/registry/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 
 from rock.sdk.bench.models.job.config import LocalDatasetConfig, RegistryDatasetConfig
-from rock.sdk.envhub.datasets.models import DatasetSpec, UploadResult
+from rock.sdk.envhub.datasets.models import DatasetSpec, TaskFile, UploadResult
 
 
 class BaseDatasetRegistry(ABC):
@@ -37,6 +37,18 @@ class BaseDatasetRegistry(ABC):
     @abstractmethod
     def list_dataset_splits(self, organization: str, dataset: str) -> list[str]:
         """List split names under one dataset. Single backend call."""
+        ...
+
+    @abstractmethod
+    def list_task_files(
+        self, organization: str, dataset: str, split: str, task_id: str, path: str = ""
+    ) -> list[TaskFile]:
+        """List files under a task path. Paths are relative to the task root."""
+        ...
+
+    @abstractmethod
+    def get_task_file(self, organization: str, dataset: str, split: str, task_id: str, path: str) -> bytes | None:
+        """Read one task file by relative path. Returns None when the object does not exist."""
         ...
 
     @abstractmethod

--- a/rock/sdk/envhub/datasets/registry/oss.py
+++ b/rock/sdk/envhub/datasets/registry/oss.py
@@ -7,7 +7,7 @@ import oss2
 
 from rock.logger import init_logger
 from rock.sdk.bench.models.job.config import LocalDatasetConfig, OssRegistryInfo, RegistryDatasetConfig
-from rock.sdk.envhub.datasets.models import DatasetSpec, UploadResult
+from rock.sdk.envhub.datasets.models import DatasetSpec, TaskFile, UploadResult
 from rock.sdk.envhub.datasets.registry.base import BaseDatasetRegistry
 
 logger = init_logger(__name__)
@@ -34,9 +34,31 @@ class OssDatasetRegistry(BaseDatasetRegistry):
             parts.append(split)
         return "/".join(parts)
 
+    def _build_task_prefix(self, org: str, name: str, split: str, task_id: str) -> str:
+        return f"{self._build_prefix(org, name, split)}/{task_id}/"
+
     @staticmethod
     def _last_segment(prefix: str) -> str:
         return prefix.rstrip("/").rsplit("/", 1)[-1]
+
+    @staticmethod
+    def _normalize_task_path(path: str, *, allow_empty: bool = False, directory: bool = False) -> str:
+        raw = (path or "").replace("\\", "/")
+        if raw.startswith("/"):
+            raise ValueError("relative task path must not be absolute")
+
+        parts = [p for p in raw.split("/") if p and p != "."]
+        if any(p == ".." for p in parts):
+            raise ValueError("relative task path must not contain '..'")
+        if not parts:
+            if allow_empty:
+                return ""
+            raise ValueError("relative task path is required")
+
+        normalized = "/".join(parts)
+        if directory or raw.endswith("/"):
+            normalized += "/"
+        return normalized
 
     @staticmethod
     def _list_objects_v2_pages(bucket: oss2.Bucket, **kwargs):
@@ -217,9 +239,62 @@ class OssDatasetRegistry(BaseDatasetRegistry):
             task_ids=task_ids[offset:max_items],
         )
 
+    def list_task_files(
+        self, organization: str, dataset: str, split: str, task_id: str, path: str = ""
+    ) -> list[TaskFile]:
+        bucket = self._build_bucket()
+        task_prefix = self._build_task_prefix(organization, dataset, split, task_id)
+        relative_prefix = self._normalize_task_path(path, allow_empty=True, directory=bool(path)) if path else ""
+
+        files: list[TaskFile] = []
+        for result in self._list_objects_v2_pages(bucket, prefix=f"{task_prefix}{relative_prefix}", max_keys=1000):
+            for obj in result.object_list:
+                key = obj.key
+                if key.endswith("/") or not key.startswith(task_prefix):
+                    continue
+                relative = key[len(task_prefix) :]
+                if not relative:
+                    continue
+                files.append(TaskFile(path=relative, size=getattr(obj, "size", None)))
+        if not files and not relative_prefix:
+            split_prefix = f"{self._build_prefix(organization, dataset, split)}/"
+            for result in self._list_objects_v2_pages(bucket, prefix=f"{split_prefix}{task_id}", max_keys=1000):
+                for obj in result.object_list:
+                    key = obj.key
+                    if key.endswith("/") or not key.startswith(split_prefix):
+                        continue
+                    relative = key[len(split_prefix) :]
+                    if "/" in relative:
+                        continue
+                    name = relative.rsplit(".", 1)[0] if "." in relative else relative
+                    if name == task_id:
+                        files.append(TaskFile(path=relative, size=getattr(obj, "size", None)))
+        return sorted(files, key=lambda f: f.path)
+
+    def get_task_file(self, organization: str, dataset: str, split: str, task_id: str, path: str) -> bytes | None:
+        bucket = self._build_bucket()
+        relative = self._normalize_task_path(path)
+        key = f"{self._build_task_prefix(organization, dataset, split, task_id)}{relative}"
+        try:
+            return bucket.get_object(key).read()
+        except (oss2.exceptions.NoSuchKey, oss2.exceptions.NotFound):
+            if "/" not in relative:
+                direct_name = relative.rsplit(".", 1)[0] if "." in relative else relative
+                if direct_name == task_id:
+                    direct_key = f"{self._build_prefix(organization, dataset, split)}/{relative}"
+                    try:
+                        return bucket.get_object(direct_key).read()
+                    except (oss2.exceptions.NoSuchKey, oss2.exceptions.NotFound):
+                        return None
+            return None
+
     def _task_exists(self, bucket: oss2.Bucket, task_prefix: str) -> bool:
         result = bucket.list_objects_v2(prefix=task_prefix, max_keys=1)
         return len(result.object_list) > 0
+
+    def _object_exists(self, bucket: oss2.Bucket, key: str) -> bool:
+        result = bucket.list_objects_v2(prefix=key, max_keys=1)
+        return any(obj.key == key for obj in result.object_list)
 
     def _upload_task(
         self,
@@ -243,6 +318,23 @@ class OssDatasetRegistry(BaseDatasetRegistry):
             bucket.put_object(key, file.read_bytes())
         return len(files)
 
+    def _upload_task_file(
+        self,
+        bucket: oss2.Bucket,
+        org: str,
+        name: str,
+        split: str,
+        task_file: Path,
+        overwrite: bool,
+    ) -> int | None:
+        key = f"{self._build_prefix(org, name, split)}/{task_file.name}"
+
+        if not overwrite and self._object_exists(bucket, key):
+            return None
+
+        bucket.put_object(key, task_file.read_bytes())
+        return 1
+
     def upload_dataset(
         self,
         source: LocalDatasetConfig,
@@ -255,15 +347,25 @@ class OssDatasetRegistry(BaseDatasetRegistry):
         local_dir = source.path
 
         bucket = self._build_bucket()
-        task_dirs = sorted([d for d in local_dir.iterdir() if d.is_dir()])
+        if local_dir.is_file():
+            upload_items = [local_dir]
+        else:
+            upload_items = sorted([p for p in local_dir.iterdir() if p.is_dir() or p.is_file()])
+
         raw: dict[str, int | None | Exception] = {}
         with ThreadPoolExecutor(max_workers=concurrency) as executor:
-            futures = {executor.submit(self._upload_task, bucket, org, name, split, d, overwrite): d for d in task_dirs}
-            for future, task_dir in futures.items():
+            futures = {}
+            for item in upload_items:
+                if item.is_dir():
+                    future = executor.submit(self._upload_task, bucket, org, name, split, item, overwrite)
+                else:
+                    future = executor.submit(self._upload_task_file, bucket, org, name, split, item, overwrite)
+                futures[future] = item
+            for future, item in futures.items():
                 try:
-                    raw[task_dir.name] = future.result()
+                    raw[item.name] = future.result()
                 except Exception as exc:
-                    raw[task_dir.name] = exc
+                    raw[item.name] = exc
 
         uploaded = skipped = failed = 0
         for task_id in sorted(raw):

--- a/tests/unit/datasets/test_client.py
+++ b/tests/unit/datasets/test_client.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from rock.sdk.bench.models.job.config import LocalDatasetConfig, OssRegistryInfo, RegistryDatasetConfig
 from rock.sdk.envhub.datasets.client import DatasetClient
-from rock.sdk.envhub.datasets.models import DatasetSpec, UploadResult
+from rock.sdk.envhub.datasets.models import DatasetSpec, TaskFile, UploadResult
 
 
 def make_registry_info():
@@ -81,3 +81,24 @@ def test_dataset_client_list_dataset_splits_delegates():
         result = client.list_dataset_splits("qwen", "bench")
     m.assert_called_once_with("qwen", "bench")
     assert result == ["test", "train"]
+
+
+def test_dataset_client_list_task_files_delegates():
+    client = DatasetClient(make_registry_info())
+    expected = [TaskFile(path="tests/test_api.py", size=10)]
+
+    with patch.object(client._registry, "list_task_files", return_value=expected) as m:
+        result = client.list_task_files("qwen", "bench", "test", "task-001", "tests")
+
+    m.assert_called_once_with("qwen", "bench", "test", "task-001", "tests")
+    assert result == expected
+
+
+def test_dataset_client_get_task_file_delegates():
+    client = DatasetClient(make_registry_info())
+
+    with patch.object(client._registry, "get_task_file", return_value=b"content") as m:
+        result = client.get_task_file("qwen", "bench", "test", "task-001", "task.yaml")
+
+    m.assert_called_once_with("qwen", "bench", "test", "task-001", "task.yaml")
+    assert result == b"content"

--- a/tests/unit/datasets/test_datasets_command.py
+++ b/tests/unit/datasets/test_datasets_command.py
@@ -5,9 +5,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from rock.cli.command.datasets import DatasetsCommand, OutputWriter
+from rock.cli.command.datasets import DatasetsCommand, OutputWriter, TaskPath
 from rock.sdk.bench.models.job.config import OssRegistryInfo
-from rock.sdk.envhub.datasets.models import DatasetSpec, UploadResult
+from rock.sdk.envhub.datasets.models import DatasetSpec, TaskFile, UploadResult
 
 
 def make_base_args(**kwargs):
@@ -187,6 +187,261 @@ def test_arun_dispatches_tasks():
     mock_tasks.assert_awaited_once_with(args)
 
 
+def test_arun_dispatches_fs_aliases():
+    for command in ("fs", "files"):
+        cmd = DatasetsCommand()
+        args = make_base_args(
+            datasets_command=command, fs_command="ls", org="qwen", dataset="my-bench", task="task-001"
+        )
+
+        with patch.object(DatasetsCommand, "_fs", new_callable=AsyncMock, create=True) as mock_fs:
+            asyncio.run(cmd.arun(args))
+
+        mock_fs.assert_awaited_once_with(args)
+
+
+@pytest.mark.parametrize("command", ["fs", "files"])
+def test_fs_parser_accepts_ls_get_download(command):
+    parser = _build_parser()
+
+    ls_ns = parser.parse_args(
+        ["datasets", command, "ls", "--org", "qwen", "--dataset", "my-bench", "--task", "task-001"]
+    )
+    get_ns = parser.parse_args(
+        [
+            "datasets",
+            command,
+            "get",
+            "--org",
+            "qwen",
+            "--dataset",
+            "my-bench",
+            "--task",
+            "task-001",
+            "--path",
+            "tests/input.json",
+        ]
+    )
+    download_ns = parser.parse_args(
+        [
+            "datasets",
+            command,
+            "download",
+            "--org",
+            "qwen",
+            "--dataset",
+            "my-bench",
+            "--task",
+            "task-001",
+            "--path",
+            "tests/",
+            "--dest",
+            "./tests",
+        ]
+    )
+
+    assert ls_ns.datasets_command == command
+    assert ls_ns.fs_command == "ls"
+    assert ls_ns.split == "test"
+    assert ls_ns.path == ""
+    assert get_ns.fs_command == "get"
+    assert get_ns.path == "tests/input.json"
+    assert download_ns.fs_command == "download"
+    assert download_ns.dest == "./tests"
+
+
+def test_fs_ls_outputs_recursive_task_files(capsys):
+    cmd = DatasetsCommand()
+    args = make_base_args(
+        datasets_command="fs",
+        fs_command="ls",
+        org="qwen",
+        dataset="my-bench",
+        split="test",
+        task="task-001",
+        path="tests",
+    )
+    mock_client = MagicMock()
+    mock_client.list_task_files.return_value = [
+        TaskFile(path="tests/test_api.py", size=10),
+        TaskFile(path="tests/fixtures/input.json", size=20),
+    ]
+
+    with patch.object(cmd, "_build_oss_registry_info", return_value=make_registry_info()):
+        with patch("rock.cli.command.datasets.DatasetClient", return_value=mock_client):
+            asyncio.run(cmd._fs(args))
+
+    mock_client.list_task_files.assert_called_once_with("qwen", "my-bench", "test", "task-001", "tests")
+    out = capsys.readouterr().out
+    assert "tests/test_api.py" in out
+    assert "tests/fixtures/input.json" in out
+
+
+def test_fs_ls_outputs_json(capsys):
+    cmd = DatasetsCommand()
+    args = make_base_args(
+        datasets_command="fs",
+        fs_command="ls",
+        org="qwen",
+        dataset="my-bench",
+        split="test",
+        task="task-001",
+        path="",
+        format="json",
+    )
+    mock_client = MagicMock()
+    mock_client.list_task_files.return_value = [TaskFile(path="task.yaml", size=42)]
+
+    with patch.object(cmd, "_build_oss_registry_info", return_value=make_registry_info()):
+        with patch("rock.cli.command.datasets.DatasetClient", return_value=mock_client):
+            asyncio.run(cmd._fs(args))
+
+    assert json.loads(capsys.readouterr().out) == {
+        "dataset": "qwen/my-bench",
+        "split": "test",
+        "task": "task-001",
+        "path": "",
+        "files": [{"path": "task.yaml", "size": 42}],
+    }
+
+
+def test_fs_get_writes_file_content(capsys):
+    cmd = DatasetsCommand()
+    args = make_base_args(
+        datasets_command="fs",
+        fs_command="get",
+        org="qwen",
+        dataset="my-bench",
+        split="test",
+        task="task-001",
+        path="task.yaml",
+    )
+    mock_client = MagicMock()
+    mock_client.get_task_file.return_value = b"instruction: fix bug\n"
+
+    with patch.object(cmd, "_build_oss_registry_info", return_value=make_registry_info()):
+        with patch("rock.cli.command.datasets.DatasetClient", return_value=mock_client):
+            asyncio.run(cmd._fs(args))
+
+    mock_client.get_task_file.assert_called_once_with("qwen", "my-bench", "test", "task-001", "task.yaml")
+    assert capsys.readouterr().out == "instruction: fix bug\n"
+
+
+def test_fs_get_without_path_reads_single_task_file(capsys):
+    cmd = DatasetsCommand()
+    args = make_base_args(
+        datasets_command="fs",
+        fs_command="get",
+        org="qwen",
+        dataset="my-bench",
+        split="test",
+        task="task-001",
+        path=None,
+    )
+    mock_client = MagicMock()
+    mock_client.list_task_files.return_value = [TaskFile(path="task-001.json", size=42)]
+    mock_client.get_task_file.return_value = b'{"instruction": "fix bug"}\n'
+
+    with patch.object(cmd, "_build_oss_registry_info", return_value=make_registry_info()):
+        with patch("rock.cli.command.datasets.DatasetClient", return_value=mock_client):
+            asyncio.run(cmd._fs(args))
+
+    mock_client.list_task_files.assert_called_once_with("qwen", "my-bench", "test", "task-001", "")
+    mock_client.get_task_file.assert_called_once_with("qwen", "my-bench", "test", "task-001", "task-001.json")
+    assert capsys.readouterr().out == '{"instruction": "fix bug"}\n'
+
+
+def test_fs_get_without_path_requires_path_when_task_has_multiple_files():
+    cmd = DatasetsCommand()
+    args = make_base_args(
+        datasets_command="fs",
+        fs_command="get",
+        org="qwen",
+        dataset="my-bench",
+        split="test",
+        task="task-001",
+        path=None,
+    )
+    mock_client = MagicMock()
+    mock_client.list_task_files.return_value = [
+        TaskFile(path="task.yaml", size=42),
+        TaskFile(path="tests/test_api.py", size=10),
+    ]
+
+    with patch.object(cmd, "_build_oss_registry_info", return_value=make_registry_info()):
+        with patch("rock.cli.command.datasets.DatasetClient", return_value=mock_client):
+            with pytest.raises(ValueError, match="--path is required"):
+                asyncio.run(cmd._fs(args))
+
+
+def test_fs_download_file_writes_destination(tmp_path):
+    cmd = DatasetsCommand()
+    dest = tmp_path / "task.yaml"
+    args = make_base_args(
+        datasets_command="fs",
+        fs_command="download",
+        org="qwen",
+        dataset="my-bench",
+        split="test",
+        task="task-001",
+        path="task.yaml",
+        dest=str(dest),
+    )
+    mock_client = MagicMock()
+    mock_client.get_task_file.return_value = b"instruction: fix bug\n"
+
+    with patch.object(cmd, "_build_oss_registry_info", return_value=make_registry_info()):
+        with patch("rock.cli.command.datasets.DatasetClient", return_value=mock_client):
+            asyncio.run(cmd._fs(args))
+
+    assert dest.read_bytes() == b"instruction: fix bug\n"
+    mock_client.list_task_files.assert_not_called()
+
+
+def test_fs_download_directory_strips_requested_prefix(tmp_path):
+    cmd = DatasetsCommand()
+    args = make_base_args(
+        datasets_command="fs",
+        fs_command="download",
+        org="qwen",
+        dataset="my-bench",
+        split="test",
+        task="task-001",
+        path="tests/",
+        dest=str(tmp_path / "downloaded-tests"),
+    )
+    mock_client = MagicMock()
+    mock_client.get_task_file.return_value = None
+    mock_client.list_task_files.return_value = [
+        TaskFile(path="tests/test_api.py", size=10),
+        TaskFile(path="tests/fixtures/input.json", size=20),
+    ]
+    mock_client.get_task_file.side_effect = [None, b"assert True\n", b"{}\n"]
+
+    with patch.object(cmd, "_build_oss_registry_info", return_value=make_registry_info()):
+        with patch("rock.cli.command.datasets.DatasetClient", return_value=mock_client):
+            asyncio.run(cmd._fs(args))
+
+    assert (tmp_path / "downloaded-tests" / "test_api.py").read_text() == "assert True\n"
+    assert (tmp_path / "downloaded-tests" / "fixtures" / "input.json").read_text() == "{}\n"
+
+
+def test_fs_rejects_unsafe_relative_path():
+    cmd = DatasetsCommand()
+    args = make_base_args(
+        datasets_command="fs",
+        fs_command="get",
+        org="qwen",
+        dataset="my-bench",
+        split="test",
+        task="task-001",
+        path="../other-task/task.yaml",
+    )
+
+    with pytest.raises(ValueError, match="relative task path"):
+        asyncio.run(cmd._fs(args))
+
+
 def test_tasks_outputs_paginated_results(capsys):
     cmd = DatasetsCommand()
     args = make_base_args(
@@ -338,6 +593,37 @@ def test_upload_outputs_json(capsys, tmp_path):
         "skipped": 1,
         "failed": 0,
     }
+
+
+def test_upload_accepts_single_file_source(capsys, tmp_path):
+    task_file = tmp_path / "task-001.json"
+    task_file.write_text("{}")
+    cmd = DatasetsCommand()
+    args = make_base_args(
+        datasets_command="upload",
+        org="qwen",
+        dataset="my-bench",
+        split="test",
+        dir=str(task_file),
+        overwrite=False,
+        concurrency=4,
+    )
+    mock_client = MagicMock()
+    mock_client.upload_dataset.return_value = UploadResult(
+        id="qwen/my-bench",
+        split="test",
+        uploaded=1,
+        skipped=0,
+        failed=0,
+    )
+
+    with patch.object(cmd, "_build_oss_registry_info", return_value=make_registry_info()):
+        with patch("rock.cli.command.datasets.DatasetClient", return_value=mock_client):
+            asyncio.run(cmd._upload(args))
+
+    source = mock_client.upload_dataset.call_args.args[0]
+    assert source.path == task_file
+    assert "Uploading to oss://b/datasets/qwen/my-bench/test/" in capsys.readouterr().out
 
 
 def test_tasks_prints_no_tasks_message_when_not_found(capsys):
@@ -530,6 +816,42 @@ def test_splits_parser_accepts_org_and_dataset():
     assert parsed.dataset == "pinch"
 
 
+# --- TaskPath value object ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("a/b.json", "a/b.json"),
+        ("a\\b.json", "a/b.json"),  # backslash normalized
+        ("a/./b", "a/b"),  # '.' segment dropped
+        ("a//b", "a/b"),  # empty segment dropped
+        ("dir/", "dir/"),  # trailing slash preserved
+    ],
+)
+def test_task_path_normalizes(raw, expected):
+    assert TaskPath(raw).value == expected
+
+
+def test_task_path_directory_flag_forces_trailing_slash():
+    assert TaskPath("dir", directory=True).value == "dir/"
+
+
+def test_task_path_allow_empty():
+    assert TaskPath("", allow_empty=True).value == ""
+
+
+@pytest.mark.parametrize("raw", ["/abs/path", "a/../b", "..", "a/../../etc"])
+def test_task_path_rejects_unsafe(raw):
+    with pytest.raises(ValueError):
+        TaskPath(raw)
+
+
+def test_task_path_empty_requires_value_by_default():
+    with pytest.raises(ValueError):
+        TaskPath("")
+
+
 # --- OutputWriter ------------------------------------------------------------
 
 
@@ -543,6 +865,11 @@ def test_output_writer_json(capsys):
     out = capsys.readouterr().out
     assert json.loads(out) == {"k": "中文"}
     assert "中文" in out  # ensure_ascii=False
+
+
+def test_output_writer_bytes_decodes_utf8(capsys):
+    OutputWriter(make_base_args()).bytes(b"hello")
+    assert capsys.readouterr().out == "hello"
 
 
 def test_output_writer_dataset_to_dict_adds_task_count():


### PR DESCRIPTION
## Summary

Split out from #1064. Adds the **`datasets fs` file-access subcommand**.

> **Depends on #1105.** Currently based on the `perf/datasets-oss-pagination` branch so the diff shows only the `fs` increment. Once #1105 is merged, this PR's base will be retargeted to `master` and it becomes fully independent.

## Changes

- `datasets fs ls/get/download` (alias `files`) to inspect and fetch files inside a single task.
- New registry methods `list_task_files` / `get_task_file` and a `TaskFile` model, supporting both directory-style and single-file task layouts.
- JSON output for all three; relative-path safety via a `TaskPath` value object (rejects absolute paths and `..` traversal).
- `upload` additionally accepts a single task file.

> Note: the CLI OO refactor (TaskPath / OutputWriter / staticmethods, per @StephenRi's review on #1064) now lands in #1105; this PR builds directly on the refactored module, so `datasets fs` is written in the same OO style.

## Testing

```
uv run pytest tests/unit/datasets/ -q
# 102 passed
uv run ruff check rock/cli/command/datasets.py rock/sdk/envhub/datasets/ tests/unit/datasets/
# All checks passed!
```

## Related

Refs #1104
