### PR TITLE
fix(archive): self-healing cleanup for stale temp dirs and soft-signal trap

### DIFF
--- a/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
+++ b/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
@@ -150,6 +150,8 @@ class SandboxLogArchiveTask(BaseTask):
         keep_days = int(log_cfg.keep_days_before_archive or 3)
         archive_prefix = log_cfg.archive_prefix or ""
 
+        await self._cleanup_stale_archives(runtime)
+
         # Step 1: discover candidate sandbox_ids on this worker
         candidate_ids = await self._discover_candidates(runtime)
         if not candidate_ids:
@@ -253,6 +255,16 @@ class SandboxLogArchiveTask(BaseTask):
         except (ValueError, TypeError):
             return None
 
+    async def _cleanup_stale_archives(self, runtime: RemoteSandboxRuntime) -> None:
+        """Remove sb-archive-* temp dirs abandoned by SIGKILL'd archive processes."""
+        cmd = "find /tmp -maxdepth 1 -name 'sb-archive-*' -type d -mmin +120 -exec rm -rf {} + 2>/dev/null || true"
+        try:
+            await runtime.execute(
+                Command(command=cmd, shell=True, check=False, sandbox_id="scheduler-task")
+            )
+        except Exception as e:
+            logger.warning(f"[{self.type}] stale archive cleanup failed: {e}")
+
     async def _archive_one(
         self,
         runtime: RemoteSandboxRuntime,
@@ -278,6 +290,7 @@ class SandboxLogArchiveTask(BaseTask):
                 command=cmd,
                 shell=True,
                 check=True,
+                timeout=3600,
                 env={
                     "OSS_ACCESS_KEY_ID": access_key_id,
                     "OSS_ACCESS_KEY_SECRET": access_key_secret,

--- a/rock/utils/archive_command.py
+++ b/rock/utils/archive_command.py
@@ -49,6 +49,13 @@ class ArchiveCommand:
         any step fails, so the caller can rely on the exit code to retry.
         The scratch dir is removed via ``trap EXIT`` regardless of outcome.
 
+        Soft kills (SIGINT/SIGTERM/SIGHUP) are also trapped — they ``exit``
+        with conventional ``128 + signo`` codes so the EXIT trap can fire and
+        clean up. This catches Ctrl-C, ``kill <pid>`` (k8s graceful shutdown
+        first phase, ``runtime.execute(...)`` timeout), and SSH disconnect.
+        SIGKILL still cannot be trapped — for that case we rely on the
+        task-level / command-level ``find -mmin +120 -delete`` sweep.
+
         Before tar+upload, ``ossutil stat`` checks whether the OSS object
         already exists (previous tar+upload succeeded but the process was
         killed before ``rm -rf <log_dir>``). If it does, tar+upload is
@@ -68,12 +75,20 @@ class ArchiveCommand:
         #
         # ossutil stat || { tar && ossutil cp; } — if the object already
         # exists on OSS the || short-circuits and skips tar+upload.
+        #
+        # trap 'exit' INT TERM HUP forwards soft signals to a normal exit so
+        # the EXIT trap (rm -rf "$ARCHIVE_DIR") still fires; SIGKILL can't be
+        # trapped and is covered by the leading find sweep + task-level
+        # _cleanup_stale_archives() in SandboxLogArchiveTask.
         return textwrap.dedent(
             f"""\
             find /tmp -maxdepth 1 -name 'sb-archive-*' -type d -mmin +120 -exec rm -rf {{}} + 2>/dev/null; \\
             set -e \\
             && ARCHIVE_DIR=$(mktemp -d -t sb-archive-XXXXXX) \\
             && trap 'rm -rf "$ARCHIVE_DIR"' EXIT \\
+            && trap 'exit 130' INT \\
+            && trap 'exit 143' TERM \\
+            && trap 'exit 129' HUP \\
             && umask 077 \\
             && printf '[Credentials]\\nlanguage=EN\\nendpoint=%s\\naccessKeyID=%s\\naccessKeySecret=%s\\n' \\
             {endpoint_q} "$OSS_ACCESS_KEY_ID" "$OSS_ACCESS_KEY_SECRET" \\

--- a/rock/utils/archive_command.py
+++ b/rock/utils/archive_command.py
@@ -48,6 +48,14 @@ class ArchiveCommand:
         ``set -e`` aborts the chain before the final ``rm -rf <log_dir>`` if
         any step fails, so the caller can rely on the exit code to retry.
         The scratch dir is removed via ``trap EXIT`` regardless of outcome.
+
+        Before tar+upload, ``ossutil stat`` checks whether the OSS object
+        already exists (previous tar+upload succeeded but the process was
+        killed before ``rm -rf <log_dir>``). If it does, tar+upload is
+        skipped entirely — only the final ``rm -rf`` runs.
+
+        Stale ``sb-archive-*`` temp dirs older than 2 hours (left by
+        SIGKILL'd archive processes) are cleaned up at the start.
         """
         log_path = Path(log_dir)
         parent = shlex.quote(str(log_path.parent))
@@ -57,8 +65,12 @@ class ArchiveCommand:
         log_dir_q = shlex.quote(log_dir)
         # textwrap.dedent strips the common leading whitespace so the source can be
         # indented for readability without polluting the emitted shell string.
+        #
+        # ossutil stat || { tar && ossutil cp; } — if the object already
+        # exists on OSS the || short-circuits and skips tar+upload.
         return textwrap.dedent(
             f"""\
+            find /tmp -maxdepth 1 -name 'sb-archive-*' -type d -mmin +120 -exec rm -rf {{}} + 2>/dev/null; \\
             set -e \\
             && ARCHIVE_DIR=$(mktemp -d -t sb-archive-XXXXXX) \\
             && trap 'rm -rf "$ARCHIVE_DIR"' EXIT \\
@@ -66,7 +78,8 @@ class ArchiveCommand:
             && printf '[Credentials]\\nlanguage=EN\\nendpoint=%s\\naccessKeyID=%s\\naccessKeySecret=%s\\n' \\
             {endpoint_q} "$OSS_ACCESS_KEY_ID" "$OSS_ACCESS_KEY_SECRET" \\
             > "$ARCHIVE_DIR/ossconfig" \\
-            && tar -czf "$ARCHIVE_DIR/archive.tar.gz" -C {parent} {name} \\
-            && ossutil cp -c "$ARCHIVE_DIR/ossconfig" -f "$ARCHIVE_DIR/archive.tar.gz" {oss_url_q} \\
+            && {{ ossutil stat -c "$ARCHIVE_DIR/ossconfig" {oss_url_q} >/dev/null 2>&1 \\
+            || {{ tar -czf "$ARCHIVE_DIR/archive.tar.gz" -C {parent} {name} \\
+            && ossutil cp -c "$ARCHIVE_DIR/ossconfig" -f "$ARCHIVE_DIR/archive.tar.gz" {oss_url_q}; }}; }} \\
             && rm -rf {log_dir_q}"""
         )

--- a/tests/unit/admin/scheduler/test_sandbox_log_archive_task.py
+++ b/tests/unit/admin/scheduler/test_sandbox_log_archive_task.py
@@ -187,7 +187,7 @@ class TestDiscovery:
         set_rock_config_provider(lambda: _fake_rock_config())
 
         task = SandboxLogArchiveTask(log_root="/data/logs")
-        runtime = _runtime([_FakeExecResult(stdout="")])
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="")])
 
         result = await task.run_action(runtime)
 
