### PR TITLE
feat(admin): add RESTful sandbox restart API endpoint

### DIFF
--- a/rock/admin/entrypoints/sandbox_api.py
+++ b/rock/admin/entrypoints/sandbox_api.py
@@ -459,6 +459,13 @@ async def restart(sandbox_id: str = Body(..., embed=True)) -> RockResponse[Sandb
     return RockResponse(result=result)
 
 
+@sandbox_router.post("/sandboxes/{sandbox_id}/restart")
+@handle_exceptions(error_message="restart sandbox failed")
+async def restart_restful(sandbox_id: NonBlankStr) -> RockResponse[SandboxStartResponse]:
+    result = await sandbox_manager.restart_async(sandbox_id)
+    return RockResponse(result=result)
+
+
 @sandbox_router.post("/commit")
 @handle_exceptions(error_message="commit sandbox failed")
 async def commit(

--- a/tests/unit/admin/entrypoints/test_sandbox_restful_api.py
+++ b/tests/unit/admin/entrypoints/test_sandbox_restful_api.py
@@ -1,0 +1,42 @@
+"""Tests for the RESTful sandbox restart endpoint on sandbox_router."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
+from httpx import ASGITransport, AsyncClient
+
+from rock.admin.entrypoints.sandbox_api import sandbox_router, set_sandbox_manager
+from rock.admin.proto.response import SandboxStartResponse
+from rock.common.exception import request_validation_exception_handler
+
+
+@pytest.fixture
+def sandbox_app():
+    mock_manager = MagicMock()
+    mock_manager.rock_config = MagicMock()
+    mock_manager.rock_config.nacos_provider = None
+    set_sandbox_manager(mock_manager)
+    app = FastAPI()
+    app.add_exception_handler(RequestValidationError, request_validation_exception_handler)
+    app.include_router(sandbox_router, prefix="/apis/envs/sandbox/v1")
+    return app, mock_manager
+
+
+BASE = "/apis/envs/sandbox/v1"
+
+
+@pytest.mark.asyncio
+async def test_restart_restful(sandbox_app):
+    app, mock_manager = sandbox_app
+    mock_manager.restart_async = AsyncMock(
+        return_value=SandboxStartResponse(sandbox_id="sb-1", host_name="h", host_ip="1.2.3.4")
+    )
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(f"{BASE}/sandboxes/sb-1/restart")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "Success"
+        assert body["result"]["sandbox_id"] == "sb-1"
+    mock_manager.restart_async.assert_called_once_with("sb-1")


### PR DESCRIPTION
close #1000 

Add POST /sandboxes/{sandbox_id}/restart endpoint as a new RESTful-style sandbox lifecycle API.