### PR TITLE
feat(admin): add GET /server/config endpoint (#1109)

### DIFF
--- a/rock-conf/rock-local.yml
+++ b/rock-conf/rock-local.yml
@@ -34,6 +34,14 @@ warmup:
 #     - "reg-a.aliyuncs.com/mirror-1"
 #     - "reg-b.aliyuncs.com/mirror-2"
 
+# Server public configuration (exposed via GET /server/config)
+server:
+  image_registries: []
+  #  - namespace: "rock"
+  #    registry_url: ""
+  #    region: "cn-hangzhou"
+  builder_image: ""
+
 # Scheduler configuration
 scheduler:
   enabled: true                    # Whether to enable the scheduler

--- a/rock/admin/entrypoints/sandbox_proxy_api.py
+++ b/rock/admin/entrypoints/sandbox_proxy_api.py
@@ -320,6 +320,14 @@ async def portforward(websocket: WebSocket, id: str, port: int):
         await websocket.close(code=1011, reason=f"Proxy error: {str(e)}")
 
 
+@sandbox_proxy_router.get("/server-config")
+@handle_exceptions(error_message="get server config failed")
+async def get_server_config():
+    """Return server public configuration."""
+    result = sandbox_proxy_service.get_server_config()
+    return RockResponse(result=result)
+
+
 @sandbox_proxy_router.get("/get_token")
 @handle_exceptions(error_message="get oss sts token failed")
 async def get_token(account: str = "legacy"):

--- a/rock/config.py
+++ b/rock/config.py
@@ -153,6 +153,25 @@ class OssConfig:
 
 
 @dataclass
+class ImageRegistryConfig:
+    namespace: str = "rock"
+    registry_url: str | None = None
+    region: str | None = None
+
+
+@dataclass
+class ServerConfig:
+    image_registries: list[ImageRegistryConfig] = field(default_factory=list)
+    builder_image: str = ""
+
+    def __post_init__(self):
+        self.image_registries = [
+            ImageRegistryConfig(**item) if isinstance(item, dict) else item
+            for item in self.image_registries
+        ]
+
+
+@dataclass
 class ProxyServiceConfig:
     timeout: float = 180.0
     max_connections: int = 500
@@ -348,6 +367,7 @@ class RockConfig:
     redis: RedisConfig = field(default_factory=RedisConfig)
     sandbox_config: SandboxConfig = field(default_factory=SandboxConfig)
     oss: OssConfig = field(default_factory=OssConfig)
+    server: ServerConfig = field(default_factory=ServerConfig)
     runtime: RuntimeConfig = field(default_factory=RuntimeConfig)
     proxy_service: ProxyServiceConfig = field(default_factory=ProxyServiceConfig)
     scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
@@ -401,6 +421,8 @@ class RockConfig:
             kwargs["sandbox_config"] = SandboxConfig(**config["sandbox_config"])
         if "oss" in config:
             kwargs["oss"] = OssConfig(**config["oss"])
+        if "server" in config:
+            kwargs["server"] = ServerConfig(**config["server"])
         if "runtime" in config:
             kwargs["runtime"] = RuntimeConfig(**config["runtime"])
         if "proxy_service" in config:

--- a/rock/sandbox/service/sandbox_proxy_service.py
+++ b/rock/sandbox/service/sandbox_proxy_service.py
@@ -34,7 +34,7 @@ from rock.admin.proto.request import SandboxQueryParams
 from rock.admin.proto.request import SandboxReadFileRequest as ReadFileRequest
 from rock.admin.proto.request import SandboxWriteFileRequest as WriteFileRequest
 from rock.admin.proto.response import SandboxListResponse, SandboxListStatusResponse, SandboxStatusResponse
-from rock.config import OssConfig, ProxyServiceConfig, RockConfig
+from rock.config import OssConfig, ProxyServiceConfig, RockConfig, ServerConfig
 from rock.deployments.constants import Port
 from rock.deployments.status import ServiceStatus
 from rock.common.port_validation import validate_port_forward_port
@@ -90,6 +90,8 @@ class SandboxProxyService:
                 self.oss_config.primary.access_key_secret,
                 primary_region,
             )
+
+        self.server_config: ServerConfig = rock_config.server
 
         self._batch_get_status_max_count = rock_config.proxy_service.batch_get_status_max_count
         self._validate_oss_config_or_warn()
@@ -744,6 +746,20 @@ class SandboxProxyService:
             "Bucket": bucket,
             "Region": region,
             "Prefix": prefix,  # transfer-object key prefix, scoped per account
+        }
+
+    def get_server_config(self) -> dict:
+        """Return server public configuration."""
+        return {
+            "ImageRegistries": [
+                {
+                    "Namespace": r.namespace,
+                    "RegistryUrl": r.registry_url,
+                    "Region": r.region,
+                }
+                for r in self.server_config.image_registries
+            ],
+            "BuilderImage": self.server_config.builder_image,
         }
 
     async def get_sandbox_websocket_url(

--- a/tests/unit/sandbox/test_sandbox_proxy.py
+++ b/tests/unit/sandbox/test_sandbox_proxy.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from rock.actions.sandbox.response import State
-from rock.config import OssConfig
+from rock.config import ImageRegistryConfig, OssConfig, ServerConfig
 from rock.deployments.config import DockerDeploymentConfig
 from rock.sandbox.sandbox_manager import SandboxManager
 from rock.sandbox.service.sandbox_proxy_service import SandboxProxyService
@@ -208,3 +208,36 @@ class TestGenOssStsToken:
         assert result["Endpoint"] == "yaml.endpoint"  # YAML fallback
         assert result["Bucket"] == "yaml-bucket"
         assert result["Region"] == "rg"  # env
+
+
+class TestGetServerConfig:
+    @pytest.fixture
+    def proxy_service(self):
+        service = SandboxProxyService.__new__(SandboxProxyService)
+        service.server_config = ServerConfig(
+            image_registries=[
+                ImageRegistryConfig(namespace="ns-1", registry_url="reg1.example.com", region="cn-hangzhou"),
+                ImageRegistryConfig(namespace="ns-2", registry_url="reg2.example.com", region="ap-southeast-1"),
+            ],
+            builder_image="builder:latest",
+        )
+        return service
+
+    def test_returns_public_config(self, proxy_service):
+        result = proxy_service.get_server_config()
+
+        assert len(result["ImageRegistries"]) == 2
+        assert result["ImageRegistries"][0]["Namespace"] == "ns-1"
+        assert result["ImageRegistries"][0]["RegistryUrl"] == "reg1.example.com"
+        assert result["ImageRegistries"][1]["Namespace"] == "ns-2"
+        assert result["ImageRegistries"][1]["Region"] == "ap-southeast-1"
+        assert result["BuilderImage"] == "builder:latest"
+
+    def test_empty_registries(self):
+        service = SandboxProxyService.__new__(SandboxProxyService)
+        service.server_config = ServerConfig()
+
+        result = service.get_server_config()
+
+        assert result["ImageRegistries"] == []
+        assert result["BuilderImage"] == ""


### PR DESCRIPTION
## Summary

- Add `ImageRegistryConfig` and `ServerConfig` dataclasses for platform public config
- Add `GET /server/config` endpoint on proxy role, returning image registries and builder image
- Add `server` section in `rock-local.yml` with `image_registries` list and `builder_image`

fixes #1109

## Test plan

- [x] Unit tests added (`TestGetServerConfig` — multiple registries + empty case)
- [x] `uv run ruff check` passes
- [x] `uv run pytest tests/unit/sandbox/test_sandbox_proxy.py` passes