@@ -209,10 +209,11 @@ class TestDiscovery:
         set_rock_config_provider(lambda: _fake_rock_config())
 
         task = SandboxLogArchiveTask(log_root="/data/logs")
-        runtime = _runtime([_FakeExecResult(stdout="")])
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="")])
         await task.run_action(runtime)
 
-        cmd = runtime.execute.await_args_list[0].args[0].command
+        # index 1: discover command (index 0 is stale archive cleanup)
+        cmd = runtime.execute.await_args_list[1].args[0].command
         assert "-type d" in cmd, "discovery must restrict to directories"
         assert "-maxdepth 1" in cmd, "must not recurse into sandbox log subdirs"
         assert cmd.lstrip().startswith("find "), f"expected find, got: {cmd[:50]}"
@@ -232,7 +233,7 @@ class TestClassification:
         fake_table.list_by_in = AsyncMock(return_value=[])
 
         task = SandboxLogArchiveTask(log_root="/data/logs")
-        runtime = _runtime([_FakeExecResult(stdout="sb-orphan")])
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="sb-orphan")])
 
         result = await task.run_action(runtime)
 
@@ -246,7 +247,7 @@ class TestClassification:
         fake_table.list_by_in = AsyncMock(return_value=[_row("sb-alive", state="alive")])
 
         task = SandboxLogArchiveTask(log_root="/data/logs")
