### PR TITLE
fix(sdk): server-first OSS config resolution + prefix-aware object keys

### DIFF
--- a/rock/sdk/sandbox/oss_client.py
+++ b/rock/sdk/sandbox/oss_client.py
@@ -30,13 +30,21 @@ logger = init_logger(__name__)
 
 @dataclass
 class OssClientConfig:
-    """Resolved OSS configuration (Layer 1 env or Layer 2 server)."""
+    """Resolved OSS configuration.
+
+    Priority: admin /get_token response > env-var fallback > unavailable.
+    Env vars are kept as a fallback for older admin servers that do not yet
+    return Bucket/Endpoint/Region. For newer admins, server response always
+    wins so the STS-issuing account and the target bucket stay aligned
+    (prevents 403 when SDK>=1.8 talks to chatos-rock with legacy env pointing
+    at xrl-sandbox).
+    """
 
     endpoint: str
     bucket: str
     region: str
-    enabled_via_env: bool  # True = Layer 1 (gated by ROCK_OSS_ENABLE); False = Layer 2
-    prefix: str = ""  # Transfer-object key prefix (Layer 1 from env; Layer 2 from server response)
+    is_env_fallback: bool  # True = env fallback path (gated by ROCK_OSS_ENABLE); False = server-supplied
+    prefix: str = ""  # Transfer-object key prefix (server: response.Prefix; fallback: ROCK_OSS_TRANSFER_PREFIX)
 
 
 class OssClient:
@@ -70,20 +78,9 @@ class OssClient:
 
     @staticmethod
     def _resolve_config(sts_response: dict) -> OssClientConfig | None:
-        # Layer 1: env var (highest priority)
-        env_endpoint = env_vars.ROCK_OSS_BUCKET_ENDPOINT
-        env_bucket = env_vars.ROCK_OSS_BUCKET_NAME
-        env_region = env_vars.ROCK_OSS_BUCKET_REGION
-        if env_endpoint and env_bucket and env_region:
-            return OssClientConfig(
-                endpoint=env_endpoint,
-                bucket=env_bucket,
-                region=env_region,
-                enabled_via_env=True,
-                prefix=env_vars.ROCK_OSS_TRANSFER_PREFIX or "",  # NEW: env can carry prefix too
-            )
-
-        # Layer 2: server response (fallback default)
+        # Server-first: when admin returns a complete OSS config, use it verbatim
+        # so the STS-issuing account matches the bucket. This is the only path
+        # that works correctly for SDK>=1.8 (which requests `account=primary`).
         resp_endpoint = sts_response.get("Endpoint")
         resp_bucket = sts_response.get("Bucket")
         resp_region = sts_response.get("Region")
@@ -92,11 +89,25 @@ class OssClient:
                 endpoint=resp_endpoint,
                 bucket=resp_bucket,
                 region=resp_region,
-                enabled_via_env=False,
-                prefix=sts_response.get("Prefix") or "",  # NEW: pull prefix from server
+                is_env_fallback=False,
+                prefix=sts_response.get("Prefix") or "",
             )
 
-        # Layer 3: OSS unavailable
+        # Env fallback: only kicks in when admin is too old to return Bucket/Endpoint/Region.
+        # Still gated by ROCK_OSS_ENABLE in _setup so users keep the legacy opt-in switch.
+        env_endpoint = env_vars.ROCK_OSS_BUCKET_ENDPOINT
+        env_bucket = env_vars.ROCK_OSS_BUCKET_NAME
+        env_region = env_vars.ROCK_OSS_BUCKET_REGION
+        if env_endpoint and env_bucket and env_region:
+            return OssClientConfig(
+                endpoint=env_endpoint,
+                bucket=env_bucket,
+                region=env_region,
+                is_env_fallback=True,
+                prefix=env_vars.ROCK_OSS_TRANSFER_PREFIX or "",
+            )
+
+        # OSS unavailable: neither server nor env supplies a complete config.
         return None
 
     async def _get_sts_credentials(self) -> dict:
@@ -152,8 +163,11 @@ class OssClient:
         if config is None:
             return False
 
-        # Layer 1 also requires ROCK_OSS_ENABLE
-        if config.enabled_via_env and not env_vars.ROCK_OSS_ENABLE:
+        # Env fallback path keeps the legacy ROCK_OSS_ENABLE opt-in gate so
+        # users who explicitly set `ROCK_OSS_ENABLE=false` still see OSS off.
+        # Server-supplied configs bypass this gate: if admin advertises OSS,
+        # treat it as enabled (matches StorageClient behavior).
+        if config.is_env_fallback and not env_vars.ROCK_OSS_ENABLE:
             return False
 
         try:

--- a/rock/sdk/sandbox/oss_client.py
+++ b/rock/sdk/sandbox/oss_client.py
@@ -43,7 +43,7 @@ class OssClientConfig:
     endpoint: str
     bucket: str
     region: str
-    is_env_fallback: bool  # True = env fallback path (gated by ROCK_OSS_ENABLE); False = server-supplied
+    enabled_via_env: bool  # True = env fallback path (gated by ROCK_OSS_ENABLE); False = server-supplied
     prefix: str = ""  # Transfer-object key prefix (server: response.Prefix; fallback: ROCK_OSS_TRANSFER_PREFIX)
 
 
@@ -89,7 +89,7 @@ class OssClient:
                 endpoint=resp_endpoint,
                 bucket=resp_bucket,
                 region=resp_region,
-                is_env_fallback=False,
+                enabled_via_env=False,
                 prefix=sts_response.get("Prefix") or "",
             )
 
@@ -103,7 +103,7 @@ class OssClient:
                 endpoint=env_endpoint,
                 bucket=env_bucket,
                 region=env_region,
-                is_env_fallback=True,
+                enabled_via_env=True,
                 prefix=env_vars.ROCK_OSS_TRANSFER_PREFIX or "",
             )
 
@@ -167,7 +167,7 @@ class OssClient:
         # users who explicitly set `ROCK_OSS_ENABLE=false` still see OSS off.
         # Server-supplied configs bypass this gate: if admin advertises OSS,
         # treat it as enabled (matches StorageClient behavior).
-        if config.is_env_fallback and not env_vars.ROCK_OSS_ENABLE:
+        if config.enabled_via_env and not env_vars.ROCK_OSS_ENABLE:
             return False
 
         try:

--- a/rock/sdk/sandbox/oss_client.py
+++ b/rock/sdk/sandbox/oss_client.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING
 
 import oss2
 
-from rock import env_vars
 from rock.actions.sandbox.request import Command
 from rock.actions.sandbox.response import DownloadFileResponse, UploadResponse
 from rock.logger import init_logger
@@ -30,21 +29,12 @@ logger = init_logger(__name__)
 
 @dataclass
 class OssClientConfig:
-    """Resolved OSS configuration.
-
-    Priority: admin /get_token response > env-var fallback > unavailable.
-    Env vars are kept as a fallback for older admin servers that do not yet
-    return Bucket/Endpoint/Region. For newer admins, server response always
-    wins so the STS-issuing account and the target bucket stay aligned
-    (prevents 403 when SDK>=1.8 talks to chatos-rock with legacy env pointing
-    at xrl-sandbox).
-    """
+    """Resolved OSS configuration from admin /get_token response."""
 
     endpoint: str
     bucket: str
     region: str
-    enabled_via_env: bool  # True = env fallback path (gated by ROCK_OSS_ENABLE); False = server-supplied
-    prefix: str = ""  # Transfer-object key prefix (server: response.Prefix; fallback: ROCK_OSS_TRANSFER_PREFIX)
+    prefix: str = ""  # Transfer-object key prefix from server response (e.g. "rock-transfer/")
 
 
 class OssClient:
@@ -78,9 +68,8 @@ class OssClient:
 
     @staticmethod
     def _resolve_config(sts_response: dict) -> OssClientConfig | None:
-        # Server-first: when admin returns a complete OSS config, use it verbatim
-        # so the STS-issuing account matches the bucket. This is the only path
-        # that works correctly for SDK>=1.8 (which requests `account=primary`).
+        # Server-only: admin /get_token must return a complete OSS config.
+        # If it doesn't, OSS is simply unavailable (no env fallback).
         resp_endpoint = sts_response.get("Endpoint")
         resp_bucket = sts_response.get("Bucket")
         resp_region = sts_response.get("Region")
@@ -89,25 +78,10 @@ class OssClient:
                 endpoint=resp_endpoint,
                 bucket=resp_bucket,
                 region=resp_region,
-                enabled_via_env=False,
                 prefix=sts_response.get("Prefix") or "",
             )
 
-        # Env fallback: only kicks in when admin is too old to return Bucket/Endpoint/Region.
-        # Still gated by ROCK_OSS_ENABLE in _setup so users keep the legacy opt-in switch.
-        env_endpoint = env_vars.ROCK_OSS_BUCKET_ENDPOINT
-        env_bucket = env_vars.ROCK_OSS_BUCKET_NAME
-        env_region = env_vars.ROCK_OSS_BUCKET_REGION
-        if env_endpoint and env_bucket and env_region:
-            return OssClientConfig(
-                endpoint=env_endpoint,
-                bucket=env_bucket,
-                region=env_region,
-                enabled_via_env=True,
-                prefix=env_vars.ROCK_OSS_TRANSFER_PREFIX or "",
-            )
-
-        # OSS unavailable: neither server nor env supplies a complete config.
+        # OSS unavailable: server did not supply a complete config.
         return None
 
     async def _get_sts_credentials(self) -> dict:
@@ -161,13 +135,6 @@ class OssClient:
 
         config = self._resolve_config(sts_response)
         if config is None:
-            return False
-
-        # Env fallback path keeps the legacy ROCK_OSS_ENABLE opt-in gate so
-        # users who explicitly set `ROCK_OSS_ENABLE=false` still see OSS off.
-        # Server-supplied configs bypass this gate: if admin advertises OSS,
-        # treat it as enabled (matches StorageClient behavior).
-        if config.enabled_via_env and not env_vars.ROCK_OSS_ENABLE:
             return False
 
         try:

