### PR TITLE
fix(admin): support OCI manifest format in mirror image probe (#1135)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 authors = [{ name = "chatos@alibaba" }]
 requires-python = "<4.0,>=3.10"
 name = "rl-rock"
-version = "1.9.2"
+version = "1.9.3"
 description = "ROCK-Reinforcement Open Construction Kit"
 readme = "README.md"
 dependencies = [

--- a/rock/admin/entrypoints/sandbox_api.py
+++ b/rock/admin/entrypoints/sandbox_api.py
@@ -141,7 +141,14 @@ async def _http_probe_manifest(
 ) -> bool:
     """Check whether ``repo:tag`` exists on *registry* via the v2 manifest API."""
     url = f"https://{registry}/v2/{repo}/manifests/{tag}"
-    headers = {"Accept": "application/vnd.docker.distribution.manifest.v2+json"}
+    headers = {
+        "Accept": ", ".join([
+            "application/vnd.docker.distribution.manifest.v2+json",
+            "application/vnd.oci.image.manifest.v1+json",
+            "application/vnd.docker.distribution.manifest.list.v2+json",
+            "application/vnd.oci.image.index.v1+json",
+        ])
+    }
     auth = (username, password) if username and password else None
 
     async with httpx.AsyncClient(timeout=timeout) as client:


### PR DESCRIPTION
## Summary
- **Fix mirror probe missing OCI images**: `_http_probe_manifest` only sent `application/vnd.docker.distribution.manifest.v2+json` as Accept header, causing OCI-format images to return 404 even though they exist and can be pulled. Added all four manifest media types (Docker v2, OCI, manifest list, OCI index).
- **Bump version to 1.9.3**

fixes #1135

## Test plan
- [x] Verify OCI-format mirror images are now detected by the probe (previously returned 404, now returns 200)
- [x] Verify Docker v2 format images still work as before
- [x] Run existing unit tests: `pytest tests/unit/admin/test_image_registry_mirror.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)