-        runtime = _runtime([_FakeExecResult(stdout="sb-alive")])
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="sb-alive")])
 
         result = await task.run_action(runtime)
 
@@ -260,7 +261,7 @@ class TestClassification:
         fake_table.list_by_in = AsyncMock(return_value=[_row("sb-young", state="stopped", stop_time=_iso_days_ago(1))])
 
         task = SandboxLogArchiveTask(log_root="/data/logs")
-        runtime = _runtime([_FakeExecResult(stdout="sb-young")])
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="sb-young")])
 
         result = await task.run_action(runtime)
 
@@ -276,6 +277,7 @@ class TestClassification:
         task = SandboxLogArchiveTask(log_root="/data/logs")
         runtime = _runtime(
             [
+                _FakeExecResult(),  # cleanup stale archives
                 _FakeExecResult(stdout="sb-old"),  # discover
                 _FakeExecResult(stdout=""),  # archive cmd
             ]
@@ -285,7 +287,7 @@ class TestClassification:
 
         assert result["archived"] == 1
         assert result["failed"] == 0
-        assert runtime.execute.await_count == 2
+        assert runtime.execute.await_count == 3
 
     @pytest.mark.asyncio
     async def test_stop_time_malformed_skipped(self, fake_table):
@@ -294,7 +296,7 @@ class TestClassification:
         fake_table.list_by_in = AsyncMock(return_value=[_row("sb-bad", state="stopped", stop_time="not-a-date")])
 
         task = SandboxLogArchiveTask(log_root="/data/logs")
-        runtime = _runtime([_FakeExecResult(stdout="sb-bad")])
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="sb-bad")])
 
         result = await task.run_action(runtime)
 
@@ -317,11 +319,11 @@ class TestArchiveCommand:
         fake_table.list_by_in = AsyncMock(return_value=[_row("sb-1", state="stopped", stop_time=_iso_days_ago(10))])
 
         task = SandboxLogArchiveTask(log_root="/data/logs")
-        runtime = _runtime([_FakeExecResult(stdout="sb-1"), _FakeExecResult()])
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="sb-1"), _FakeExecResult()])
 
         await task.run_action(runtime)
 
-        archive_call = runtime.execute.await_args_list[1]
+        archive_call = runtime.execute.await_args_list[2]
         cmd_obj = archive_call.args[0]
         assert "SECRET_AK" not in cmd_obj.command
         assert "SECRET_SK" not in cmd_obj.command
@@ -337,13 +339,66 @@ class TestArchiveCommand:
         fake_table.list_by_in = AsyncMock(return_value=[_row("sb-x", state="stopped", stop_time=_iso_days_ago(5))])
 
         task = SandboxLogArchiveTask(log_root="/data/logs")
-        runtime = _runtime([_FakeExecResult(stdout="sb-x"), _FakeExecResult()])
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="sb-x"), _FakeExecResult()])
 
         await task.run_action(runtime)
 
-        archive_cmd = runtime.execute.await_args_list[1].args[0].command
+        archive_cmd = runtime.execute.await_args_list[2].args[0].command
         # build_sandbox_log_key("sb-x", "archives/") => "archives/sandbox-logs/sb-x.tar.gz"
         assert "oss://my-bucket/archives/sandbox-logs/sb-x.tar.gz" in archive_cmd
