### PR TITLE
fix(admin): always reset registry credentials on mirror image rewrite (#1128)

### DIFF
--- a/rock/admin/entrypoints/sandbox_api.py
+++ b/rock/admin/entrypoints/sandbox_api.py
@@ -122,9 +122,8 @@ def _probe_cache_set(candidate: str, hit: bool) -> None:
 
 def _apply_mirror_hit(config: DockerDeploymentConfig, mirror, candidate: str) -> None:
     config.image = candidate
-    if mirror.username and mirror.password:
-        config.registry_username = mirror.username
-        config.registry_password = mirror.password
+    config.registry_username = mirror.username
+    config.registry_password = mirror.password
 
 
 def _parse_bearer_challenge(header: str) -> dict[str, str]:

--- a/tests/unit/admin/test_image_registry_mirror.py
+++ b/tests/unit/admin/test_image_registry_mirror.py
@@ -153,6 +153,43 @@ async def test_credentials_propagated_on_hit(restore_sandbox_manager, stub_manif
     assert stub_manifest_probe.probes[0]["registry"] == "rock-a.example.com"
 
 
+async def test_user_credentials_cleared_when_mirror_has_no_auth(restore_sandbox_manager, stub_manifest_probe):
+    """User-supplied registry credentials must not leak to a mirror that needs no auth."""
+    sandbox_api.sandbox_manager = _make_manager(
+        [ImageRegistryMirror(registry="rock-a.example.com", namespace="rock-public")]
+    )
+    config = DockerDeploymentConfig(image="my-registry.io/myimage:v1", registry_username="orig-user", registry_password="orig-pw")
+    stub_manifest_probe.probe_results.append(True)
+
+    await sandbox_api._apply_image_registry_mirror(config)
+
+    assert config.image == "rock-a.example.com/rock-public/myimage:v1"
+    assert config.registry_username is None
+    assert config.registry_password is None
+
+
+async def test_user_credentials_replaced_by_mirror_credentials(restore_sandbox_manager, stub_manifest_probe):
+    """When both user and mirror have credentials, the mirror's credentials must win."""
+    sandbox_api.sandbox_manager = _make_manager(
+        [
+            ImageRegistryMirror(
+                registry="rock-a.example.com",
+                namespace="rock-public",
+                username="mirror-user",
+                password="mirror-pw",
+            ),
+        ]
+    )
+    config = DockerDeploymentConfig(image="my-registry.io/myimage:v1", registry_username="orig-user", registry_password="orig-pw")
+    stub_manifest_probe.probe_results.append(True)
+
+    await sandbox_api._apply_image_registry_mirror(config)
+
+    assert config.image == "rock-a.example.com/rock-public/myimage:v1"
+    assert config.registry_username == "mirror-user"
+    assert config.registry_password == "mirror-pw"
+
+
 async def test_invalid_mirror_entry_skipped(restore_sandbox_manager, stub_manifest_probe):
     sandbox_api.sandbox_manager = _make_manager(
         [


### PR DESCRIPTION
## Summary
- `_apply_mirror_hit` conditionally set `registry_username`/`registry_password` only when the mirror had auth configured (`if mirror.username and mirror.password`). When the mirror had no auth but the user supplied credentials for the original registry, those stale credentials leaked to the mirror, causing `docker login` failures against the wrong registry.
- Always set credentials to the mirror's values (or `None`) when rewriting the image URL, so original-registry credentials never leak to the mirror.
- Added two tests covering the credential-leak scenario.

## Test plan
- [x] `test_user_credentials_cleared_when_mirror_has_no_auth` — user creds cleared when mirror needs no auth
- [x] `test_user_credentials_replaced_by_mirror_credentials` — user creds replaced by mirror creds
- [x] All 25 existing mirror tests still pass

fixes #1128

🤖 Generated with [Claude Code](https://claude.com/claude-code)