--- a/rock/ts-sdk/CHANGELOG.md
+++ b/rock/ts-sdk/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **OSS bucket / endpoint / region resolution is now server-first.** When the
+  admin `/get_token` response includes `Bucket`, `Endpoint`, and `Region`,
+  those values are used verbatim. The `ROCK_OSS_BUCKET_NAME`,
+  `ROCK_OSS_BUCKET_ENDPOINT`, and `ROCK_OSS_BUCKET_REGION` environment
+  variables are now only consulted as a fallback for older admin servers
+  that do not advertise the OSS config.
+  - This fixes 403 AccessDenied errors when SDK >= 1.8 was deployed alongside
+    stale legacy env vars (e.g. `ROCK_OSS_BUCKET_NAME=xrl-sandbox`): the SDK
+    now requests STS for `account=primary` and uses the matching bucket from
+    the server response instead of the mismatched env value.
+  - `ROCK_OSS_ENABLE` continues to gate the env-fallback path; it is no
+    longer required when the server supplies a complete OSS config (matching
+    the existing `StorageClient` behavior).
+- **`getOssStsCredentials()` now requests `account=primary`.** Previously it
+  hit `/get_token` with no query, which the admin defaulted to `legacy`.
+  This ensures the STS-issuing account matches the bucket the server
+  advertises.
+
+### Added
+
+- `Sandbox.resolveOssConfig(credentials)` static helper that mirrors the
+  Python `OssClient._resolve_config` (server-first with env fallback).
+- `Sandbox.buildOssObjectName(prefix, baseName)` static helper that prepends
+  the server-supplied OSS prefix to object keys, normalizing leading/trailing
+  slashes.
+
+### Fixed
+
+- **OSS 403 AccessDenied on uploads/downloads.** `uploadViaOss` and
+  `downloadViaOss` previously wrote to the bucket root (e.g.
+  `1700000000-file.tar.gz`), but primary-account STS tokens carry a RAM
+  policy that only permits writes under the advertised prefix (typically
+  `rock-transfer/`). The SDK now prepends `ossConfig.prefix` to the object
+  key, matching the Python SDK `OssClient._compute_object_name` behavior.
+
 ## [1.3.9] - 2026-03-29
 
 ### Added

--- a/rock/ts-sdk/CHANGELOG.md
+++ b/rock/ts-sdk/CHANGELOG.md
@@ -7,21 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **`ROCK_OSS_BUCKET_NAME`, `ROCK_OSS_BUCKET_ENDPOINT`, `ROCK_OSS_BUCKET_REGION` env vars
+  are no longer read by the SDK.** OSS bucket/endpoint/region are now resolved
+  exclusively from the admin `/get_token?account=primary` response. Users who
+  still have these env vars set can safely leave them — they are simply ignored.
+- **`ROCK_OSS_ENABLE` env var is no longer read by the SDK.** OSS availability
+  is determined solely by whether the admin returns a complete config. If the
+  server provides Bucket/Endpoint/Region, OSS is enabled; otherwise it is
+  unavailable. The auto-mode upload/download threshold (1 MB) is unchanged.
+- `resolveOssConfig` no longer returns an `enabledViaEnv` field.
+
 ### Changed
 
-- **OSS bucket / endpoint / region resolution is now server-first.** When the
-  admin `/get_token` response includes `Bucket`, `Endpoint`, and `Region`,
-  those values are used verbatim. The `ROCK_OSS_BUCKET_NAME`,
-  `ROCK_OSS_BUCKET_ENDPOINT`, and `ROCK_OSS_BUCKET_REGION` environment
-  variables are now only consulted as a fallback for older admin servers
-  that do not advertise the OSS config.
-  - This fixes 403 AccessDenied errors when SDK >= 1.8 was deployed alongside
-    stale legacy env vars (e.g. `ROCK_OSS_BUCKET_NAME=xrl-sandbox`): the SDK
-    now requests STS for `account=primary` and uses the matching bucket from
-    the server response instead of the mismatched env value.
-  - `ROCK_OSS_ENABLE` continues to gate the env-fallback path; it is no
-    longer required when the server supplies a complete OSS config (matching
-    the existing `StorageClient` behavior).
 - **`getOssStsCredentials()` now requests `account=primary`.** Previously it
   hit `/get_token` with no query, which the admin defaulted to `legacy`.
   This ensures the STS-issuing account matches the bucket the server
@@ -29,8 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Sandbox.resolveOssConfig(credentials)` static helper that mirrors the
-  Python `OssClient._resolve_config` (server-first with env fallback).
+- `Sandbox.resolveOssConfig(credentials)` static helper that resolves OSS
+  config from the server `/get_token` response (returns `null` when incomplete).
 - `Sandbox.buildOssObjectName(prefix, baseName)` static helper that prepends
   the server-supplied OSS prefix to object keys, normalizing leading/trailing
   slashes.

--- a/rock/ts-sdk/README.md
+++ b/rock/ts-sdk/README.md
@@ -222,9 +222,7 @@ console.log(result.output);
 | `ROCK_BASE_URL` | ROCK 服务基础 URL | `http://localhost:8080` |
 | `ROCK_ENVHUB_BASE_URL` | EnvHub 服务 URL | `http://localhost:8081` |
 | `ROCK_SANDBOX_STARTUP_TIMEOUT_SECONDS` | 沙箱启动超时时间 | `180` |
-| `ROCK_OSS_ENABLE` | 是否启用 OSS 上传/下载 | `false` |
-| `ROCK_OSS_BUCKET_ENDPOINT` | OSS Endpoint | - |
-| `ROCK_OSS_BUCKET_NAME` | OSS Bucket 名称 | - |
+| `ROCK_OSS_TIMEOUT` | OSS 操作超时时间 (ms) | `300000` |
 
 ### SandboxConfig 选项
 

--- a/rock/ts-sdk/docs/DEVELOPER_GUIDE.md
+++ b/rock/ts-sdk/docs/DEVELOPER_GUIDE.md
@@ -297,10 +297,9 @@ ROCK_ENVHUB_BASE_URL=http://your-envhub-server:8081
 ROCK_SANDBOX_STARTUP_TIMEOUT_SECONDS=300
 
 # OSS 配置 (大文件上传/下载)
-ROCK_OSS_ENABLE=true
-ROCK_OSS_BUCKET_ENDPOINT=https://oss-cn-hangzhou.aliyuncs.com
-ROCK_OSS_BUCKET_NAME=your-bucket
-ROCK_OSS_BUCKET_REGION=oss-cn-hangzhou
+# OSS bucket/endpoint/region 由 admin /get_token 接口自动返回，无需手动配置。
+# 仅 timeout 可通过环境变量覆盖：
+ROCK_OSS_TIMEOUT=300000
 
 # 日志配置
 ROCK_LOGGING_PATH=/var/log/rock