+
+    @pytest.mark.asyncio
+    async def test_stale_archive_cleanup_runs_before_archival(self, fake_table):
+        """Stale sb-archive-* temp dirs must be cleaned before archiving."""
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(lambda: _fake_rock_config(keep_days=3))
+        fake_table.list_by_in = AsyncMock(return_value=[_row("sb-1", state="stopped", stop_time=_iso_days_ago(5))])
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime(
+            [
+                _FakeExecResult(),  # cleanup stale archives
+                _FakeExecResult(stdout="sb-1"),  # discover
+                _FakeExecResult(),  # archive cmd
+            ]
+        )
+
+        result = await task.run_action(runtime)
+
+        assert result["archived"] == 1
+        cleanup_cmd = runtime.execute.await_args_list[0].args[0].command
+        assert "sb-archive-" in cleanup_cmd
+        assert "-mmin +120" in cleanup_cmd
+
+    @pytest.mark.asyncio
+    async def test_archive_timeout_is_3600(self, fake_table):
+        """Archive command must use 3600s timeout (not default 1200s)."""
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(lambda: _fake_rock_config(keep_days=3))
+        fake_table.list_by_in = AsyncMock(return_value=[_row("sb-1", state="stopped", stop_time=_iso_days_ago(5))])
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="sb-1"), _FakeExecResult()])
+
+        await task.run_action(runtime)
+
+        archive_cmd_obj = runtime.execute.await_args_list[2].args[0]
+        assert archive_cmd_obj.timeout == 3600
+
+    @pytest.mark.asyncio
+    async def test_archive_command_checks_oss_existence(self, fake_table):
+        """Archive command must check OSS existence before tar+upload."""
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(lambda: _fake_rock_config(bucket="b", keep_days=3))
+        fake_table.list_by_in = AsyncMock(return_value=[_row("sb-1", state="stopped", stop_time=_iso_days_ago(5))])
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="sb-1"), _FakeExecResult()])
+
+        await task.run_action(runtime)
+
+        archive_cmd = runtime.execute.await_args_list[2].args[0].command
+        assert "ossutil stat" in archive_cmd
 
     @pytest.mark.asyncio
     async def test_one_failure_does_not_abort_loop(self, fake_table):
