### PR TITLE
chore: bump version to 1.9.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 authors = [{ name = "chatos@alibaba" }]
 requires-python = "<4.0,>=3.10"
 name = "rl-rock"
-version = "1.9.1"
+version = "1.9.2"
 description = "ROCK-Reinforcement Open Construction Kit"
 readme = "README.md"
 dependencies = [


### PR DESCRIPTION
## Summary
- Bump `rl-rock` version from 1.9.1 to 1.9.2 in `pyproject.toml`

fixes #1132

## Test plan
- [ ] Verify `pyproject.toml` version field is `1.9.2`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)