@@ -637,11 +636,7 @@ console.log(`Port mapping: ${JSON.stringify(status.portMapping)}`);
 ### Q: 如何处理大文件上传？
 
 ```typescript
-// 启用 OSS 上传 (> 1MB 自动使用 OSS)
-process.env.ROCK_OSS_ENABLE = 'true';
-process.env.ROCK_OSS_BUCKET_NAME = 'your-bucket';
-// ... 其他 OSS 配置
-
+// > 1MB 自动使用 OSS 上传（OSS 配置由 admin /get_token 自动返回）
 await sandbox.upload({
   sourcePath: './large-file.zip',
   targetPath: '/remote/large-file.zip',

--- a/rock/ts-sdk/src/env_vars.ts
+++ b/rock/ts-sdk/src/env_vars.ts
@@ -99,22 +99,6 @@ export const envVars = {
   },
 
   // OSS
-  get ROCK_OSS_ENABLE(): boolean {
-    return getEnv('ROCK_OSS_ENABLE', 'false')?.toLowerCase() === 'true';
-  },
-
-  get ROCK_OSS_BUCKET_ENDPOINT(): string | undefined {
-    return getEnv('ROCK_OSS_BUCKET_ENDPOINT');
-  },
-
-  get ROCK_OSS_BUCKET_NAME(): string | undefined {
-    return getEnv('ROCK_OSS_BUCKET_NAME');
-  },
-
-  get ROCK_OSS_BUCKET_REGION(): string | undefined {
-    return getEnv('ROCK_OSS_BUCKET_REGION');
-  },
-
   get ROCK_OSS_TIMEOUT(): number {
     return parseInt(getEnv('ROCK_OSS_TIMEOUT', '300000')!, 10); // Default: 5 minutes
   },

--- a/rock/ts-sdk/src/sandbox/client.ts
+++ b/rock/ts-sdk/src/sandbox/client.ts
@@ -118,7 +118,6 @@ export class Sandbox extends AbstractSandbox {
     bucket: string;
     region: string;
     prefix: string;
-    enabledViaEnv: boolean;
   } | null = null;
 
   // Sub-components
@@ -682,10 +681,9 @@ export class Sandbox extends AbstractSandbox {
       // Check if we should use OSS upload
       const stats = await fs.stat(sourcePath);
       const fileSize = stats.size;
-      const ossEnabled = envVars.ROCK_OSS_ENABLE;
       const ossThreshold = 1024 * 1024; // 1MB
 
-      if (uploadMode === 'oss' || (uploadMode === 'auto' && ossEnabled && fileSize > ossThreshold)) {
+      if (uploadMode === 'oss' || (uploadMode === 'auto' && fileSize > ossThreshold)) {
         return this.uploadViaOss(sourcePath, targetPath, timeout, onProgress);
       }
 
@@ -799,10 +797,9 @@ export class Sandbox extends AbstractSandbox {
 
     const fileSize = parseInt(sizeResult.stdout.trim(), 10);
     const ossThreshold = 1024 * 1024; // 1MB
-    const ossEnabled = envVars.ROCK_OSS_ENABLE;
 
-    // OSS enabled AND file >= 1MB: use OSS
-    if (ossEnabled && fileSize >= ossThreshold) {
+    // File >= 1MB: use OSS (if server provides OSS config, setupOss will succeed)
+    if (fileSize >= ossThreshold) {
       return this.downloadViaOss(remotePath, localPath, timeout, onProgress);
     }
 
@@ -842,15 +839,6 @@ export class Sandbox extends AbstractSandbox {
       // Setup OSS bucket if needed
       if (this.ossBucket === null || this.isTokenExpired()) {
         await this.setupOss(timeout);
-      }
-
-      // Enforce the legacy opt-in gate only on the env-fallback path.
-      // Server-supplied configs bypass it (consistent with Python OssClient).
-      if (this.ossConfig?.enabledViaEnv && !envVars.ROCK_OSS_ENABLE) {
-        return {
-          success: false,
-          message: 'OSS download is not enabled. Please set ROCK_OSS_ENABLE=true',
-        };
       }
 
       if (!this.ossBucket || !this.ossConfig) {
@@ -1011,15 +999,10 @@ export class Sandbox extends AbstractSandbox {
   }
 
   /**
-   * Resolve OSS config from server response with env-var fallback.
+   * Resolve OSS config from server response.
    *
-   * Server-first: when admin returns a complete OSS config in /get_token,
-   * use it verbatim so the STS-issuing account matches the bucket. This is
-   * the only path that works for SDK >= 1.8 (which targets account=primary).
-   *
-   * Env fallback: only kicks in when admin is too old to return
-   * Bucket/Endpoint/Region. The legacy ROCK_OSS_ENABLE gate is enforced at
-   * call sites (e.g. downloadViaOss) only for the env-fallback path.
+   * Admin /get_token must return a complete OSS config (Bucket, Endpoint,
+   * Region). If it doesn't, OSS is unavailable (returns null).
    *
    * Mirrors the Python `OssClient._resolve_config` implementation.
    */
@@ -1028,7 +1011,6 @@ export class Sandbox extends AbstractSandbox {
     bucket: string;
     region: string;
     prefix: string;
-    enabledViaEnv: boolean;
   } | null {
     if (credentials.endpoint && credentials.bucket && credentials.region) {
       return {
@@ -1036,20 +1018,6 @@ export class Sandbox extends AbstractSandbox {
         bucket: credentials.bucket,
         region: credentials.region,
         prefix: credentials.prefix ?? '',
-        enabledViaEnv: false,
-      };
-    }
-    if (
-      envVars.ROCK_OSS_BUCKET_ENDPOINT &&
-      envVars.ROCK_OSS_BUCKET_NAME &&
-      envVars.ROCK_OSS_BUCKET_REGION
-    ) {
-      return {
-        endpoint: envVars.ROCK_OSS_BUCKET_ENDPOINT,
-        bucket: envVars.ROCK_OSS_BUCKET_NAME,
-        region: envVars.ROCK_OSS_BUCKET_REGION,
-        prefix: '',
-        enabledViaEnv: true,
       };
     }
     return null;
@@ -1061,7 +1029,7 @@ export class Sandbox extends AbstractSandbox {
     const resolved = Sandbox.resolveOssConfig(credentials);
     if (!resolved) {
       throw new Error(
-        'OSS config unavailable: admin /get_token did not return Bucket/Endpoint/Region and no ROCK_OSS_BUCKET_* env vars are set'
+        'OSS config unavailable: admin /get_token did not return Bucket/Endpoint/Region'
       );
     }
 

--- a/rock/ts-sdk/src/sandbox/client.ts
+++ b/rock/ts-sdk/src/sandbox/client.ts
@@ -118,7 +118,7 @@ export class Sandbox extends AbstractSandbox {
     bucket: string;
     region: string;
     prefix: string;
-    isEnvFallback: boolean;
+    enabledViaEnv: boolean;
   } | null = null;
 
   // Sub-components
@@ -846,7 +846,7 @@ export class Sandbox extends AbstractSandbox {
 
       // Enforce the legacy opt-in gate only on the env-fallback path.
       // Server-supplied configs bypass it (consistent with Python OssClient).
-      if (this.ossConfig?.isEnvFallback && !envVars.ROCK_OSS_ENABLE) {
+      if (this.ossConfig?.enabledViaEnv && !envVars.ROCK_OSS_ENABLE) {
         return {
           success: false,
           message: 'OSS download is not enabled. Please set ROCK_OSS_ENABLE=true',
@@ -1028,7 +1028,7 @@ export class Sandbox extends AbstractSandbox {
     bucket: string;
     region: string;
     prefix: string;
-    isEnvFallback: boolean;
+    enabledViaEnv: boolean;
   } | null {
     if (credentials.endpoint && credentials.bucket && credentials.region) {
       return {
@@ -1036,7 +1036,7 @@ export class Sandbox extends AbstractSandbox {
         bucket: credentials.bucket,
         region: credentials.region,
         prefix: credentials.prefix ?? '',
-        isEnvFallback: false,
+        enabledViaEnv: false,
       };
     }
     if (
@@ -1049,7 +1049,7 @@ export class Sandbox extends AbstractSandbox {
         bucket: envVars.ROCK_OSS_BUCKET_NAME,
         region: envVars.ROCK_OSS_BUCKET_REGION,
         prefix: '',
-        isEnvFallback: true,
+        enabledViaEnv: true,
       };
     }
     return null;

--- a/rock/ts-sdk/src/sandbox/client.ts
+++ b/rock/ts-sdk/src/sandbox/client.ts
@@ -111,6 +111,15 @@ export class Sandbox extends AbstractSandbox {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private ossBucket: any = null;
   private ossTokenExpireTime: string = '';
+  // Resolved OSS config (server-first; env is only fallback when admin is too
+  // old to advertise Bucket/Endpoint/Region in /get_token).
+  private ossConfig: {
+    endpoint: string;
+    bucket: string;
+    region: string;
+    prefix: string;
+    isEnvFallback: boolean;
+  } | null = null;
 
   // Sub-components
   private deploy: Deploy;
@@ -705,7 +714,10 @@ export class Sandbox extends AbstractSandbox {
    * Get OSS STS credentials from sandbox
    */
   async getOssStsCredentials(): Promise<OssCredentials> {
-    const url = `${this.url}/get_token`;
+    // Always request the primary account: SDK >= 1.8 uses chatos-rock; the
+    // server returns matching Bucket/Endpoint/Region in this case, which the
+    // server-first config resolution relies on.
+    const url = `${this.url}/get_token?account=primary`;
     const headers = this.buildHeaders();
 
     const response = await HttpUtils.get<OssCredentials>(url, headers);
@@ -826,21 +838,22 @@ export class Sandbox extends AbstractSandbox {
    * Download file via OSS as intermediary
    */
   private async downloadViaOss(remotePath: string, localPath: string, timeout?: number, onProgress?: (info: ProgressInfo) => void): Promise<DownloadFileResponse> {
-    // Check OSS is enabled
-    if (!envVars.ROCK_OSS_ENABLE) {
-      return {
-        success: false,
-        message: 'OSS download is not enabled. Please set ROCK_OSS_ENABLE=true',
-      };
-    }
-
     try {
       // Setup OSS bucket if needed
       if (this.ossBucket === null || this.isTokenExpired()) {
         await this.setupOss(timeout);
       }
 
-      if (!this.ossBucket) {
+      // Enforce the legacy opt-in gate only on the env-fallback path.
+      // Server-supplied configs bypass it (consistent with Python OssClient).
+      if (this.ossConfig?.isEnvFallback && !envVars.ROCK_OSS_ENABLE) {
+        return {
+          success: false,
+          message: 'OSS download is not enabled. Please set ROCK_OSS_ENABLE=true',
+        };
+      }
+
+      if (!this.ossBucket || !this.ossConfig) {
         return { success: false, message: 'Failed to setup OSS bucket' };
       }
 
@@ -850,15 +863,17 @@ export class Sandbox extends AbstractSandbox {
       // Generate unique object name
       const timestamp = Date.now();
       const fileName = remotePath.split('/').pop() ?? 'file';
-      const objectName = `download-${timestamp}-${fileName}`;
+      // Prepend server-supplied prefix (e.g. "rock-transfer/") so the OSS key
+      // matches the STS RAM policy. The primary-account STS only permits
+      // writes under this prefix; bucket-root writes return 403 AccessDenied.
+      const objectName = Sandbox.buildOssObjectName(this.ossConfig?.prefix, `download-${timestamp}-${fileName}`);
 
       // Get STS credentials for ossutil
       const credentials = await this.getOssStsCredentials();
-      const bucketName = envVars.ROCK_OSS_BUCKET_NAME ?? '';
-      const region = (envVars.ROCK_OSS_BUCKET_REGION ?? '').replace(/^oss-/, ''); // Normalize: remove "oss-" prefix if present
-      // Use ROCK_OSS_BUCKET_ENDPOINT if available, otherwise build from region
-      // Endpoint format: "oss-cn-hangzhou.aliyuncs.com" (no protocol prefix)
-      const endpoint = envVars.ROCK_OSS_BUCKET_ENDPOINT ?? `oss-${region}.aliyuncs.com`;
+      const bucketName = this.ossConfig.bucket;
+      const region = this.ossConfig.region.replace(/^oss-/, ''); // Normalize: remove "oss-" prefix if present
+      // Endpoint comes from resolved config (server or env). Format: "oss-cn-hangzhou.aliyuncs.com".
+      const endpoint = this.ossConfig.endpoint;
 
       // Upload from sandbox to OSS via ossutil v2
       // ossutil v2 uses command-line parameters for credentials (no separate config needed)
@@ -913,7 +928,10 @@ export class Sandbox extends AbstractSandbox {
 
       const timestamp = Date.now();
       const fileName = sourcePath.split('/').pop() ?? 'file';
-      const objectName = `${timestamp}-${fileName}`;
+      // Prepend server-supplied prefix (e.g. "rock-transfer/") so the OSS key
+      // matches the STS RAM policy. The primary-account STS only permits
+      // writes under this prefix; bucket-root writes return 403 AccessDenied.
+      const objectName = Sandbox.buildOssObjectName(this.ossConfig?.prefix, `${timestamp}-${fileName}`);
 
       // Check file size to determine upload method
       const fs = await import('fs/promises');
@@ -977,22 +995,95 @@ export class Sandbox extends AbstractSandbox {
    * Setup OSS bucket with STS credentials
    * @param timeout - Optional timeout in milliseconds (defaults to ROCK_OSS_TIMEOUT env var or 300000ms)
    */
+  /**
+   * Compose an OSS object key by prepending the server-supplied prefix.
+   *
+   * STS tokens issued by the primary account carry a RAM policy that only
+   * permits writes under the advertised prefix (typically "rock-transfer/").
+   * Writing to the bucket root returns 403 AccessDenied. This helper applies
+   * the prefix consistently for upload and download paths.
+   *
+   * Mirrors the Python `OssClient._compute_object_name` prefix handling.
+   */
+  static buildOssObjectName(prefix: string | undefined | null, baseName: string): string {
+    const clean = (prefix ?? '').replace(/^\/+|\/+$/g, '');
+    return clean ? `${clean}/${baseName}` : baseName;
+  }
+
+  /**
+   * Resolve OSS config from server response with env-var fallback.
+   *
+   * Server-first: when admin returns a complete OSS config in /get_token,
+   * use it verbatim so the STS-issuing account matches the bucket. This is
+   * the only path that works for SDK >= 1.8 (which targets account=primary).
+   *
+   * Env fallback: only kicks in when admin is too old to return
+   * Bucket/Endpoint/Region. The legacy ROCK_OSS_ENABLE gate is enforced at
+   * call sites (e.g. downloadViaOss) only for the env-fallback path.
+   *
+   * Mirrors the Python `OssClient._resolve_config` implementation.
+   */
+  static resolveOssConfig(credentials: OssCredentials): {
+    endpoint: string;
+    bucket: string;
+    region: string;
+    prefix: string;
+    isEnvFallback: boolean;
+  } | null {
+    if (credentials.endpoint && credentials.bucket && credentials.region) {
+      return {
+        endpoint: credentials.endpoint,
+        bucket: credentials.bucket,
+        region: credentials.region,
+        prefix: credentials.prefix ?? '',
+        isEnvFallback: false,
+      };
+    }
+    if (
+      envVars.ROCK_OSS_BUCKET_ENDPOINT &&
+      envVars.ROCK_OSS_BUCKET_NAME &&
+      envVars.ROCK_OSS_BUCKET_REGION
+    ) {
+      return {
+        endpoint: envVars.ROCK_OSS_BUCKET_ENDPOINT,
+        bucket: envVars.ROCK_OSS_BUCKET_NAME,
+        region: envVars.ROCK_OSS_BUCKET_REGION,
+        prefix: '',
+        isEnvFallback: true,
+      };
+    }
+    return null;
+  }
+
   private async setupOss(timeout?: number): Promise<void> {
     const credentials = await this.getOssStsCredentials();
+
+    const resolved = Sandbox.resolveOssConfig(credentials);
+    if (!resolved) {
+      throw new Error(
+        'OSS config unavailable: admin /get_token did not return Bucket/Endpoint/Region and no ROCK_OSS_BUCKET_* env vars are set'
+      );
+    }
+
+    this.ossConfig = resolved;
 
     const OSS = (await import('ali-oss')).default;
 
     // Priority: parameter > env var > default (300000ms = 5 minutes)
     const ossTimeout = timeout ?? envVars.ROCK_OSS_TIMEOUT;
 
+    // ali-oss expects region without "oss-" prefix; endpoint normalization
+    // is handled separately in downloadViaOss when building ossutil commands.
+    const aliRegion = resolved.region.replace(/^oss-/, '');
+
     this.ossBucket = new OSS({
       secure: true, // Use HTTPS for OSS connections
       timeout: ossTimeout,
-      region: envVars.ROCK_OSS_BUCKET_REGION ?? '',
+      region: aliRegion,
       accessKeyId: credentials.accessKeyId,
       accessKeySecret: credentials.accessKeySecret,
       stsToken: credentials.securityToken,
-      bucket: envVars.ROCK_OSS_BUCKET_NAME ?? '',
+      bucket: resolved.bucket,
       refreshSTSToken: async () => {
         const newCreds = await this.getOssStsCredentials();
         return {

--- a/rock/ts-sdk/src/sandbox/oss-secure.test.ts
+++ b/rock/ts-sdk/src/sandbox/oss-secure.test.ts
@@ -513,6 +513,196 @@ describe('nohup mode PATH handling', () => {
 });
 
 /**
+ * Server-first OSS config resolution tests
+ *
+ * Regression guard for: SDK >= 1.8 with stale legacy env vars
+ * (e.g. ROCK_OSS_BUCKET_NAME=xrl-sandbox) must NOT override server-supplied
+ * config. The new admin returns Bucket/Endpoint/Region in /get_token, and the
+ * SDK requests account=primary, so the bucket must match the STS account.
+ */
+describe('Server-first OSS config resolution', () => {
+  let sandbox: Sandbox;
+  let mockPost: jest.Mock;
+  let mockGet: jest.Mock;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockPost = jest.fn();
+    mockGet = jest.fn();
+    mockedAxios.create = jest.fn().mockReturnValue({
+      post: mockPost,
+      get: mockGet,
+    });
+
+    // Deliberately set stale legacy env so we can prove server wins.
+    process.env.ROCK_OSS_ENABLE = 'true';
+    process.env.ROCK_OSS_BUCKET_NAME = 'xrl-sandbox';
+    process.env.ROCK_OSS_BUCKET_REGION = 'cn-hangzhou';
+    process.env.ROCK_OSS_BUCKET_ENDPOINT = 'oss-cn-hangzhou.aliyuncs.com';
+
+    sandbox = new Sandbox({ image: 'test:latest', startupTimeout: 2 });
+
+    mockPost.mockResolvedValueOnce({
+      data: {
+        status: 'Success',
+        result: { sandbox_id: 'test-id', host_name: 'test-host', host_ip: '127.0.0.1' },
+      },
+      headers: {},
+    });
+    mockGet.mockResolvedValue({
+      data: { status: 'Success', result: { is_alive: true } },
+      headers: {},
+    });
+    await sandbox.start();
+  });
+
+  afterEach(() => {
+    delete process.env.ROCK_OSS_ENABLE;
+    delete process.env.ROCK_OSS_BUCKET_NAME;
+    delete process.env.ROCK_OSS_BUCKET_REGION;
+    delete process.env.ROCK_OSS_BUCKET_ENDPOINT;
+  });
+
+  test('getOssStsCredentials requests account=primary', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        status: 'Success',
+        result: {
+          access_key_id: 'STS.PRIMARY',
+          access_key_secret: 'sec',
+          security_token: 'tok',
+          expiration: '2099-01-01T00:00:00Z',
+        },
+      },
+      headers: {},
+    });
+
+    await sandbox.getOssStsCredentials();
+
+    const calledUrl = mockGet.mock.calls.at(-1)?.[0] as string;
+    expect(calledUrl).toContain('/get_token');
+    expect(calledUrl).toContain('account=primary');
+  });
+
+  test('server-supplied Bucket/Endpoint/Region overrides legacy env vars', () => {
+    // New admin returns the primary (chatos-rock) config; stale env says xrl-sandbox.
+    const credentials = {
+      accessKeyId: 'STS.PRIMARY',
+      accessKeySecret: 'sec',
+      securityToken: 'tok',
+      expiration: '2099-01-01T00:00:00Z',
+      endpoint: 'oss-cn-hangzhou.aliyuncs.com',
+      bucket: 'chatos-rock',
+      region: 'cn-hangzhou',
+      prefix: 'rock-transfer/',
+    };
+
+    const resolved = Sandbox.resolveOssConfig(credentials);
+
+    expect(resolved).not.toBeNull();
+    expect(resolved!.bucket).toBe('chatos-rock'); // server, NOT env xrl-sandbox
+    expect(resolved!.endpoint).toBe('oss-cn-hangzhou.aliyuncs.com');
+    expect(resolved!.region).toBe('cn-hangzhou');
+    expect(resolved!.prefix).toBe('rock-transfer/');
+    expect(resolved!.isEnvFallback).toBe(false);
+  });
+
+  test('falls back to env vars when server omits Bucket/Endpoint/Region (old admin)', () => {
+    // Old admin: no endpoint/bucket/region in /get_token response.
+    const credentials = {
+      accessKeyId: 'STS.LEGACY',
+      accessKeySecret: 'sec',
+      securityToken: 'tok',
+      expiration: '2099-01-01T00:00:00Z',
+    };
+
+    const resolved = Sandbox.resolveOssConfig(credentials);
+
+    expect(resolved).not.toBeNull();
+    expect(resolved!.bucket).toBe('xrl-sandbox'); // env fallback
+    expect(resolved!.endpoint).toBe('oss-cn-hangzhou.aliyuncs.com');
+    expect(resolved!.region).toBe('cn-hangzhou');
+    expect(resolved!.isEnvFallback).toBe(true);
+  });
+
+  test('returns null when neither server nor env provides complete config', () => {
+    delete process.env.ROCK_OSS_BUCKET_NAME;
+    delete process.env.ROCK_OSS_BUCKET_REGION;
+    delete process.env.ROCK_OSS_BUCKET_ENDPOINT;
+
+    const credentials = {
+      accessKeyId: 'STS',
+      accessKeySecret: 'sec',
+      securityToken: 'tok',
+      expiration: '2099-01-01T00:00:00Z',
+    };
+
+    expect(Sandbox.resolveOssConfig(credentials)).toBeNull();
+  });
+
+  test('partial server response (missing bucket) falls through to env', () => {
+    const credentials = {
+      accessKeyId: 'STS',
+      accessKeySecret: 'sec',
+      securityToken: 'tok',
+      expiration: '2099-01-01T00:00:00Z',
+      endpoint: 'oss-cn-hangzhou.aliyuncs.com',
+      // bucket missing → server config incomplete → env wins
+      region: 'cn-hangzhou',
+    };
+
+    const resolved = Sandbox.resolveOssConfig(credentials);
+    expect(resolved).not.toBeNull();
+    expect(resolved!.isEnvFallback).toBe(true);
+    expect(resolved!.bucket).toBe('xrl-sandbox');
+  });
+});
+
+/**
+ * OSS object name prefix tests
+ *
+ * Regression guard for: STS tokens from account=primary carry a RAM policy
+ * restricting writes to the advertised Prefix (e.g. "rock-transfer/").
+ * Writing to bucket root returns 403 AccessDenied — both uploadViaOss and
+ * downloadViaOss must prepend the prefix to the object key.
+ */
+describe('Sandbox.buildOssObjectName', () => {
+  test('prepends server-supplied prefix to base name', () => {
+    expect(Sandbox.buildOssObjectName('rock-transfer/', '1700000000-foo.tar.gz'))
+      .toBe('rock-transfer/1700000000-foo.tar.gz');
+  });
+
+  test('normalizes leading and trailing slashes', () => {
+    expect(Sandbox.buildOssObjectName('/rock-transfer/', 'obj')).toBe('rock-transfer/obj');
+    expect(Sandbox.buildOssObjectName('rock-transfer', 'obj')).toBe('rock-transfer/obj');
+    expect(Sandbox.buildOssObjectName('///rock-transfer///', 'obj')).toBe('rock-transfer/obj');
+  });
+
+  test('returns base name unchanged when prefix is empty/null/undefined', () => {
+    expect(Sandbox.buildOssObjectName('', 'obj')).toBe('obj');
+    expect(Sandbox.buildOssObjectName(null, 'obj')).toBe('obj');
+    expect(Sandbox.buildOssObjectName(undefined, 'obj')).toBe('obj');
+  });
+
+  test('returns base name unchanged when prefix is only slashes', () => {
+    expect(Sandbox.buildOssObjectName('/', 'obj')).toBe('obj');
+    expect(Sandbox.buildOssObjectName('////', 'obj')).toBe('obj');
+  });
+
+  test('supports nested multi-segment prefix', () => {
+    expect(Sandbox.buildOssObjectName('rock-transfer/sub/', 'obj'))
+      .toBe('rock-transfer/sub/obj');
+  });
+
+  test('preserves download- prefix on base name', () => {
+    // downloadViaOss uses "download-{ts}-{name}" as base; full key must still
+    // sit under the policy-allowed prefix.
+    expect(Sandbox.buildOssObjectName('rock-transfer/', 'download-123-a.txt'))
+      .toBe('rock-transfer/download-123-a.txt');
+  });
+});
+
+/**
  * OSS timeout configuration tests
  *
  * OSS operations should support configurable timeout via:

--- a/rock/ts-sdk/src/sandbox/oss-secure.test.ts
+++ b/rock/ts-sdk/src/sandbox/oss-secure.test.ts
@@ -71,11 +71,6 @@ describe('OSS client configuration', () => {
       get: mockGet,
     });
 
-    // Set OSS environment variables
-    process.env.ROCK_OSS_ENABLE = 'true';
-    process.env.ROCK_OSS_BUCKET_NAME = 'test-bucket';
-    process.env.ROCK_OSS_BUCKET_REGION = 'cn-hangzhou';
-
     sandbox = new Sandbox({
       image: 'test:latest',
       startupTimeout: 2,
@@ -83,9 +78,6 @@ describe('OSS client configuration', () => {
   });
 
   afterEach(() => {
-    delete process.env.ROCK_OSS_ENABLE;
-    delete process.env.ROCK_OSS_BUCKET_NAME;
-    delete process.env.ROCK_OSS_BUCKET_REGION;
   });
 
   describe('getOssStsCredentials()', () => {
@@ -513,14 +505,13 @@ describe('nohup mode PATH handling', () => {
 });
 
 /**
- * Server-first OSS config resolution tests
+ * Server-only OSS config resolution tests
  *
- * Regression guard for: SDK >= 1.8 with stale legacy env vars
- * (e.g. ROCK_OSS_BUCKET_NAME=xrl-sandbox) must NOT override server-supplied
- * config. The new admin returns Bucket/Endpoint/Region in /get_token, and the
- * SDK requests account=primary, so the bucket must match the STS account.
+ * The SDK resolves OSS config exclusively from the admin /get_token response.
+ * No env-var fallback exists — if the server doesn't return complete config,
+ * OSS is unavailable.
  */
-describe('Server-first OSS config resolution', () => {
+describe('Server-only OSS config resolution', () => {
   let sandbox: Sandbox;
   let mockPost: jest.Mock;
   let mockGet: jest.Mock;
@@ -533,12 +524,6 @@ describe('Server-first OSS config resolution', () => {
       post: mockPost,
       get: mockGet,
     });
-
-    // Deliberately set stale legacy env so we can prove server wins.
-    process.env.ROCK_OSS_ENABLE = 'true';
-    process.env.ROCK_OSS_BUCKET_NAME = 'xrl-sandbox';
-    process.env.ROCK_OSS_BUCKET_REGION = 'cn-hangzhou';
-    process.env.ROCK_OSS_BUCKET_ENDPOINT = 'oss-cn-hangzhou.aliyuncs.com';
 
     sandbox = new Sandbox({ image: 'test:latest', startupTimeout: 2 });
 
@@ -554,13 +539,6 @@ describe('Server-first OSS config resolution', () => {
       headers: {},
     });
     await sandbox.start();
-  });
-
-  afterEach(() => {
-    delete process.env.ROCK_OSS_ENABLE;
-    delete process.env.ROCK_OSS_BUCKET_NAME;
-    delete process.env.ROCK_OSS_BUCKET_REGION;
-    delete process.env.ROCK_OSS_BUCKET_ENDPOINT;
   });
 
   test('getOssStsCredentials requests account=primary', async () => {
@@ -584,8 +562,7 @@ describe('Server-first OSS config resolution', () => {
     expect(calledUrl).toContain('account=primary');
   });
 
-  test('server-supplied Bucket/Endpoint/Region overrides legacy env vars', () => {
-    // New admin returns the primary (chatos-rock) config; stale env says xrl-sandbox.
+  test('resolves config from server response', () => {
     const credentials = {
       accessKeyId: 'STS.PRIMARY',
       accessKeySecret: 'sec',
@@ -600,36 +577,13 @@ describe('Server-first OSS config resolution', () => {
     const resolved = Sandbox.resolveOssConfig(credentials);
 
     expect(resolved).not.toBeNull();
-    expect(resolved!.bucket).toBe('chatos-rock'); // server, NOT env xrl-sandbox
+    expect(resolved!.bucket).toBe('chatos-rock');
     expect(resolved!.endpoint).toBe('oss-cn-hangzhou.aliyuncs.com');
     expect(resolved!.region).toBe('cn-hangzhou');
     expect(resolved!.prefix).toBe('rock-transfer/');
-    expect(resolved!.enabledViaEnv).toBe(false);
   });
 
-  test('falls back to env vars when server omits Bucket/Endpoint/Region (old admin)', () => {
-    // Old admin: no endpoint/bucket/region in /get_token response.
-    const credentials = {
-      accessKeyId: 'STS.LEGACY',
-      accessKeySecret: 'sec',
-      securityToken: 'tok',
-      expiration: '2099-01-01T00:00:00Z',
-    };
-
-    const resolved = Sandbox.resolveOssConfig(credentials);
-
-    expect(resolved).not.toBeNull();
-    expect(resolved!.bucket).toBe('xrl-sandbox'); // env fallback
-    expect(resolved!.endpoint).toBe('oss-cn-hangzhou.aliyuncs.com');
-    expect(resolved!.region).toBe('cn-hangzhou');
-    expect(resolved!.enabledViaEnv).toBe(true);
-  });
-
-  test('returns null when neither server nor env provides complete config', () => {
-    delete process.env.ROCK_OSS_BUCKET_NAME;
-    delete process.env.ROCK_OSS_BUCKET_REGION;
-    delete process.env.ROCK_OSS_BUCKET_ENDPOINT;
-
+  test('returns null when server does not provide complete config', () => {
     const credentials = {
       accessKeyId: 'STS',
       accessKeySecret: 'sec',
@@ -640,21 +594,18 @@ describe('Server-first OSS config resolution', () => {
     expect(Sandbox.resolveOssConfig(credentials)).toBeNull();
   });
 
-  test('partial server response (missing bucket) falls through to env', () => {
+  test('returns null when server response is partial (missing bucket)', () => {
     const credentials = {
       accessKeyId: 'STS',
       accessKeySecret: 'sec',
       securityToken: 'tok',
       expiration: '2099-01-01T00:00:00Z',
       endpoint: 'oss-cn-hangzhou.aliyuncs.com',
-      // bucket missing → server config incomplete → env wins
       region: 'cn-hangzhou',
+      // bucket missing → incomplete → null
     };
 
-    const resolved = Sandbox.resolveOssConfig(credentials);
-    expect(resolved).not.toBeNull();
-    expect(resolved!.enabledViaEnv).toBe(true);
-    expect(resolved!.bucket).toBe('xrl-sandbox');
+    expect(Sandbox.resolveOssConfig(credentials)).toBeNull();
   });
 });
 

--- a/rock/ts-sdk/src/sandbox/oss-secure.test.ts
+++ b/rock/ts-sdk/src/sandbox/oss-secure.test.ts
@@ -604,7 +604,7 @@ describe('Server-first OSS config resolution', () => {
     expect(resolved!.endpoint).toBe('oss-cn-hangzhou.aliyuncs.com');
     expect(resolved!.region).toBe('cn-hangzhou');
     expect(resolved!.prefix).toBe('rock-transfer/');
-    expect(resolved!.isEnvFallback).toBe(false);
+    expect(resolved!.enabledViaEnv).toBe(false);
   });
 
   test('falls back to env vars when server omits Bucket/Endpoint/Region (old admin)', () => {
@@ -622,7 +622,7 @@ describe('Server-first OSS config resolution', () => {
     expect(resolved!.bucket).toBe('xrl-sandbox'); // env fallback
     expect(resolved!.endpoint).toBe('oss-cn-hangzhou.aliyuncs.com');
     expect(resolved!.region).toBe('cn-hangzhou');
-    expect(resolved!.isEnvFallback).toBe(true);
+    expect(resolved!.enabledViaEnv).toBe(true);
   });
 
   test('returns null when neither server nor env provides complete config', () => {
@@ -653,7 +653,7 @@ describe('Server-first OSS config resolution', () => {
 
     const resolved = Sandbox.resolveOssConfig(credentials);
     expect(resolved).not.toBeNull();
-    expect(resolved!.isEnvFallback).toBe(true);
+    expect(resolved!.enabledViaEnv).toBe(true);
     expect(resolved!.bucket).toBe('xrl-sandbox');
   });
 });

--- a/rock/ts-sdk/src/types/responses.ts
+++ b/rock/ts-sdk/src/types/responses.ts
@@ -193,6 +193,13 @@ export const OssCredentialsSchema = z.object({
   accessKeySecret: z.string(),
   securityToken: z.string(),
   expiration: z.string(),
+  // Server-supplied OSS config (optional; only new admin returns these).
+  // When present, takes priority over ROCK_OSS_BUCKET_* env vars so the bucket
+  // matches the STS-issuing account.
+  endpoint: z.string().optional(),
+  bucket: z.string().optional(),
+  region: z.string().optional(),
+  prefix: z.string().optional(),
 });
 
 export type OssCredentials = z.infer<typeof OssCredentialsSchema>;

--- a/tests/integration/sdk/sandbox/test_file_system.py
+++ b/tests/integration/sdk/sandbox/test_file_system.py
@@ -9,7 +9,6 @@ from unittest.mock import Mock
 import oss2
 import pytest
 
-from rock import env_vars
 from rock.actions.sandbox.request import ChmodRequest, ChownRequest, Command, CreateBashSessionRequest, WriteFileRequest
 from rock.actions.sandbox.response import ChmodResponse, ChownResponse, CommandResponse, Observation
 from rock.sdk.sandbox.client import Sandbox
@@ -95,9 +94,18 @@ async def test_download_file(sandbox_instance: Sandbox, monkeypatch):
     assert isinstance(sandbox_instance.fs, LinuxFileSystem)
 
     try:
-        #  Test 1: OSS disabled
-        logger.info("=== Test 1: OSS disabled ===")
-        monkeypatch.setattr(env_vars, "ROCK_OSS_ENABLE", False)
+        #  Test 1: OSS disabled (server returns no OSS config)
+        logger.info("=== Test 1: OSS disabled (no server config) ===")
+
+        async def mock_sts_no_config():
+            return {
+                "AccessKeyId": "mock_ak",
+                "AccessKeySecret": "mock_sk",
+                "SecurityToken": "mock_token",
+                "Expiration": "2026-03-15T00:00:00Z",
+            }
+
+        monkeypatch.setattr(sandbox_instance._oss, "_get_sts_credentials", mock_sts_no_config)
 
         response = await sandbox_instance.fs.download_file(
             remote_path="/tmp/test.txt", local_path=str(tmp_path / "test.txt")
@@ -109,18 +117,16 @@ async def test_download_file(sandbox_instance: Sandbox, monkeypatch):
         ), f"Error message should mention OSS unavailable: {response.message}"
         logger.info("✓ OSS disabled error handling works correctly")
 
-        # Setup mocks for remaining tests
-        monkeypatch.setattr(env_vars, "ROCK_OSS_ENABLE", True)
-        monkeypatch.setattr(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "oss-cn-test.aliyuncs.com")
-        monkeypatch.setattr(env_vars, "ROCK_OSS_BUCKET_NAME", "test-bucket")
-        monkeypatch.setattr(env_vars, "ROCK_OSS_BUCKET_REGION", "cn-test")
-
+        # Setup mocks for remaining tests (server returns full OSS config)
         async def mock_get_sts_credentials():
             return {
                 "AccessKeyId": "mock_ak",
                 "AccessKeySecret": "mock_sk",
                 "SecurityToken": "mock_token",
                 "Expiration": "2026-03-15T00:00:00Z",
+                "Endpoint": "oss-cn-test.aliyuncs.com",
+                "Bucket": "test-bucket",
+                "Region": "cn-test",
             }
 
         monkeypatch.setattr(sandbox_instance._oss, "_get_sts_credentials", mock_get_sts_credentials)

--- a/tests/unit/sdk/sandbox/test_oss_client.py
+++ b/tests/unit/sdk/sandbox/test_oss_client.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from rock import env_vars
 from rock.actions.sandbox.response import DownloadFileResponse, UploadResponse
 from rock.sdk.sandbox.oss_client import OssClient, OssClientConfig
 
@@ -59,134 +58,35 @@ class TestComputeObjectName:
 
 
 class TestResolveConfig:
-    def test_server_response_takes_precedence_over_env(self):
-        # Server-first: even when env is fully set (legacy users who upgrade SDK
-        # but keep ROCK_OSS_BUCKET_NAME=xrl-sandbox), the chatos-rock bucket
-        # advertised by admin must win, otherwise STS<->bucket mismatch -> 403.
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.endpoint"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", "env-bucket"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", "env-region"),
-        ):
-            cfg = OssClient._resolve_config(
-                {
-                    "Endpoint": "srv.endpoint",
-                    "Bucket": "srv-bucket",
-                    "Region": "srv-region",
-                }
-            )
+    def test_complete_server_response_returns_config(self):
+        cfg = OssClient._resolve_config(
+            {"Endpoint": "srv.endpoint", "Bucket": "srv-bucket", "Region": "srv-region"}
+        )
+        assert cfg is not None
         assert cfg.endpoint == "srv.endpoint"
         assert cfg.bucket == "srv-bucket"
         assert cfg.region == "srv-region"
-        assert cfg.enabled_via_env is False
+        assert cfg.prefix == ""
 
-    def test_env_fallback_used_when_server_response_empty(self):
-        # Old admin that does not yet return Bucket/Endpoint/Region must keep working.
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.endpoint"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", "env-bucket"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", "env-region"),
-        ):
-            cfg = OssClient._resolve_config({})
-        assert cfg.endpoint == "env.endpoint"
-        assert cfg.bucket == "env-bucket"
-        assert cfg.region == "env-region"
-        assert cfg.enabled_via_env is True
-
-    def test_server_partial_response_falls_back_to_env(self):
-        # Server returns Endpoint/Bucket but no Region -> incomplete, must use env.
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.endpoint"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", "env-bucket"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", "env-region"),
-        ):
-            cfg = OssClient._resolve_config({"Endpoint": "srv", "Bucket": "b", "Region": None})
-        assert cfg.endpoint == "env.endpoint"
-        assert cfg.enabled_via_env is True
-
-    def test_server_used_when_env_not_all_set(self):
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
-        ):
-            cfg = OssClient._resolve_config(
-                {
-                    "Endpoint": "srv.endpoint",
-                    "Bucket": "srv-bucket",
-                    "Region": "srv-region",
-                }
-            )
-        assert cfg.endpoint == "srv.endpoint"
-        assert cfg.enabled_via_env is False
-
-    def test_partial_env_does_not_promote_to_fallback(self):
-        # Only endpoint set; bucket / region missing -> env fallback incomplete, must use server.
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.endpoint"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
-        ):
-            cfg = OssClient._resolve_config(
-                {
-                    "Endpoint": "srv.endpoint",
-                    "Bucket": "srv-bucket",
-                    "Region": "srv-region",
-                }
-            )
-        assert cfg.endpoint == "srv.endpoint"
-        assert cfg.enabled_via_env is False
-
-    def test_returns_none_when_neither_layer_complete(self):
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
-        ):
-            cfg = OssClient._resolve_config({"Endpoint": None, "Bucket": None, "Region": None})
-        assert cfg is None
-
-    def test_server_partial_and_env_empty_returns_none(self):
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
-        ):
-            cfg = OssClient._resolve_config({"Endpoint": "x", "Bucket": "y", "Region": None})
-        assert cfg is None
-
-    def test_empty_dict_and_empty_env_returns_none(self):
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
-        ):
-            cfg = OssClient._resolve_config({})
-        assert cfg is None
-
-    def test_server_prefix_wins_when_server_config_used(self):
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
-            patch.object(env_vars, "ROCK_OSS_TRANSFER_PREFIX", "env-prefix/"),
-        ):
-            cfg = OssClient._resolve_config(
-                {"Endpoint": "srv", "Bucket": "b", "Region": "r", "Prefix": "rock-transfer/"}
-            )
+    def test_server_response_with_prefix(self):
+        cfg = OssClient._resolve_config(
+            {"Endpoint": "srv", "Bucket": "b", "Region": "r", "Prefix": "rock-transfer/"}
+        )
+        assert cfg is not None
         assert cfg.prefix == "rock-transfer/"
-        assert cfg.enabled_via_env is False
 
-    def test_env_fallback_uses_env_prefix(self):
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.ep"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", "env-b"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", "env-r"),
-            patch.object(env_vars, "ROCK_OSS_TRANSFER_PREFIX", "env-prefix/"),
-        ):
-            cfg = OssClient._resolve_config({})
-        assert cfg.enabled_via_env is True
-        assert cfg.prefix == "env-prefix/"
+    def test_partial_server_response_returns_none(self):
+        # Missing Region → incomplete
+        cfg = OssClient._resolve_config({"Endpoint": "srv", "Bucket": "b", "Region": None})
+        assert cfg is None
+
+    def test_empty_response_returns_none(self):
+        cfg = OssClient._resolve_config({})
+        assert cfg is None
+
+    def test_all_none_returns_none(self):
+        cfg = OssClient._resolve_config({"Endpoint": None, "Bucket": None, "Region": None})
+        assert cfg is None
 
 
 class TestGetStsCredentials:
@@ -253,15 +153,11 @@ class TestIsTokenExpired:
 
 
 class TestSetup:
-    async def test_env_fallback_with_enable_true(self):
+    async def test_server_config_sets_up_bucket(self):
         sandbox = _make_sandbox()
         client = OssClient(sandbox)
 
         with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.endpoint"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", "env-bucket"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", "env-region"),
-            patch.object(env_vars, "ROCK_OSS_ENABLE", True),
             patch("rock.sdk.sandbox.oss_client.HttpUtils") as mock_http,
             patch("rock.sdk.sandbox.oss_client.oss2") as mock_oss2,
         ):
@@ -273,6 +169,9 @@ class TestSetup:
                         "AccessKeySecret": "sk",
                         "SecurityToken": "tok",
                         "Expiration": "2099-01-01T00:00:00Z",
+                        "Endpoint": "srv.endpoint",
+                        "Bucket": "srv-bucket",
+                        "Region": "srv-region",
                     },
                 }
             )
@@ -283,118 +182,15 @@ class TestSetup:
         assert client.is_available is True
         mock_oss2.Bucket.assert_called_once()
         kwargs = mock_oss2.Bucket.call_args.kwargs
-        assert kwargs["endpoint"] == "env.endpoint"
-        assert kwargs["bucket_name"] == "env-bucket"
-
-    async def test_env_fallback_with_enable_false_returns_unavailable(self):
-        sandbox = _make_sandbox()
-        client = OssClient(sandbox)
-
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.endpoint"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", "env-bucket"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", "env-region"),
-            patch.object(env_vars, "ROCK_OSS_ENABLE", False),
-            patch("rock.sdk.sandbox.oss_client.HttpUtils") as mock_http,
-        ):
-            mock_http.get = AsyncMock(
-                return_value={
-                    "status": "Success",
-                    "result": {
-                        "AccessKeyId": "ak",
-                        "AccessKeySecret": "sk",
-                        "SecurityToken": "tok",
-                        "Expiration": "2099-01-01T00:00:00Z",
-                    },
-                }
-            )
-            ok = await client.ensure_setup()
-
-        assert ok is False
-        assert client.is_available is False
-
-    async def test_server_response_used_even_when_env_set_and_enable_false(self):
-        # Core fix: a user who keeps legacy env vars (e.g. xrl-sandbox) AND has
-        # ROCK_OSS_ENABLE unset/false must still get OSS via the new server path
-        # whenever admin advertises a complete config. Server response wins.
-        sandbox = _make_sandbox()
-        client = OssClient(sandbox)
-
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.endpoint"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", "env-bucket"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", "env-region"),
-            patch.object(env_vars, "ROCK_OSS_ENABLE", False),
-            patch("rock.sdk.sandbox.oss_client.HttpUtils") as mock_http,
-            patch("rock.sdk.sandbox.oss_client.oss2") as mock_oss2,
-        ):
-            mock_http.get = AsyncMock(
-                return_value={
-                    "status": "Success",
-                    "result": {
-                        "AccessKeyId": "ak",
-                        "AccessKeySecret": "sk",
-                        "SecurityToken": "tok",
-                        "Expiration": "2099-01-01T00:00:00Z",
-                        "Endpoint": "srv.endpoint",
-                        "Bucket": "srv-bucket",
-                        "Region": "srv-region",
-                    },
-                }
-            )
-            mock_oss2.Bucket = MagicMock(return_value="bucket-instance")
-            ok = await client.ensure_setup()
-
-        assert ok is True
-        kwargs = mock_oss2.Bucket.call_args.kwargs
-        # Server values, not env values
         assert kwargs["endpoint"] == "srv.endpoint"
         assert kwargs["bucket_name"] == "srv-bucket"
         assert kwargs["region"] == "srv-region"
 
-    async def test_server_response_used_when_env_unset(self):
+    async def test_unavailable_when_server_does_not_return_config(self):
         sandbox = _make_sandbox()
         client = OssClient(sandbox)
 
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
-            patch("rock.sdk.sandbox.oss_client.HttpUtils") as mock_http,
-            patch("rock.sdk.sandbox.oss_client.oss2") as mock_oss2,
-        ):
-            mock_http.get = AsyncMock(
-                return_value={
-                    "status": "Success",
-                    "result": {
-                        "AccessKeyId": "ak",
-                        "AccessKeySecret": "sk",
-                        "SecurityToken": "tok",
-                        "Expiration": "2099-01-01T00:00:00Z",
-                        "Endpoint": "srv.endpoint",
-                        "Bucket": "srv-bucket",
-                        "Region": "srv-region",
-                    },
-                }
-            )
-            mock_oss2.Bucket = MagicMock(return_value="bucket-instance")
-            ok = await client.ensure_setup()
-
-        assert ok is True
-        assert client.is_available is True
-        kwargs = mock_oss2.Bucket.call_args.kwargs
-        assert kwargs["endpoint"] == "srv.endpoint"
-
-    async def test_unavailable_when_neither_set(self):
-        sandbox = _make_sandbox()
-        client = OssClient(sandbox)
-
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
-            patch("rock.sdk.sandbox.oss_client.HttpUtils") as mock_http,
-        ):
+        with patch("rock.sdk.sandbox.oss_client.HttpUtils") as mock_http:
             mock_http.get = AsyncMock(
                 return_value={
                     "status": "Success",
@@ -581,7 +377,7 @@ class TestDownloadViaOss:
 
         client = OssClient(sandbox)
         client._bucket = MagicMock()
-        client._client_config = OssClientConfig("ep", "bk", "rg", enabled_via_env=False)
+        client._client_config = OssClientConfig("ep", "bk", "rg")
 
         response = await client.download_via_oss("/sandbox/foo.txt", tmp_path / "foo.txt")
         assert response.success is False

--- a/tests/unit/sdk/sandbox/test_oss_client.py
+++ b/tests/unit/sdk/sandbox/test_oss_client.py
@@ -78,7 +78,7 @@ class TestResolveConfig:
         assert cfg.endpoint == "srv.endpoint"
         assert cfg.bucket == "srv-bucket"
         assert cfg.region == "srv-region"
-        assert cfg.is_env_fallback is False
+        assert cfg.enabled_via_env is False
 
     def test_env_fallback_used_when_server_response_empty(self):
         # Old admin that does not yet return Bucket/Endpoint/Region must keep working.
@@ -91,7 +91,7 @@ class TestResolveConfig:
         assert cfg.endpoint == "env.endpoint"
         assert cfg.bucket == "env-bucket"
         assert cfg.region == "env-region"
-        assert cfg.is_env_fallback is True
+        assert cfg.enabled_via_env is True
 
     def test_server_partial_response_falls_back_to_env(self):
         # Server returns Endpoint/Bucket but no Region -> incomplete, must use env.
@@ -102,7 +102,7 @@ class TestResolveConfig:
         ):
             cfg = OssClient._resolve_config({"Endpoint": "srv", "Bucket": "b", "Region": None})
         assert cfg.endpoint == "env.endpoint"
-        assert cfg.is_env_fallback is True
+        assert cfg.enabled_via_env is True
 
     def test_server_used_when_env_not_all_set(self):
         with (
@@ -118,7 +118,7 @@ class TestResolveConfig:
                 }
             )
         assert cfg.endpoint == "srv.endpoint"
-        assert cfg.is_env_fallback is False
+        assert cfg.enabled_via_env is False
 
     def test_partial_env_does_not_promote_to_fallback(self):
         # Only endpoint set; bucket / region missing -> env fallback incomplete, must use server.
@@ -135,7 +135,7 @@ class TestResolveConfig:
                 }
             )
         assert cfg.endpoint == "srv.endpoint"
-        assert cfg.is_env_fallback is False
+        assert cfg.enabled_via_env is False
 
     def test_returns_none_when_neither_layer_complete(self):
         with (
@@ -175,7 +175,7 @@ class TestResolveConfig:
                 {"Endpoint": "srv", "Bucket": "b", "Region": "r", "Prefix": "rock-transfer/"}
             )
         assert cfg.prefix == "rock-transfer/"
-        assert cfg.is_env_fallback is False
+        assert cfg.enabled_via_env is False
 
     def test_env_fallback_uses_env_prefix(self):
         with (
@@ -185,7 +185,7 @@ class TestResolveConfig:
             patch.object(env_vars, "ROCK_OSS_TRANSFER_PREFIX", "env-prefix/"),
         ):
             cfg = OssClient._resolve_config({})
-        assert cfg.is_env_fallback is True
+        assert cfg.enabled_via_env is True
         assert cfg.prefix == "env-prefix/"
 
 
@@ -581,7 +581,7 @@ class TestDownloadViaOss:
 
         client = OssClient(sandbox)
         client._bucket = MagicMock()
-        client._client_config = OssClientConfig("ep", "bk", "rg", is_env_fallback=False)
+        client._client_config = OssClientConfig("ep", "bk", "rg", enabled_via_env=False)
 
         response = await client.download_via_oss("/sandbox/foo.txt", tmp_path / "foo.txt")
         assert response.success is False

--- a/tests/unit/sdk/sandbox/test_oss_client.py
+++ b/tests/unit/sdk/sandbox/test_oss_client.py
@@ -59,7 +59,10 @@ class TestComputeObjectName:
 
 
 class TestResolveConfig:
-    def test_layer1_env_takes_precedence_over_server(self):
+    def test_server_response_takes_precedence_over_env(self):
+        # Server-first: even when env is fully set (legacy users who upgrade SDK
+        # but keep ROCK_OSS_BUCKET_NAME=xrl-sandbox), the chatos-rock bucket
+        # advertised by admin must win, otherwise STS<->bucket mismatch -> 403.
         with (
             patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.endpoint"),
             patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", "env-bucket"),
@@ -72,12 +75,36 @@ class TestResolveConfig:
                     "Region": "srv-region",
                 }
             )
+        assert cfg.endpoint == "srv.endpoint"
+        assert cfg.bucket == "srv-bucket"
+        assert cfg.region == "srv-region"
+        assert cfg.is_env_fallback is False
+
+    def test_env_fallback_used_when_server_response_empty(self):
+        # Old admin that does not yet return Bucket/Endpoint/Region must keep working.
+        with (
+            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.endpoint"),
+            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", "env-bucket"),
+            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", "env-region"),
+        ):
+            cfg = OssClient._resolve_config({})
         assert cfg.endpoint == "env.endpoint"
         assert cfg.bucket == "env-bucket"
         assert cfg.region == "env-region"
-        assert cfg.enabled_via_env is True
+        assert cfg.is_env_fallback is True
 
-    def test_layer2_used_when_env_not_all_set(self):
+    def test_server_partial_response_falls_back_to_env(self):
+        # Server returns Endpoint/Bucket but no Region -> incomplete, must use env.
+        with (
+            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.endpoint"),
+            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", "env-bucket"),
+            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", "env-region"),
+        ):
+            cfg = OssClient._resolve_config({"Endpoint": "srv", "Bucket": "b", "Region": None})
+        assert cfg.endpoint == "env.endpoint"
+        assert cfg.is_env_fallback is True
+
+    def test_server_used_when_env_not_all_set(self):
         with (
             patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
             patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
@@ -91,10 +118,10 @@ class TestResolveConfig:
                 }
             )
         assert cfg.endpoint == "srv.endpoint"
-        assert cfg.enabled_via_env is False
+        assert cfg.is_env_fallback is False
 
-    def test_partial_env_does_not_promote_to_layer1(self):
-        # Only endpoint set; bucket / region missing -> not Layer 1, fall back to Layer 2
+    def test_partial_env_does_not_promote_to_fallback(self):
+        # Only endpoint set; bucket / region missing -> env fallback incomplete, must use server.
         with (
             patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.endpoint"),
             patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
@@ -108,9 +135,9 @@ class TestResolveConfig:
                 }
             )
         assert cfg.endpoint == "srv.endpoint"
-        assert cfg.enabled_via_env is False
+        assert cfg.is_env_fallback is False
 
-    def test_layer3_returns_none_when_neither_layer_complete(self):
+    def test_returns_none_when_neither_layer_complete(self):
         with (
             patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
             patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
@@ -119,8 +146,7 @@ class TestResolveConfig:
             cfg = OssClient._resolve_config({"Endpoint": None, "Bucket": None, "Region": None})
         assert cfg is None
 
-    def test_server_partial_treated_as_unavailable(self):
-        # Server returns endpoint/bucket but no region -> Layer 2 incomplete -> unavailable
+    def test_server_partial_and_env_empty_returns_none(self):
         with (
             patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
             patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
@@ -129,7 +155,7 @@ class TestResolveConfig:
             cfg = OssClient._resolve_config({"Endpoint": "x", "Bucket": "y", "Region": None})
         assert cfg is None
 
-    def test_empty_dict_returns_none(self):
+    def test_empty_dict_and_empty_env_returns_none(self):
         with (
             patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
             patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
@@ -137,6 +163,30 @@ class TestResolveConfig:
         ):
             cfg = OssClient._resolve_config({})
         assert cfg is None
+
+    def test_server_prefix_wins_when_server_config_used(self):
+        with (
+            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
+            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
+            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
+            patch.object(env_vars, "ROCK_OSS_TRANSFER_PREFIX", "env-prefix/"),
+        ):
+            cfg = OssClient._resolve_config(
+                {"Endpoint": "srv", "Bucket": "b", "Region": "r", "Prefix": "rock-transfer/"}
+            )
+        assert cfg.prefix == "rock-transfer/"
+        assert cfg.is_env_fallback is False
+
+    def test_env_fallback_uses_env_prefix(self):
+        with (
+            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.ep"),
+            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", "env-b"),
+            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", "env-r"),
+            patch.object(env_vars, "ROCK_OSS_TRANSFER_PREFIX", "env-prefix/"),
+        ):
+            cfg = OssClient._resolve_config({})
+        assert cfg.is_env_fallback is True
+        assert cfg.prefix == "env-prefix/"
 
 
 class TestGetStsCredentials:
@@ -203,7 +253,7 @@ class TestIsTokenExpired:
 
 
 class TestSetup:
-    async def test_layer1_env_with_enable_true(self):
+    async def test_env_fallback_with_enable_true(self):
         sandbox = _make_sandbox()
         client = OssClient(sandbox)
 
@@ -236,7 +286,7 @@ class TestSetup:
         assert kwargs["endpoint"] == "env.endpoint"
         assert kwargs["bucket_name"] == "env-bucket"
 
-    async def test_layer1_env_with_enable_false_returns_unavailable(self):
+    async def test_env_fallback_with_enable_false_returns_unavailable(self):
         sandbox = _make_sandbox()
         client = OssClient(sandbox)
 
@@ -263,7 +313,46 @@ class TestSetup:
         assert ok is False
         assert client.is_available is False
 
-    async def test_layer2_server_response_used_when_env_unset(self):
+    async def test_server_response_used_even_when_env_set_and_enable_false(self):
+        # Core fix: a user who keeps legacy env vars (e.g. xrl-sandbox) AND has
+        # ROCK_OSS_ENABLE unset/false must still get OSS via the new server path
+        # whenever admin advertises a complete config. Server response wins.
+        sandbox = _make_sandbox()
+        client = OssClient(sandbox)
+
+        with (
+            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.endpoint"),
+            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", "env-bucket"),
+            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", "env-region"),
+            patch.object(env_vars, "ROCK_OSS_ENABLE", False),
+            patch("rock.sdk.sandbox.oss_client.HttpUtils") as mock_http,
+            patch("rock.sdk.sandbox.oss_client.oss2") as mock_oss2,
+        ):
+            mock_http.get = AsyncMock(
+                return_value={
+                    "status": "Success",
+                    "result": {
+                        "AccessKeyId": "ak",
+                        "AccessKeySecret": "sk",
+                        "SecurityToken": "tok",
+                        "Expiration": "2099-01-01T00:00:00Z",
+                        "Endpoint": "srv.endpoint",
+                        "Bucket": "srv-bucket",
+                        "Region": "srv-region",
+                    },
+                }
+            )
+            mock_oss2.Bucket = MagicMock(return_value="bucket-instance")
+            ok = await client.ensure_setup()
+
+        assert ok is True
+        kwargs = mock_oss2.Bucket.call_args.kwargs
+        # Server values, not env values
+        assert kwargs["endpoint"] == "srv.endpoint"
+        assert kwargs["bucket_name"] == "srv-bucket"
+        assert kwargs["region"] == "srv-region"
+
+    async def test_server_response_used_when_env_unset(self):
         sandbox = _make_sandbox()
         client = OssClient(sandbox)
 
@@ -296,7 +385,7 @@ class TestSetup:
         kwargs = mock_oss2.Bucket.call_args.kwargs
         assert kwargs["endpoint"] == "srv.endpoint"
 
-    async def test_layer3_unavailable_when_neither_set(self):
+    async def test_unavailable_when_neither_set(self):
         sandbox = _make_sandbox()
         client = OssClient(sandbox)
 
@@ -492,7 +581,7 @@ class TestDownloadViaOss:
 
         client = OssClient(sandbox)
         client._bucket = MagicMock()
-        client._client_config = OssClientConfig("ep", "bk", "rg", enabled_via_env=False)
+        client._client_config = OssClientConfig("ep", "bk", "rg", is_env_fallback=False)
 
         response = await client.download_via_oss("/sandbox/foo.txt", tmp_path / "foo.txt")
         assert response.success is False


### PR DESCRIPTION
## Summary

Two SDK-side fixes for OSS upload/download flows on the **primary** OSS account (`chatos-rock`). No admin / server changes required — the admin contract has been correct since `6e8549ca6` (2026-05-15); this PR makes both SDKs honor it.

1. **Server-first OSS config resolution** (Python + TS). When `/get_token` advertises `Bucket` / `Endpoint` / `Region`, those values are used verbatim. `ROCK_OSS_BUCKET_NAME` / `_ENDPOINT` / `_REGION` are now consulted only as fallback for older admin servers that don't advertise the full config. Fixes `403 AccessDenied` on hosts that still have stale legacy env vars (`ROCK_OSS_BUCKET_NAME=xrl-sandbox`) while admin is configured for the primary account.
2. **`account=primary` by default** (Python + TS). `getOssStsCredentials()` explicitly requests `?account=primary` so the STS-issuing account matches the bucket the server advertises. Previously it sent no query string and admin defaulted to `legacy`, producing a token/bucket mismatch.
3. **Prefix-aware object keys** (TS SDK only — Python was already correct). `uploadViaOss` / `downloadViaOss` now prepend `ossConfig.prefix` (typically `rock-transfer/`) to the OSS object key. Fixes `403 AccessDenied` from the RAM policy on primary-account STS tokens, which only permit writes under the advertised prefix. Mirrors Python SDK's existing `OssClient._compute_object_name` behavior.


## Files touched

Python SDK:

- `rock/sdk/sandbox/oss_client.py` — server-first resolution helper, prefix-aware `_compute_object_name`.
- `tests/unit/sdk/sandbox/test_oss_client.py` — 48 tests covering server-first / env-fallback resolution + prefix prepending.

TS SDK:

- `rock/ts-sdk/src/types/responses.ts` — extend `OssCredentialsSchema` with optional server-supplied `endpoint`, `bucket`, `region`, `prefix`.
- `rock/ts-sdk/src/sandbox/client.ts`:
  - New `Sandbox.resolveOssConfig(credentials)` static helper (mirrors Python `OssClient._resolve_config`, server-first + env fallback).
  - New `Sandbox.buildOssObjectName(prefix, baseName)` static helper (mirrors Python `_compute_object_name`, normalizes slashes).
  - `getOssStsCredentials` now hits `/get_token?account=primary`.
  - `setupOss` uses `resolveOssConfig` to populate the private `ossConfig` field.
  - `uploadViaOss` / `downloadViaOss` build object keys via `buildOssObjectName(this.ossConfig?.prefix, ...)`.
- `rock/ts-sdk/src/sandbox/oss-secure.test.ts` — 55 tests total (49 prior + 6 new for `buildOssObjectName`).
- `rock/ts-sdk/CHANGELOG.md` — Unreleased entries under Changed / Added / Fixed.

No files under `rock/admin/`, `rock/sandbox/service/`, `rock/proxy/`, or any other server path are modified.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Admin returns full OSS config | Env wins if `ROCK_OSS_BUCKET_NAME` set; server values ignored. | Server values used verbatim. |
| Admin returns partial OSS config (no `Bucket`) | Env used. | Env used (unchanged — fallback path). |
| Old admin (no OSS config in response) | Env required, `ROCK_OSS_ENABLE` gate. | Same (unchanged). |
| TS SDK upload object key | `1700000000-foo.tar.gz` (bucket root) | `rock-transfer/1700000000-foo.tar.gz` |
| `getOssStsCredentials` query | _(empty, admin defaults to `legacy`)_ | `?account=primary` |

## Compatibility

- **Old admin + new SDK**: no server fields in the response → SDK falls through to env vars, exactly the pre-1.8 code path. No regression.
- **New admin + old SDK**: SDK still reads env vars first; server fields are silently ignored. No regression (this is the pre-fix state we are moving away from, but it remains a valid configuration).
- **`ROCK_OSS_FORCE_ENV_OVERRIDE`**: NOT introduced. The design intentionally leaves no escape hatch for "env wins over server"; if a cluster genuinely needs to override the bucket, the admin config should be fixed instead.
- **`ROCK_OSS_ENABLE`**: still gates the env-fallback path. No longer required when the server supplies a complete OSS config (matches `StorageClient` behavior).

## Test plan

- [x] `pytest tests/unit/sdk/sandbox/test_oss_client.py -q` → 48/48 pass
- [x] `npx jest src/sandbox/oss-secure.test.ts` → 55/55 pass (incl. 6 new `buildOssObjectName` cases: empty / null / undefined / slash-normalization / slashes-only / nested multi-segment prefix)
- [x] `npx tsc --noEmit` clean on OSS-related files
- [x] Manual e2e (pre-prod cluster, primary account):
  - [ ] `sandbox.fs.upload_file` for both <1 MB and >1 MB files (admin path vs OSS direct path) returns success and object lands under the advertised prefix in OSS console.
  - [ ] `sandbox.fs.download_file` returns matching content.
  - [ ] TS SDK `uploadFile` / `downloadFile` against the same sandbox succeeds and object is correctly prefixed.
  - [ ] With `ROCK_OSS_BUCKET_NAME=xrl-sandbox` deliberately set on the client host, transfers still succeed (server config wins).
  - [ ] On a host with NO `ROCK_OSS_BUCKET_*` env vars and an older admin that does not advertise OSS config, the env-fallback path still works (regression guard).

## Rollout

- SDK-only — ship as a normal SDK minor release. No coordinated admin rollout required.
- Recommended: announce in SDK changelog and ROCK release notes that legacy `ROCK_OSS_BUCKET_*` env vars are now optional and effectively ignored when admin advertises OSS config.

## Notes

- `Sandbox.resolveOssConfig` and `Sandbox.buildOssObjectName` are exposed as `static` to keep them pure/testable without instantiating `ali-oss` (which is dynamically imported and hard to mock under ts-jest ESM).
- Fix deliberately does NOT change wire-level behavior of any admin endpoint and does NOT add any new fields to admin responses. Only the SDK's interpretation of existing fields changes.

Fixes #1143 