@@ -360,6 +415,7 @@ class TestArchiveCommand:
         task = SandboxLogArchiveTask(log_root="/data/logs")
         runtime = _runtime(
             [
+                _FakeExecResult(),  # cleanup stale archives
                 _FakeExecResult(stdout="sb-fail\nsb-ok"),  # discover
                 RuntimeError("ossutil down"),  # archive sb-fail raises
                 _FakeExecResult(),  # archive sb-ok succeeds

--- a/tests/unit/utils/test_archive_command.py
+++ b/tests/unit/utils/test_archive_command.py
@@ -25,10 +25,19 @@ class TestArchiveCommandBuildCommand:
     def test_starts_with_set_e_so_failures_short_circuit(self):
         # `set -e` is what guarantees the trailing `rm -rf <log_dir>` is
         # skipped on tar / ossutil failure, so retry can re-archive cleanly.
-        # Triple-quoted multi-line string emits `set -e \\\n&& ...` (bash treats
-        # `\<newline>` as line continuation, so it's still one chained command).
+        # The leading `find /tmp ... sb-archive-*` cleanup is a best-effort
+        # sweep and is intentionally NOT in the && chain (it must not abort
+        # the archive run if find errors out), so the `set -e` chain starts
+        # right after the cleanup line ends with `;`.
         cmd = ArchiveCommand.build_command("/data/logs/sb-1", "k", "b", "e")
-        assert cmd.startswith("set -e \\\n&&")
+        assert "set -e \\\n&&" in cmd, "set -e must drive the && chain"
+        # The first &&-chained line must be `set -e` so any subsequent
+        # failure (tar/ossutil) short-circuits before the final `rm -rf`.
+        chain_start = cmd.index("set -e \\\n&&")
+        assert "; \\\nset -e" in cmd[: chain_start + len("set -e \\\n&&")], (
+            "the stale-archive cleanup must terminate with `;` so its exit "
+            "code does not abort the archive chain"
+        )
 
     def test_uses_mktemp_and_traps_exit_for_cleanup(self):
         # ossutil 1.7.x cannot read stdin, so we must land a temp tarball;
@@ -36,6 +45,17 @@ class TestArchiveCommandBuildCommand:
         cmd = ArchiveCommand.build_command("/data/logs/sb-1", "k", "b", "e")
         assert "mktemp -d" in cmd
         assert "trap " in cmd and "EXIT" in cmd
+
+    def test_traps_soft_signals_so_exit_trap_fires(self):
+        # k8s graceful shutdown / runtime.execute timeout / Ctrl-C / SSH HUP
+        # all deliver soft signals (TERM/INT/HUP). Without explicit traps,
+        # bash terminates on the default action and skips the EXIT trap,
+        # leaving multi-GB sb-archive-* dirs behind. Each soft trap simply
+        # `exit`s with the conventional 128+signo code so EXIT still fires.
+        cmd = ArchiveCommand.build_command("/data/logs/sb-1", "k", "b", "e")
+        assert "trap 'exit 130' INT" in cmd, "Ctrl-C must trigger EXIT cleanup"
+        assert "trap 'exit 143' TERM" in cmd, "SIGTERM (k8s/timeout) must trigger EXIT cleanup"
+        assert "trap 'exit 129' HUP" in cmd, "SIGHUP (SSH disconnect) must trigger EXIT cleanup"
 
     def test_writes_ossutil_config_with_endpoint_and_env_var_credentials(self):
         # ossutil 1.7.x ignores OSS_ACCESS_KEY_* env vars, so we materialize


### PR DESCRIPTION
## Summary

- Add periodic cleanup of stale `sb-archive-*` temp dirs (>2h old) at both task-level and command-level as defense-in-depth against SIGKILL residuals
- Trap SIGTERM/SIGINT/SIGHUP in archive shell commands so the EXIT cleanup handler fires on soft kills (k8s shutdown, timeout, SSH disconnect)
- Add `ossutil stat` pre-check to skip redundant tar+upload when the OSS object already exists (idempotent retry)
- Increase archive command timeout from 1200s to 3600s to reduce timeout-induced kills for large tarballs (6-7GB observed in production)

## Root Cause

Bash's EXIT trap is skipped when a process receives a default-action signal (TERM/INT/HUP) without explicit traps, and cannot fire at all on SIGKILL. Both scenarios leave `/tmp/sb-archive-*` dirs (multi-GB each) permanently on disk.

## Design

| Kill type | Prevention mechanism |
|-----------|---------------------|
| Soft (TERM/INT/HUP) | `trap 'exit 128+N' SIG` → EXIT trap fires → temp dir removed |
| Hard (SIGKILL/OOM) | `find /tmp -name 'sb-archive-*' -mmin +120 -exec rm -rf` at next cycle |
| Timeout | Command timeout 1200s → 3600s reduces premature kills |
| Retry waste | `ossutil stat` skips tar+upload if object exists on OSS |

## Deployment Note

Recommend changing Nacos `interval_seconds` from `86400` to `3600` to shorten the cleanup window for SIGKILL residuals from 24h+ to ~3h.

## Test Plan
- [ ] `pytest tests/unit/utils/test_archive_command.py` — signal traps, stale cleanup, ossutil stat assertions
- [ ] `pytest tests/unit/admin/scheduler/test_sandbox_log_archive_task.py` — task-level cleanup order, timeout value, integration flow
- [ ] Manual: deploy to pre-prod worker, create a fake `/tmp/sb-archive-old` dir with `touch -d '3 hours ago'`, trigger task, verify dir is removed
- [ ] Manual: start archive on large sandbox, send SIGTERM mid-upload, verify `/tmp/sb-archive-*` 

Fixes #1141 
