### PR TITLE
feat(deployments): add XFS project quota fallback for containerd image store (#1123)

### DIFF
--- a/rock/deployments/docker.py
+++ b/rock/deployments/docker.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime
+import hashlib
 import json
 import os
 import random
@@ -46,6 +47,9 @@ from rock.utils import (
 __all__ = ["DockerDeployment", "DockerDeploymentConfig"]
 CHECK_CLEAR_INTERVAL_SECONDS = 300
 
+XFS_PRJID_MIN = 1 << 31
+XFS_PRJID_RANGE = (1 << 32) - XFS_PRJID_MIN
+
 
 logger = init_logger(__name__)
 
@@ -65,6 +69,9 @@ class DockerDeployment(AbstractDeployment):
         if registry_password:
             self._config.registry_password = registry_password
         self._effective_disk_limit_rootfs: str | None = self._config.disk_limit_rootfs
+        self._rootfs_xfs_prjid: int | None = None
+        self._rootfs_xfs_mountpoint: str | None = None
+        self._rootfs_upper_dir: str | None = None
         self._runtime: RemoteSandboxRuntime | None = None
         self._container_process = None
         self._runtime_timeout = 0.15
@@ -428,10 +435,13 @@ class DockerDeployment(AbstractDeployment):
         limit would clobber it. Cleanup is also docker's responsibility:
         `docker rm` resets the prjid's limit when the upper dir is torn down.
         """
-        if self._effective_disk_limit_rootfs is None:
+        if self._rootfs_xfs_prjid is not None and self._rootfs_upper_dir is not None:
+            project_id, upper_dir = self._rootfs_xfs_prjid, self._rootfs_upper_dir
+        elif self._effective_disk_limit_rootfs is not None:
+            project_id, upper_dir = self._get_docker_rootfs_prjid_and_upper_dir()
+        else:
             return
 
-        project_id, upper_dir = self._get_docker_rootfs_prjid_and_upper_dir()
         logger.info(f"setup_log_dir_quota_shared: log={log_file_path!r}, prjid={project_id}, upper_dir={upper_dir!r}")
         if project_id is None or upper_dir is None:
             logger.info(f"docker rootfs prjid unavailable for {log_file_path!r}; cannot share, fall back")
@@ -457,7 +467,7 @@ class DockerDeployment(AbstractDeployment):
             )
             if findmnt_result.returncode != 0 or not findmnt_result.stdout.strip():
                 logger.warning(
-                    f"findmnt failed for upper_dir {upper_dir!r}: " f"{findmnt_result.stderr.strip() or 'empty output'}"
+                    f"findmnt failed for upper_dir {upper_dir!r}: {findmnt_result.stderr.strip() or 'empty output'}"
                 )
                 return
             xfs_mountpoint = findmnt_result.stdout.strip()
@@ -483,6 +493,154 @@ class DockerDeployment(AbstractDeployment):
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as e:
             logger.warning(f"Failed to share rootfs prjid with log dir {log_file_path!r}: {e}")
 
+    def _get_container_upper_dir(self) -> str | None:
+        """Return the overlay UpperDir for the container.
+
+        Strategy 1 — ``docker inspect`` (overlay2, available after create):
+        Strategy 2 — ``/proc/mounts`` (containerd image store, available after start):
+        Returns None if both fail.
+        """
+        # Strategy 1: docker inspect
+        try:
+            result = subprocess.run(
+                ["docker", "inspect", "--format={{.GraphDriver.Data.UpperDir}}", self._container_name],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            upper = result.stdout.strip()
+            if result.returncode == 0 and upper and upper != "<no value>":
+                return upper
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
+            pass
+
+        # Strategy 2: /proc/mounts — overlay mounts whose target path contains the container id
+        try:
+            container_id_result = subprocess.run(
+                ["docker", "inspect", "--format={{.Id}}", self._container_name],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if container_id_result.returncode != 0 or not container_id_result.stdout.strip():
+                return None
+            container_id = container_id_result.stdout.strip()
+
+            with open("/proc/mounts") as f:
+                for line in f:
+                    parts = line.split()
+                    if len(parts) < 4:
+                        continue
+                    fstype, mount_target, options = parts[2], parts[1], parts[3]
+                    if fstype != "overlay" or container_id not in mount_target:
+                        continue
+                    for opt in options.split(","):
+                        if opt.startswith("upperdir="):
+                            return opt[len("upperdir=") :]
+        except OSError:
+            pass
+        return None
+
+    def _setup_rootfs_quota_xfs(self) -> None:
+        """Set XFS project quota on the container's UpperDir as a fallback.
+
+        Called after ``docker start`` when ``--storage-opt`` is not supported
+        but the user configured ``disk_limit_rootfs``.  Best-effort: any
+        failure logs a warning and silently skips quota setup.
+        """
+        upper_dir = self._get_container_upper_dir()
+        if not upper_dir:
+            logger.warning(f"[{self._container_name}] cannot find container UpperDir, skipping XFS quota fallback")
+            return
+
+        if not DockerUtil.is_xfs_prjquota_path(upper_dir):
+            logger.info(f"[{self._container_name}] UpperDir {upper_dir!r} not on xfs+prjquota, skipping XFS quota")
+            return
+
+        try:
+            prjid = (
+                int(hashlib.sha1(self._container_name.encode()).hexdigest()[:8], 16) % XFS_PRJID_RANGE
+            ) + XFS_PRJID_MIN
+
+            findmnt_result = subprocess.run(
+                ["findmnt", "-T", upper_dir, "-o", "TARGET", "--noheadings"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if findmnt_result.returncode != 0 or not findmnt_result.stdout.strip():
+                logger.warning(f"[{self._container_name}] findmnt failed for {upper_dir!r}, skipping XFS quota")
+                return
+            mountpoint = findmnt_result.stdout.strip()
+
+            set_project_cmd = f"project -s -p {shlex.quote(upper_dir)} {prjid}"
+            result = subprocess.run(
+                ["xfs_quota", "-x", "-c", set_project_cmd, mountpoint],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode != 0:
+                logger.warning(
+                    f"[{self._container_name}] xfs_quota project -s failed: "
+                    f"{result.stderr.strip() or result.stdout.strip()}"
+                )
+                return
+
+            limit_cmd = f"limit -p bhard={self._config.disk_limit_rootfs} {prjid}"
+            result = subprocess.run(
+                ["xfs_quota", "-x", "-c", limit_cmd, mountpoint],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode != 0:
+                logger.warning(
+                    f"[{self._container_name}] xfs_quota limit failed: {result.stderr.strip() or result.stdout.strip()}"
+                )
+                return
+
+            self._rootfs_xfs_prjid = prjid
+            self._rootfs_xfs_mountpoint = mountpoint
+            self._rootfs_upper_dir = upper_dir
+            logger.info(
+                f"[{self._container_name}] XFS quota fallback: prjid={prjid}, "
+                f"bhard={self._config.disk_limit_rootfs}, upper_dir={upper_dir!r}"
+            )
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as e:
+            logger.warning(f"[{self._container_name}] XFS quota fallback failed: {e}")
+
+    def _cleanup_rootfs_xfs_quota(self) -> None:
+        """Remove XFS project quota set by ``_setup_rootfs_quota_xfs``."""
+        if self._rootfs_xfs_prjid is None or self._rootfs_xfs_mountpoint is None:
+            return
+        prjid = self._rootfs_xfs_prjid
+        mountpoint = self._rootfs_xfs_mountpoint
+
+        def _run_xfs_quota(cmd: str) -> None:
+            try:
+                subprocess.run(
+                    ["xfs_quota", "-x", "-c", cmd, mountpoint],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as e:
+                logger.warning(f"[{self._container_name}] xfs_quota cleanup ({cmd!r}) failed: {e}")
+
+        _run_xfs_quota(f"limit -p bhard=0 bsoft=0 {prjid}")
+
+        if self._rootfs_upper_dir:
+            _run_xfs_quota(f"project -C -p {shlex.quote(self._rootfs_upper_dir)} {prjid}")
+
+        if self._container_name and env_vars.ROCK_LOGGING_PATH:
+            log_dir = f"{env_vars.ROCK_LOGGING_PATH}/{self._container_name}"
+            _run_xfs_quota(f"project -C -p {shlex.quote(log_dir)} {prjid}")
+
+        self._rootfs_xfs_prjid = None
+        self._rootfs_xfs_mountpoint = None
+        self._rootfs_upper_dir = None
+
     async def start(self):
         """Starts the runtime."""
         with StageTimer("startup_timing", f"[{self._container_name}] Check availability", logger):
@@ -490,11 +648,11 @@ class DockerDeployment(AbstractDeployment):
                 raise Exception("Docker is not available")
 
         storage_opt_supported = DockerUtil.detect_storage_opt_support()
-        # Resolve effective rootfs quota: downgrade to None if storage-opt is not supported.
         if self._config.disk_limit_rootfs is not None and not storage_opt_supported:
             logger.warning(
-                f"[{self.config.container_name}] --storage-opt not supported on this worker "
-                f"(requires overlay2 + xfs + prjquota), ignoring disk_limit_rootfs={self._config.disk_limit_rootfs}"
+                f"[{self.config.container_name}] disk_limit_rootfs not supported on this worker "
+                f"(requires overlay2 or containerd snapshotter on xfs+prjquota), "
+                f"ignoring disk_limit_rootfs={self._config.disk_limit_rootfs}"
             )
             self._effective_disk_limit_rootfs = None
         else:
@@ -583,12 +741,21 @@ class DockerDeployment(AbstractDeployment):
             # fails before _wait_until_alive sets _container_process up for _stop to manage, we own the
             # orphan and must remove it. _wait_until_alive's own failure path already calls self.stop().
             try:
-                # Bind log dir to the docker-allocated rootfs prjid in the create→start gap,
-                # before any container process can write. The bhard is set by `--storage-opt
-                # size=` on the rootfs prjid, so log and rootfs share one quota.
-                if log_file_path is not None:
+                is_containerd = DockerUtil.detect_containerd_image_store()
+
+                # [overlay2] Bind log dir to the docker-allocated rootfs prjid in the
+                # create→start gap (prjid exists after docker create).
+                if log_file_path is not None and not is_containerd:
                     self._setup_log_dir_quota_shared(log_file_path)
+
                 self._container_process = await loop.run_in_executor(executor, self._docker_start)
+
+                # [containerd fallback] --storage-opt is silently ignored by containerd,
+                # apply XFS project quota on the container's UpperDir instead.
+                if self._config.disk_limit_rootfs is not None and is_containerd:
+                    self._setup_rootfs_quota_xfs()
+                    if log_file_path is not None:
+                        self._setup_log_dir_quota_shared(log_file_path)
             except Exception:
                 DockerUtil.remove_container_force(self._container_name)
                 raise
@@ -823,6 +990,7 @@ class DockerDeployment(AbstractDeployment):
                 logger.warning(f"Failed to kill container {self._container_name} with SIGKILL")
 
             self._container_process = None
+            self._cleanup_rootfs_xfs_quota()
             self._cleanup_kata_disk()
             self._container_name = None
 

--- a/rock/utils/docker.py
+++ b/rock/utils/docker.py
@@ -111,12 +111,7 @@ class DockerUtil:
             return True
 
         # Path 2: containerd image store — XFS quota fallback
-        is_containerd = False
-        for entry in info.get("DriverStatus") or []:
-            if isinstance(entry, list) and len(entry) == 2 and entry[0] == "driver-type":
-                is_containerd = entry[1] == "io.containerd.snapshotter.v1"
-                break
-        if is_containerd:
+        if cls.detect_containerd_image_store(info):
             if not cls.is_xfs_prjquota_path(docker_root):
                 return False
             logger.info(
@@ -129,7 +124,7 @@ class DockerUtil:
         return False
 
     @classmethod
-    def detect_containerd_image_store(cls) -> bool:
+    def detect_containerd_image_store(cls, info: dict | None = None) -> bool:
         """Return True when Docker is using the containerd image store (snapshotter).
 
         Detection is based on the ``driver-type`` entry inside ``DriverStatus``
@@ -137,7 +132,8 @@ class DockerUtil:
         driver-type is ``io.containerd.snapshotter.v1`` regardless of which
         snapshotter (overlayfs, native, btrfs …) is active.
         """
-        info = cls.get_docker_info()
+        if info is None:
+            info = cls.get_docker_info()
         if info is None:
             return False
         for entry in info.get("DriverStatus") or []:

--- a/rock/utils/docker.py
+++ b/rock/utils/docker.py
@@ -82,36 +82,68 @@ class DockerUtil:
 
     @classmethod
     def detect_storage_opt_support(cls) -> bool:
-        """Detect whether --storage-opt size= is supported in this environment.
+        """Detect whether rootfs disk-limit can be enforced in this environment.
 
-        Requirements:
-        - Docker storage driver is overlay2
-        - Docker root directory is on an XFS mount with prjquota/pquota enabled
-          (checked via is_xfs_prjquota_path)
+        Supported configurations:
+        1. overlay2 storage driver + XFS with prjquota  (native ``--storage-opt size=``)
+        2. containerd image store (snapshotter) + XFS with prjquota  (XFS quota fallback;
+           ``--storage-opt`` is silently ignored by containerd, quota is applied manually)
 
         Returns:
-            True if --storage-opt size= can be used, False otherwise.
+            True if rootfs disk-limit can be enforced, False otherwise.
         """
         info = cls.get_docker_info()
         if info is None:
             return False
 
-        # Check 1: Driver must be overlay2
-        if info.get("Driver") != "overlay2":
-            logger.info(f"detect_storage_opt_support: storage driver is {info.get('Driver')!r}, not overlay2")
-            return False
-
-        # Check 2: DockerRootDir must be on XFS with prjquota/pquota
         docker_root = info.get("DockerRootDir")
         if not docker_root:
             logger.warning("detect_storage_opt_support: DockerRootDir not found in docker info")
             return False
 
-        if not cls.is_xfs_prjquota_path(docker_root):
-            return False
+        driver = info.get("Driver", "")
 
-        logger.info(f"detect_storage_opt_support: supported — overlay2, {docker_root!r} is xfs+prjquota")
-        return True
+        # Path 1: overlay2 — native --storage-opt size=
+        if driver == "overlay2":
+            if not cls.is_xfs_prjquota_path(docker_root):
+                return False
+            logger.info(f"detect_storage_opt_support: supported — overlay2, {docker_root!r} is xfs+prjquota")
+            return True
+
+        # Path 2: containerd image store — XFS quota fallback
+        is_containerd = False
+        for entry in info.get("DriverStatus") or []:
+            if isinstance(entry, list) and len(entry) == 2 and entry[0] == "driver-type":
+                is_containerd = entry[1] == "io.containerd.snapshotter.v1"
+                break
+        if is_containerd:
+            if not cls.is_xfs_prjquota_path(docker_root):
+                return False
+            logger.info(
+                f"detect_storage_opt_support: supported — containerd image store, "
+                f"{docker_root!r} is xfs+prjquota (will use XFS quota fallback)"
+            )
+            return True
+
+        logger.info(f"detect_storage_opt_support: storage driver is {driver!r}, not overlay2 or containerd snapshotter")
+        return False
+
+    @classmethod
+    def detect_containerd_image_store(cls) -> bool:
+        """Return True when Docker is using the containerd image store (snapshotter).
+
+        Detection is based on the ``driver-type`` entry inside ``DriverStatus``
+        from ``docker info``.  When the containerd image store is enabled the
+        driver-type is ``io.containerd.snapshotter.v1`` regardless of which
+        snapshotter (overlayfs, native, btrfs …) is active.
+        """
+        info = cls.get_docker_info()
+        if info is None:
+            return False
+        for entry in info.get("DriverStatus") or []:
+            if isinstance(entry, list) and len(entry) == 2 and entry[0] == "driver-type":
+                return entry[1] == "io.containerd.snapshotter.v1"
+        return False
 
     @classmethod
     def is_docker_available(cls):

--- a/tests/unit/deployments/test_docker_deployment_disk_limit.py
+++ b/tests/unit/deployments/test_docker_deployment_disk_limit.py
@@ -5,14 +5,16 @@ Tests cover:
 - DockerDeploymentConfig default and custom disk_limit_rootfs values
 - DockerDeployment._storage_opts() argument generation
 - DockerDeployment.start() graceful degradation when storage-opt is unsupported
+- XFS project quota fallback for containerd image store
 """
 
+import subprocess
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from rock.deployments.config import DockerDeploymentConfig
-from rock.deployments.docker import DockerDeployment
+from rock.deployments.docker import XFS_PRJID_MIN, XFS_PRJID_RANGE, DockerDeployment
 
 # ---- DockerDeploymentConfig tests ----
 
@@ -148,3 +150,171 @@ class TestDockerDeploymentStartDiskLimit:
 
         assert deployment.config.disk_limit_rootfs is None
         assert deployment.effective_disk_limit_rootfs is None
+
+
+# ---- XFS quota fallback tests (containerd image store) ----
+
+
+def _make_subprocess_result(returncode=0, stdout="", stderr=""):
+    r = MagicMock(spec=subprocess.CompletedProcess)
+    r.returncode = returncode
+    r.stdout = stdout
+    r.stderr = stderr
+    return r
+
+
+class TestSetupRootfsQuotaXfs:
+    """Tests for DockerDeployment._setup_rootfs_quota_xfs()."""
+
+    @patch("rock.deployments.docker.DockerSandboxValidator")
+    def _make_deployment(self, _mock_validator, disk_limit="50g"):
+        deployment = DockerDeployment.from_config(DockerDeploymentConfig(disk_limit_rootfs=disk_limit))
+        deployment.set_container_name("test-container-abc")
+        deployment._effective_disk_limit_rootfs = None
+        return deployment
+
+    @patch("rock.deployments.docker.subprocess.run")
+    @patch("rock.deployments.docker.DockerUtil.is_xfs_prjquota_path", return_value=True)
+    def test_rootfs_xfs_fallback_sets_quota(self, _mock_xfs, mock_run):
+        """When UpperDir is on xfs+prjquota, prjid and bhard should be set."""
+        deployment = self._make_deployment()
+
+        mock_run.side_effect = [
+            # docker inspect UpperDir
+            _make_subprocess_result(stdout="/var/lib/docker/overlay2/abc123/diff"),
+            # findmnt for mountpoint
+            _make_subprocess_result(stdout="/data"),
+            # xfs_quota project -s
+            _make_subprocess_result(),
+            # xfs_quota limit
+            _make_subprocess_result(),
+        ]
+
+        deployment._setup_rootfs_quota_xfs()
+
+        assert deployment._rootfs_xfs_prjid is not None
+        assert XFS_PRJID_MIN <= deployment._rootfs_xfs_prjid < XFS_PRJID_MIN + XFS_PRJID_RANGE
+        assert deployment._rootfs_xfs_mountpoint == "/data"
+        assert deployment._rootfs_upper_dir == "/var/lib/docker/overlay2/abc123/diff"
+
+    @patch("rock.deployments.docker.subprocess.run")
+    @patch("rock.deployments.docker.DockerUtil.is_xfs_prjquota_path", return_value=False)
+    def test_rootfs_xfs_fallback_degrades_when_not_xfs(self, _mock_xfs, mock_run):
+        """When UpperDir is not on xfs+prjquota, should degrade gracefully."""
+        deployment = self._make_deployment()
+
+        mock_run.return_value = _make_subprocess_result(stdout="/var/lib/docker/overlay2/abc/diff")
+
+        deployment._setup_rootfs_quota_xfs()
+
+        assert deployment._rootfs_xfs_prjid is None
+        assert deployment._rootfs_xfs_mountpoint is None
+
+    @patch("rock.deployments.docker.subprocess.run")
+    def test_rootfs_xfs_fallback_degrades_when_no_upper_dir(self, mock_run):
+        """When UpperDir cannot be found, should degrade gracefully."""
+        deployment = self._make_deployment()
+
+        # docker inspect returns empty / <no value>
+        mock_run.side_effect = [
+            _make_subprocess_result(stdout="<no value>"),
+            # docker inspect for container id (strategy 2)
+            _make_subprocess_result(returncode=1),
+        ]
+
+        deployment._setup_rootfs_quota_xfs()
+
+        assert deployment._rootfs_xfs_prjid is None
+
+
+class TestCleanupRootfsXfsQuota:
+    """Tests for DockerDeployment._cleanup_rootfs_xfs_quota()."""
+
+    @patch("rock.deployments.docker.DockerSandboxValidator")
+    @patch("rock.deployments.docker.subprocess.run")
+    @patch("rock.deployments.docker.env_vars")
+    def test_cleanup_calls_xfs_quota(self, mock_env, mock_run, _mock_validator):
+        """Stop should invoke xfs_quota to clear limit and unbind project."""
+        mock_env.ROCK_LOGGING_PATH = "/var/log/rock"
+        mock_env.ROCK_WORKER_ENV_TYPE = "docker"
+        mock_env.ROCK_TIME_ZONE = "UTC"
+        mock_run.return_value = _make_subprocess_result()
+
+        deployment = DockerDeployment.from_config(DockerDeploymentConfig(disk_limit_rootfs="50g"))
+        deployment.set_container_name("test-container-xyz")
+        deployment._rootfs_xfs_prjid = 2147483700
+        deployment._rootfs_xfs_mountpoint = "/data"
+        deployment._rootfs_upper_dir = "/data/docker/overlay2/abc/diff"
+
+        deployment._cleanup_rootfs_xfs_quota()
+
+        assert deployment._rootfs_xfs_prjid is None
+        assert deployment._rootfs_xfs_mountpoint is None
+        assert deployment._rootfs_upper_dir is None
+
+        xfs_calls = [c for c in mock_run.call_args_list if c[0][0][0] == "xfs_quota"]
+        assert len(xfs_calls) == 3
+
+    @patch("rock.deployments.docker.DockerSandboxValidator")
+    def test_cleanup_noop_when_no_prjid(self, _mock_validator):
+        """When no XFS quota was set, cleanup should be a no-op."""
+        deployment = DockerDeployment.from_config(DockerDeploymentConfig(disk_limit_rootfs="50g"))
+        deployment.set_container_name("test-noop")
+        assert deployment._rootfs_xfs_prjid is None
+        deployment._cleanup_rootfs_xfs_quota()
+
+
+class TestGetContainerUpperDir:
+    """Tests for DockerDeployment._get_container_upper_dir()."""
+
+    @patch("rock.deployments.docker.DockerSandboxValidator")
+    @patch("rock.deployments.docker.subprocess.run")
+    def test_strategy1_docker_inspect(self, mock_run, _mock_validator):
+        """Should return UpperDir from docker inspect when available."""
+        deployment = DockerDeployment.from_config(DockerDeploymentConfig())
+        deployment.set_container_name("test-c1")
+
+        mock_run.return_value = _make_subprocess_result(stdout="/var/lib/docker/overlay2/abc/diff")
+        result = deployment._get_container_upper_dir()
+
+        assert result == "/var/lib/docker/overlay2/abc/diff"
+
+    @patch("rock.deployments.docker.DockerSandboxValidator")
+    @patch("rock.deployments.docker.subprocess.run")
+    @patch("builtins.open")
+    def test_strategy2_proc_mounts(self, mock_open, mock_run, _mock_validator):
+        """Should fall back to /proc/mounts when docker inspect returns <no value>."""
+        deployment = DockerDeployment.from_config(DockerDeploymentConfig())
+        deployment.set_container_name("test-c2")
+
+        container_id = "abcdef1234567890"
+        mock_run.side_effect = [
+            # docker inspect UpperDir → <no value>
+            _make_subprocess_result(stdout="<no value>"),
+            # docker inspect Id
+            _make_subprocess_result(stdout=container_id),
+        ]
+        mount_line = (
+            f"overlay /run/containerd/io.containerd.runtime.v2/moby/{container_id}/rootfs "
+            f"overlay rw,lowerdir=/x,upperdir=/data/snapshots/{container_id}/fs,workdir=/w 0 0\n"
+        )
+        mock_open.return_value.__enter__ = lambda s: iter([mount_line])
+        mock_open.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = deployment._get_container_upper_dir()
+        assert result == f"/data/snapshots/{container_id}/fs"
+
+    @patch("rock.deployments.docker.DockerSandboxValidator")
+    @patch("rock.deployments.docker.subprocess.run")
+    def test_returns_none_when_both_fail(self, mock_run, _mock_validator):
+        """Should return None when both strategies fail."""
+        deployment = DockerDeployment.from_config(DockerDeploymentConfig())
+        deployment.set_container_name("test-c3")
+
+        mock_run.side_effect = [
+            _make_subprocess_result(stdout="<no value>"),
+            _make_subprocess_result(returncode=1),
+        ]
+
+        result = deployment._get_container_upper_dir()
+        assert result is None

--- a/tests/unit/utils/test_docker_util.py
+++ b/tests/unit/utils/test_docker_util.py
@@ -37,6 +37,18 @@ def _docker_info_json(driver="overlay2", backing_fs="xfs", docker_root="/var/lib
     return json.dumps(info)
 
 
+def _containerd_info_json(docker_root="/var/lib/docker"):
+    """Return a JSON string for containerd image store (snapshotter)."""
+    info = {
+        "Driver": "overlayfs",
+        "DriverStatus": [
+            ["driver-type", "io.containerd.snapshotter.v1"],
+        ],
+        "DockerRootDir": docker_root,
+    }
+    return json.dumps(info)
+
+
 # ---- detect_storage_opt_support tests ----
 
 
@@ -125,6 +137,33 @@ class TestDetectStorageOptSupport:
         mock_run.return_value = _make_run_result(stdout=json.dumps(info))
         assert DockerUtil.detect_storage_opt_support() is False
 
+    @patch("rock.utils.docker.subprocess.run")
+    def test_containerd_image_store_xfs_prjquota(self, mock_run):
+        """Should return True for containerd image store on xfs+prjquota."""
+        mock_run.side_effect = [
+            _make_run_result(stdout=_containerd_info_json()),
+            _make_run_result(stdout="xfs rw,relatime,attr2,inode64,prjquota"),
+        ]
+        assert DockerUtil.detect_storage_opt_support() is True
+
+    @patch("rock.utils.docker.subprocess.run")
+    def test_containerd_image_store_no_prjquota(self, mock_run):
+        """Should return False for containerd image store without prjquota."""
+        mock_run.side_effect = [
+            _make_run_result(stdout=_containerd_info_json()),
+            _make_run_result(stdout="xfs rw,relatime,attr2,inode64,noquota"),
+        ]
+        assert DockerUtil.detect_storage_opt_support() is False
+
+    @patch("rock.utils.docker.subprocess.run")
+    def test_containerd_image_store_non_xfs(self, mock_run):
+        """Should return False for containerd image store on non-XFS."""
+        mock_run.side_effect = [
+            _make_run_result(stdout=_containerd_info_json()),
+            _make_run_result(stdout="ext4 rw,relatime"),
+        ]
+        assert DockerUtil.detect_storage_opt_support() is False
+
 
 # ---- is_xfs_prjquota_path tests ----
 
@@ -179,3 +218,51 @@ class TestIsXfsPrjquotaPath:
         """If findmnt returns only FSTYPE with no OPTIONS column, return False."""
         mock_run.return_value = _make_run_result(stdout="xfs")
         assert DockerUtil.is_xfs_prjquota_path("/data/logs") is False
+
+
+# ---- detect_containerd_image_store tests ----
+
+
+class TestDetectContainerdImageStore:
+    """Tests for DockerUtil.detect_containerd_image_store()."""
+
+    @patch("rock.utils.docker.subprocess.run")
+    def test_containerd_snapshotter_detected(self, mock_run):
+        """Should return True when DriverStatus contains containerd snapshotter driver-type."""
+        info = {
+            "Driver": "overlayfs",
+            "DriverStatus": [["driver-type", "io.containerd.snapshotter.v1"]],
+            "DockerRootDir": "/var/lib/docker",
+        }
+        mock_run.return_value = _make_run_result(stdout=json.dumps(info))
+        assert DockerUtil.detect_containerd_image_store() is True
+
+    @patch("rock.utils.docker.subprocess.run")
+    def test_overlay2_not_containerd(self, mock_run):
+        """Should return False for classic overlay2 (no snapshotter driver-type)."""
+        mock_run.return_value = _make_run_result(stdout=_docker_info_json(driver="overlay2"))
+        assert DockerUtil.detect_containerd_image_store() is False
+
+    @patch("rock.utils.docker.subprocess.run")
+    def test_docker_info_fails(self, mock_run):
+        """Should return False when docker info is unavailable."""
+        mock_run.return_value = _make_run_result(returncode=1, stderr="Cannot connect")
+        assert DockerUtil.detect_containerd_image_store() is False
+
+    @patch("rock.utils.docker.subprocess.run")
+    def test_no_driver_status(self, mock_run):
+        """Should return False when DriverStatus is missing."""
+        info = {"Driver": "overlayfs", "DockerRootDir": "/var/lib/docker"}
+        mock_run.return_value = _make_run_result(stdout=json.dumps(info))
+        assert DockerUtil.detect_containerd_image_store() is False
+
+    @patch("rock.utils.docker.subprocess.run")
+    def test_different_driver_type(self, mock_run):
+        """Should return False when driver-type is not containerd snapshotter."""
+        info = {
+            "Driver": "overlay2",
+            "DriverStatus": [["driver-type", "io.docker.storage.v1"]],
+            "DockerRootDir": "/var/lib/docker",
+        }
+        mock_run.return_value = _make_run_result(stdout=json.dumps(info))
+        assert DockerUtil.detect_containerd_image_store() is False


### PR DESCRIPTION
## Summary

- Add XFS project quota fallback for `disk_limit_rootfs` when Docker uses the containerd image store (where `--storage-opt size=` is unsupported)
- After `docker start`, detect the container's overlay UpperDir (via `docker inspect` or `/proc/mounts`), then apply `xfs_quota` project quota as a best-effort disk limit
- Clean up quota bindings on container stop; degrade gracefully when filesystem is not XFS with `prjquota`

Fixes #1123

## Test plan

- [x] Unit tests for `_setup_rootfs_quota_xfs()` — quota set, degrade on non-XFS, degrade on missing UpperDir
- [x] Unit tests for `_cleanup_rootfs_xfs_quota()` — cleanup calls xfs_quota, no-op when no prjid
- [x] Unit tests for `_get_container_upper_dir()` — strategy 1 (docker inspect), strategy 2 (/proc/mounts), both fail
- [x] Unit tests for `DockerUtil.detect_containerd_image_store()`
- [x] All 43 related tests pass
- [x] Lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)