### PR TITLE
fix(admin): guard FileCleanupTask Step 2 empty-dir delete with -mmin

### DIFF
--- a/rock/admin/scheduler/tasks/file_cleanup_task.py
+++ b/rock/admin/scheduler/tasks/file_cleanup_task.py
@@ -107,7 +107,10 @@ class FileCleanupTask(BaseTask):
             interval_seconds: Execution interval in seconds, default 24 hours
             target_dirs: List of TargetDirConfig, each specifying a directory path
                 and its own exclude_dirs/exclude_files.
-            max_age_mins: Max file age in minutes since last modification, default 7 days (10080 mins)
+            max_age_mins: Max file age in minutes since last modification, default 7 days (10080 mins).
+                Also used as the minimum age guard for empty-directory deletion in Step 2,
+                so a freshly-mkdir'd sandbox dir that has not yet flushed its first log
+                file is not race-deleted out from under a live sandbox.
             max_file_size: Max file size threshold (e.g. "500M", "1G"), files exceeding this will be removed
 
         Raises:
@@ -262,7 +265,19 @@ class FileCleanupTask(BaseTask):
         Steps:
             1. Delete files (with exclusions) older than max_age_mins OR
                exceeding max_file_size.
-            2. Remove empty directories left behind (with exclusions).
+            2. Remove empty directories left behind (with exclusions),
+               guarded by ``-mmin +max_age_mins``.
+
+        Why Step 2 needs the same age guard as Step 1:
+            ``find -depth -type d -empty -delete`` with no age check will race
+            against any sandbox that has just done ``mkdir -p`` for its log
+            directory but not yet flushed its first log file. The directory is
+            transiently empty for a few seconds-to-minutes; if cleanup fires in
+            that window, the live sandbox's log path disappears and subsequent
+            writes fail. Reusing ``max_age_mins`` here means a directory must be
+            both empty AND not modified within the same retention window we
+            apply to files — same threshold, same intent ("nothing recent
+            lives here"), no extra knob to misconfigure.
 
         Args:
             dir_config: The target directory configuration with its exclusions
@@ -281,7 +296,8 @@ class FileCleanupTask(BaseTask):
         dir_exclude_expr = " ".join(dir_exclude_not_parts) + " " if dir_exclude_not_parts else ""
 
         # Step 1: Delete files (with exclusions) older than max_age_mins OR exceeding max_file_size
-        # Step 2: Remove empty directories (bottom-up with -depth, excluding configured dirs)
+        # Step 2: Remove empty directories (bottom-up with -depth, excluding configured dirs),
+        #         only if the directory itself has not been modified within max_age_mins.
         command = (
             f'if [ -d "{target_dir}" ]; then '
             f'find "{target_dir}" {exclude_expr}'
@@ -289,7 +305,7 @@ class FileCleanupTask(BaseTask):
             f"\\( -mmin +{self.max_age_mins} -o {size_find_expr} \\) "
             f"-delete; "
             f'find "{target_dir}" -depth {dir_exclude_expr}'
-            f"-type d -empty -delete; "
+            f"-type d -empty -mmin +{self.max_age_mins} -delete; "
             f'echo "cleanup_done"; '
             f'else echo "dir_not_found"; fi'
         )

--- a/tests/unit/admin/scheduler/test_file_cleanup_task.py
+++ b/tests/unit/admin/scheduler/test_file_cleanup_task.py
@@ -129,7 +129,10 @@ class TestBuildCleanupCommand:
     def test_command_uses_delete_for_empty_dirs(self):
         task = self._new_task()
         cmd = task._build_cleanup_command(TargetDirConfig(path="/data/cache"))
-        assert "-type d -empty -delete" in cmd
+        # Step 2 reuses self.max_age_mins (default 10080) as its -mmin guard so
+        # transiently-empty sandbox dirs that have not yet flushed their first
+        # log are never race-deleted. The trailing `-delete;` token must remain.
+        assert "-type d -empty -mmin +10080 -delete;" in cmd
         assert "-exec rmdir" not in cmd
 
     def test_command_includes_target_dir_existence_check(self):
@@ -205,7 +208,7 @@ class TestBuildCleanupCommand:
         task = self._new_task(target_dirs=[dir_cfg])
         cmd = task._build_cleanup_command(dir_cfg)
         parts = cmd.split(";")
-        empty_dir_find = [p for p in parts if "-type d -empty -delete" in p][0]
+        empty_dir_find = [p for p in parts if "-type d -empty" in p][0]
         assert '-not -path "*/docker"' in empty_dir_find
         assert '-not -path "*/docker/*"' in empty_dir_find
 
@@ -214,7 +217,7 @@ class TestBuildCleanupCommand:
         task = self._new_task(target_dirs=[dir_cfg])
         cmd = task._build_cleanup_command(dir_cfg)
         parts = cmd.split(";")
-        empty_dir_find = [p for p in parts if "-type d -empty -delete" in p][0]
+        empty_dir_find = [p for p in parts if "-type d -empty" in p][0]
         assert '-not -path "/data/logs/special"' in empty_dir_find
         assert '-not -path "/data/logs/special/*"' in empty_dir_find
 
@@ -223,9 +226,78 @@ class TestBuildCleanupCommand:
         task = self._new_task(target_dirs=[dir_cfg])
         cmd = task._build_cleanup_command(dir_cfg)
         parts = cmd.split(";")
-        empty_dir_find = [p for p in parts if "-type d -empty -delete" in p][0]
+        empty_dir_find = [p for p in parts if "-type d -empty" in p][0]
         assert '-not -path "/data/logs/sub/dir"' in empty_dir_find
         assert '-not -path "/data/logs/sub/dir/*"' in empty_dir_find
+
+    # ----------------------------------------------------------------------- #
+    # Regression: empty-dir deletion in Step 2 must inherit max_age_mins.
+    #
+    # Pre-fix bug: ``find -depth -type d -empty -delete`` had no age guard, so
+    # a sandbox dir that had just been mkdir'd but had not yet flushed its first
+    # log file (i.e. transiently empty for a few seconds–minutes) would be
+    # deleted out from under the live sandbox by the next hourly cleanup run.
+    # The fix wires self.max_age_mins into Step 2's -mmin so an empty dir must
+    # also be unmodified within the retention window before it can be removed.
+    # ----------------------------------------------------------------------- #
+
+    def test_step2_includes_mmin_guard_default(self):
+        task = self._new_task()  # default max_age_mins=10080
+        cmd = task._build_cleanup_command(TargetDirConfig(path="/data/cache"))
+        parts = cmd.split(";")
+        empty_dir_find = [p for p in parts if "-type d -empty" in p][0]
+        assert "-mmin +10080" in empty_dir_find
+        # Both -empty and -mmin must precede -delete; -delete is the terminal
+        # action and must not appear before either predicate.
+        empty_idx = empty_dir_find.index("-empty")
+        mmin_idx = empty_dir_find.index("-mmin")
+        delete_idx = empty_dir_find.index("-delete")
+        assert empty_idx < delete_idx
+        assert mmin_idx < delete_idx
+
+    def test_step2_mmin_matches_custom_max_age_mins(self):
+        # Custom retention window must propagate from Step 1 into Step 2 so
+        # operators tuning max_age_mins do not need a second knob to keep the
+        # two find passes consistent.
+        task = self._new_task(max_age_mins=4320)
+        cmd = task._build_cleanup_command(TargetDirConfig(path="/data/cache"))
+        parts = cmd.split(";")
+        empty_dir_find = [p for p in parts if "-type d -empty" in p][0]
+        assert "-mmin +4320" in empty_dir_find
+
+    def test_step2_mmin_present_with_excludes(self):
+        # The -mmin guard must remain present even when -not -path expressions
+        # are interleaved into the empty-dir find invocation.
+        dir_cfg = TargetDirConfig(
+            path="/data/logs",
+            exclude_dirs=["docker"],
+            exclude_files=["docuum.log"],
+        )
+        task = self._new_task(target_dirs=[dir_cfg], max_age_mins=1440)
+        cmd = task._build_cleanup_command(dir_cfg)
+        parts = cmd.split(";")
+        empty_dir_find = [p for p in parts if "-type d -empty" in p][0]
+        assert "-mmin +1440" in empty_dir_find
+        assert '-not -path "*/docker"' in empty_dir_find
+        assert '-not -path "*/docker/*"' in empty_dir_find
+
+    def test_step2_no_unguarded_empty_delete_anywhere(self):
+        # Hard regression guard: the bare token `-empty -delete` (no -mmin
+        # between them) must never appear in any generated command. If a future
+        # refactor accidentally drops the guard, this assertion will fire
+        # before the change reaches production.
+        for max_age in (60, 1440, 10080, 43200):
+            for cfg in (
+                TargetDirConfig(path="/data/cache"),
+                TargetDirConfig(path="/data/logs", exclude_dirs=["docker"]),
+                TargetDirConfig(path="/data/logs", exclude_files=["rocklet.log"]),
+            ):
+                task = self._new_task(target_dirs=[cfg], max_age_mins=max_age)
+                cmd = task._build_cleanup_command(cfg)
+                assert "-empty -delete" not in cmd, (
+                    f"unguarded empty-dir delete leaked into command for "
+                    f"max_age_mins={max_age}, dir_cfg={cfg}: {cmd}"
+                )
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Guard `FileCleanupTask._build_cleanup_command` Step 2 (empty-directory deletion) with `-mmin +max_age_mins`, eliminating a race that lets the hourly cleanup task delete live sandbox log directories that are transiently empty between `mkdir -p` and the first log flush. Reuses the existing `max_age_mins` knob — no new parameter, no YAML migration.

## What changed

`rock/admin/scheduler/tasks/file_cleanup_task.py` — one line of generated shell, now reading:

```bash
find "$target_dir" -depth $dir_exclude_expr -type d -empty -mmin +{max_age_mins} -delete
```

Plus an updated docstring on `_build_cleanup_command` explaining why Step 2 needs the same age guard as Step 1, and why we deliberately reuse `max_age_mins` instead of introducing a new knob.

## What did NOT change

- `__init__` signature — no new constructor arg.
- `from_config` — no new YAML field, no schema bump, no deployment migration.
- `target_dirs` semantics, `exclude_dirs` / `exclude_files` semantics, `max_file_size`, `interval_seconds`.
- Step 1 file-delete behavior, `-not -path` exclusion shape, `-prune`-avoidance comment.
- Any other scheduler task.

## Why reuse `max_age_mins` instead of a new knob

A directory cleanup task has one mental model: "delete entries that have been quiescent for at least `max_age_mins`". Files and directories are both "entries"; splitting them into two retention windows would invite drift (operators tune one and forget the other) without any operational benefit — there is no realistic scenario in which you want to keep stale files for 7 days but reap empty directories after 10 minutes. The single-knob fix matches the user's mental model and the existing config schema.

## Tests

`tests/unit/admin/scheduler/test_file_cleanup_task.py` — updated 1 existing assertion and added 4 regression tests:

| Test | Asserts |
|------|---------|
| `test_command_uses_delete_for_empty_dirs` (updated) | Default command now emits `-type d -empty -mmin +10080 -delete;` |
| `test_step2_includes_mmin_guard_default` (new) | Default `max_age_mins=10080` propagates into Step 2; `-empty` and `-mmin` both precede `-delete` |
| `test_step2_mmin_matches_custom_max_age_mins` (new) | Custom `max_age_mins=4320` produces `-mmin +4320` in Step 2 |
| `test_step2_mmin_present_with_excludes` (new) | Guard remains present when `-not -path` exclusions are interleaved (`exclude_dirs` + `exclude_files`) |
| `test_step2_no_unguarded_empty_delete_anywhere` (new) | **Hard regression guard.** Across a 4 × 3 matrix of `max_age_mins` (60 / 1440 / 10080 / 43200) × dir configs (plain / `exclude_dirs` / `exclude_files`), the bare token `-empty -delete` (no `-mmin` between them) **must never** appear in any generated command. Future refactors that drop the guard will fail CI before merging. |

```
tests/unit/admin/scheduler/test_file_cleanup_task.py ........................ [42 passed in 0.50s]
```

## Behavior delta

| Scenario | Before | After |
|----------|--------|-------|
| Sandbox just `mkdir`'d, no log file yet | ❌ Deleted on next run | ✅ Kept until dir mtime exceeds `max_age_mins` |
| Long-idle truly stale empty dir (mtime old) | ✅ Deleted | ✅ Deleted (mtime past threshold) |
| Excluded dir (e.g. `docker`) | ✅ Skipped | ✅ Skipped (unchanged) |
| Step 1 file deletion | unchanged | unchanged |

## Backward compatibility

Fully backward compatible:
- No config-format changes — existing YAML files keep working as-is.
- No public API changes — `__init__` and `from_config` signatures are unchanged.
- Behavior change is strictly safer: dirs that *would have been* deleted by the buggy version are now retained until they meet the same age criterion as files. No directory deletion is added that did not happen before.

The only externally observable difference is that empty directories younger than `max_age_mins` will no longer be removed on a given run. This is the desired outcome.

## Risk

Low. The change is:
- one shell-token addition (`-mmin +{N}`) inserted between two existing tokens of an already-tested `find` invocation,
- gated by an existing, already-validated config field,
- covered by both updated and net-new regression tests,
- guarded by a "hard wall" matrix test that fails the build if the change is ever undone.

## Test plan

- [x] `pytest tests/unit/admin/scheduler/test_file_cleanup_task.py -v` → 42 passed
- [ ] Manual sanity run on a worker: trigger `FileCleanupTask` with a freshly-created empty dir, confirm dir survives; touch a file in another empty dir, age it past `max_age_mins`, confirm it gets cleaned.
- [ ] Spot-check on staging (`vpc-nt-a` is the cluster where the bug was originally observed): verify hourly cleanup no longer races sandbox startup.

Fixes #1107 