### PR TITLE
feat(sdk-py): server-first OSS config + prefix-aware object keys (hardened)

### DIFF
--- a/rock/sdk/sandbox/oss_client.py
+++ b/rock/sdk/sandbox/oss_client.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import re
 import shlex
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -16,7 +17,6 @@ from typing import TYPE_CHECKING
 
 import oss2
 
-from rock import env_vars
 from rock.actions.sandbox.request import Command
 from rock.actions.sandbox.response import DownloadFileResponse, UploadResponse
 from rock.logger import init_logger
@@ -30,13 +30,12 @@ logger = init_logger(__name__)
 
 @dataclass
 class OssClientConfig:
-    """Resolved OSS configuration (Layer 1 env or Layer 2 server)."""
+    """Resolved OSS configuration from admin /get_token response."""
 
     endpoint: str
     bucket: str
     region: str
-    enabled_via_env: bool  # True = Layer 1 (gated by ROCK_OSS_ENABLE); False = Layer 2
-    prefix: str = ""  # Transfer-object key prefix (Layer 1 from env; Layer 2 from server response)
+    prefix: str = ""  # Transfer-object key prefix from server response (e.g. "rock-transfer/")
 
 
 class OssClient:
@@ -63,27 +62,19 @@ class OssClient:
         digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
         filename = Path(sandbox_path).name or Path(local_path).name
         # Honor server-pushed Prefix so chatos-rock's rock-transfer/ lifecycle catches the object.
-        clean_prefix = (prefix or "").strip("/")
+        # Sanitize: trim whitespace, strip leading/trailing slashes, collapse internal "//" runs.
+        # Without this, a stray prefix like " ", "/rock-transfer/" or "rock//transfer" would
+        # produce a malformed OSS key (e.g. "   /file", "//file", "rock//transfer/file").
+        clean_prefix = re.sub(r"/+", "/", (prefix or "").strip().strip("/"))
+        clean_filename = f"{digest}-{filename}".lstrip("/")
         if clean_prefix:
-            return f"{clean_prefix}/{digest}-{filename}"
-        return f"{digest}-{filename}"
+            return f"{clean_prefix}/{clean_filename}"
+        return clean_filename
 
     @staticmethod
     def _resolve_config(sts_response: dict) -> OssClientConfig | None:
-        # Layer 1: env var (highest priority)
-        env_endpoint = env_vars.ROCK_OSS_BUCKET_ENDPOINT
-        env_bucket = env_vars.ROCK_OSS_BUCKET_NAME
-        env_region = env_vars.ROCK_OSS_BUCKET_REGION
-        if env_endpoint and env_bucket and env_region:
-            return OssClientConfig(
-                endpoint=env_endpoint,
-                bucket=env_bucket,
-                region=env_region,
-                enabled_via_env=True,
-                prefix=env_vars.ROCK_OSS_TRANSFER_PREFIX or "",  # NEW: env can carry prefix too
-            )
-
-        # Layer 2: server response (fallback default)
+        # Server-only: admin /get_token must return a complete OSS config.
+        # If it doesn't, OSS is simply unavailable (no env fallback).
         resp_endpoint = sts_response.get("Endpoint")
         resp_bucket = sts_response.get("Bucket")
         resp_region = sts_response.get("Region")
@@ -92,11 +83,10 @@ class OssClient:
                 endpoint=resp_endpoint,
                 bucket=resp_bucket,
                 region=resp_region,
-                enabled_via_env=False,
-                prefix=sts_response.get("Prefix") or "",  # NEW: pull prefix from server
+                prefix=sts_response.get("Prefix") or "",
             )
 
-        # Layer 3: OSS unavailable
+        # OSS unavailable: server did not supply a complete config.
         return None
 
     async def _get_sts_credentials(self) -> dict:
@@ -150,10 +140,6 @@ class OssClient:
 
         config = self._resolve_config(sts_response)
         if config is None:
-            return False
-
-        # Layer 1 also requires ROCK_OSS_ENABLE
-        if config.enabled_via_env and not env_vars.ROCK_OSS_ENABLE:
             return False
 
         try:

--- a/tests/integration/sdk/sandbox/test_file_system.py
+++ b/tests/integration/sdk/sandbox/test_file_system.py
@@ -9,7 +9,6 @@ from unittest.mock import Mock
 import oss2
 import pytest
 
-from rock import env_vars
 from rock.actions.sandbox.request import ChmodRequest, ChownRequest, Command, CreateBashSessionRequest, WriteFileRequest
 from rock.actions.sandbox.response import ChmodResponse, ChownResponse, CommandResponse, Observation
 from rock.sdk.sandbox.client import Sandbox
@@ -95,9 +94,18 @@ async def test_download_file(sandbox_instance: Sandbox, monkeypatch):
     assert isinstance(sandbox_instance.fs, LinuxFileSystem)
 
     try:
-        #  Test 1: OSS disabled
-        logger.info("=== Test 1: OSS disabled ===")
-        monkeypatch.setattr(env_vars, "ROCK_OSS_ENABLE", False)
+        #  Test 1: OSS disabled (server returns no OSS config)
+        logger.info("=== Test 1: OSS disabled (no server config) ===")
+
+        async def mock_sts_no_config():
+            return {
+                "AccessKeyId": "mock_ak",
+                "AccessKeySecret": "mock_sk",
+                "SecurityToken": "mock_token",
+                "Expiration": "2026-03-15T00:00:00Z",
+            }
+
+        monkeypatch.setattr(sandbox_instance._oss, "_get_sts_credentials", mock_sts_no_config)
 
         response = await sandbox_instance.fs.download_file(
             remote_path="/tmp/test.txt", local_path=str(tmp_path / "test.txt")
@@ -109,18 +117,16 @@ async def test_download_file(sandbox_instance: Sandbox, monkeypatch):
         ), f"Error message should mention OSS unavailable: {response.message}"
         logger.info("✓ OSS disabled error handling works correctly")
 
-        # Setup mocks for remaining tests
-        monkeypatch.setattr(env_vars, "ROCK_OSS_ENABLE", True)
-        monkeypatch.setattr(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "oss-cn-test.aliyuncs.com")
-        monkeypatch.setattr(env_vars, "ROCK_OSS_BUCKET_NAME", "test-bucket")
-        monkeypatch.setattr(env_vars, "ROCK_OSS_BUCKET_REGION", "cn-test")
-
+        # Setup mocks for remaining tests (server returns full OSS config)
         async def mock_get_sts_credentials():
             return {
                 "AccessKeyId": "mock_ak",
                 "AccessKeySecret": "mock_sk",
                 "SecurityToken": "mock_token",
                 "Expiration": "2026-03-15T00:00:00Z",
+                "Endpoint": "oss-cn-test.aliyuncs.com",
+                "Bucket": "test-bucket",
+                "Region": "cn-test",
             }
 
         monkeypatch.setattr(sandbox_instance._oss, "_get_sts_credentials", mock_get_sts_credentials)

--- a/tests/unit/sdk/sandbox/test_oss_client.py
+++ b/tests/unit/sdk/sandbox/test_oss_client.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from rock import env_vars
 from rock.actions.sandbox.response import DownloadFileResponse, UploadResponse
 from rock.sdk.sandbox.oss_client import OssClient, OssClientConfig
 
@@ -59,83 +58,34 @@ class TestComputeObjectName:
 
 
 class TestResolveConfig:
-    def test_layer1_env_takes_precedence_over_server(self):
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.endpoint"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", "env-bucket"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", "env-region"),
-        ):
-            cfg = OssClient._resolve_config(
-                {
-                    "Endpoint": "srv.endpoint",
-                    "Bucket": "srv-bucket",
-                    "Region": "srv-region",
-                }
-            )
-        assert cfg.endpoint == "env.endpoint"
-        assert cfg.bucket == "env-bucket"
-        assert cfg.region == "env-region"
-        assert cfg.enabled_via_env is True
-
-    def test_layer2_used_when_env_not_all_set(self):
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
-        ):
-            cfg = OssClient._resolve_config(
-                {
-                    "Endpoint": "srv.endpoint",
-                    "Bucket": "srv-bucket",
-                    "Region": "srv-region",
-                }
-            )
+    def test_complete_server_response_returns_config(self):
+        cfg = OssClient._resolve_config(
+            {"Endpoint": "srv.endpoint", "Bucket": "srv-bucket", "Region": "srv-region"}
+        )
+        assert cfg is not None
         assert cfg.endpoint == "srv.endpoint"
-        assert cfg.enabled_via_env is False
+        assert cfg.bucket == "srv-bucket"
+        assert cfg.region == "srv-region"
+        assert cfg.prefix == ""
 
-    def test_partial_env_does_not_promote_to_layer1(self):
-        # Only endpoint set; bucket / region missing -> not Layer 1, fall back to Layer 2
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.endpoint"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
-        ):
-            cfg = OssClient._resolve_config(
-                {
-                    "Endpoint": "srv.endpoint",
-                    "Bucket": "srv-bucket",
-                    "Region": "srv-region",
-                }
-            )
-        assert cfg.endpoint == "srv.endpoint"
-        assert cfg.enabled_via_env is False
+    def test_server_response_with_prefix(self):
+        cfg = OssClient._resolve_config(
+            {"Endpoint": "srv", "Bucket": "b", "Region": "r", "Prefix": "rock-transfer/"}
+        )
+        assert cfg is not None
+        assert cfg.prefix == "rock-transfer/"
 
-    def test_layer3_returns_none_when_neither_layer_complete(self):
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
-        ):
-            cfg = OssClient._resolve_config({"Endpoint": None, "Bucket": None, "Region": None})
+    def test_partial_server_response_returns_none(self):
+        # Missing Region → incomplete
+        cfg = OssClient._resolve_config({"Endpoint": "srv", "Bucket": "b", "Region": None})
         assert cfg is None
 
-    def test_server_partial_treated_as_unavailable(self):
-        # Server returns endpoint/bucket but no region -> Layer 2 incomplete -> unavailable
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
-        ):
-            cfg = OssClient._resolve_config({"Endpoint": "x", "Bucket": "y", "Region": None})
+    def test_empty_response_returns_none(self):
+        cfg = OssClient._resolve_config({})
         assert cfg is None
 
-    def test_empty_dict_returns_none(self):
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
-        ):
-            cfg = OssClient._resolve_config({})
+    def test_all_none_returns_none(self):
+        cfg = OssClient._resolve_config({"Endpoint": None, "Bucket": None, "Region": None})
         assert cfg is None
 
 
@@ -203,74 +153,11 @@ class TestIsTokenExpired:
 
 
 class TestSetup:
-    async def test_layer1_env_with_enable_true(self):
+    async def test_server_config_sets_up_bucket(self):
         sandbox = _make_sandbox()
         client = OssClient(sandbox)
 
         with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.endpoint"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", "env-bucket"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", "env-region"),
-            patch.object(env_vars, "ROCK_OSS_ENABLE", True),
-            patch("rock.sdk.sandbox.oss_client.HttpUtils") as mock_http,
-            patch("rock.sdk.sandbox.oss_client.oss2") as mock_oss2,
-        ):
-            mock_http.get = AsyncMock(
-                return_value={
-                    "status": "Success",
-                    "result": {
-                        "AccessKeyId": "ak",
-                        "AccessKeySecret": "sk",
-                        "SecurityToken": "tok",
-                        "Expiration": "2099-01-01T00:00:00Z",
-                    },
-                }
-            )
-            mock_oss2.Bucket = MagicMock(return_value="bucket-instance")
-            ok = await client.ensure_setup()
-
-        assert ok is True
-        assert client.is_available is True
-        mock_oss2.Bucket.assert_called_once()
-        kwargs = mock_oss2.Bucket.call_args.kwargs
-        assert kwargs["endpoint"] == "env.endpoint"
-        assert kwargs["bucket_name"] == "env-bucket"
-
-    async def test_layer1_env_with_enable_false_returns_unavailable(self):
-        sandbox = _make_sandbox()
-        client = OssClient(sandbox)
-
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.endpoint"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", "env-bucket"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", "env-region"),
-            patch.object(env_vars, "ROCK_OSS_ENABLE", False),
-            patch("rock.sdk.sandbox.oss_client.HttpUtils") as mock_http,
-        ):
-            mock_http.get = AsyncMock(
-                return_value={
-                    "status": "Success",
-                    "result": {
-                        "AccessKeyId": "ak",
-                        "AccessKeySecret": "sk",
-                        "SecurityToken": "tok",
-                        "Expiration": "2099-01-01T00:00:00Z",
-                    },
-                }
-            )
-            ok = await client.ensure_setup()
-
-        assert ok is False
-        assert client.is_available is False
-
-    async def test_layer2_server_response_used_when_env_unset(self):
-        sandbox = _make_sandbox()
-        client = OssClient(sandbox)
-
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
             patch("rock.sdk.sandbox.oss_client.HttpUtils") as mock_http,
             patch("rock.sdk.sandbox.oss_client.oss2") as mock_oss2,
         ):
@@ -293,19 +180,17 @@ class TestSetup:
 
         assert ok is True
         assert client.is_available is True
+        mock_oss2.Bucket.assert_called_once()
         kwargs = mock_oss2.Bucket.call_args.kwargs
         assert kwargs["endpoint"] == "srv.endpoint"
+        assert kwargs["bucket_name"] == "srv-bucket"
+        assert kwargs["region"] == "srv-region"
 
-    async def test_layer3_unavailable_when_neither_set(self):
+    async def test_unavailable_when_server_does_not_return_config(self):
         sandbox = _make_sandbox()
         client = OssClient(sandbox)
 
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
-            patch("rock.sdk.sandbox.oss_client.HttpUtils") as mock_http,
-        ):
+        with patch("rock.sdk.sandbox.oss_client.HttpUtils") as mock_http:
             mock_http.get = AsyncMock(
                 return_value={
                     "status": "Success",
@@ -492,7 +377,7 @@ class TestDownloadViaOss:
 
         client = OssClient(sandbox)
         client._bucket = MagicMock()
-        client._client_config = OssClientConfig("ep", "bk", "rg", enabled_via_env=False)
+        client._client_config = OssClientConfig("ep", "bk", "rg")
 
         response = await client.download_via_oss("/sandbox/foo.txt", tmp_path / "foo.txt")
         assert response.success is False
@@ -608,3 +493,48 @@ def test_compute_object_name_no_prefix_keeps_legacy_layout():
         sandbox_path="/data/x",
     )
     assert "/" not in name  # flat layout
+
+
+def test_compute_object_name_whitespace_only_prefix_treated_as_empty():
+    """A prefix that is just whitespace must NOT produce '   /<digest>-x'."""
+    name = OssClient._compute_object_name(
+        sandbox_id="sb-1",
+        local_path="/tmp/x",
+        sandbox_path="/data/x",
+        prefix="   ",
+    )
+    assert "/" not in name
+    assert " " not in name
+    assert name.endswith("-x")
+
+
+def test_compute_object_name_collapses_internal_double_slashes():
+    """Server-pushed prefix with stray '//' should be normalized in the OSS key."""
+    name = OssClient._compute_object_name(
+        sandbox_id="sb-1",
+        local_path="/tmp/x",
+        sandbox_path="/data/x",
+        prefix="rock//transfer///",
+    )
+    assert name.startswith("rock/transfer/")
+    assert "//" not in name
+
+
+def test_compute_object_name_none_prefix_is_treated_as_empty():
+    name = OssClient._compute_object_name(
+        sandbox_id="sb-1",
+        local_path="/tmp/x",
+        sandbox_path="/data/x",
+        prefix=None,
+    )
+    assert "/" not in name
+
+
+def test_compute_object_name_empty_string_prefix_is_treated_as_empty():
+    name = OssClient._compute_object_name(
+        sandbox_id="sb-1",
+        local_path="/tmp/x",
+        sandbox_path="/data/x",
+        prefix="",
+    )
+    assert "/" not in name


### PR DESCRIPTION
Closes the Python half of the OSS server-first migration (see paired
issue and the TypeScript PR #<TS_PR_NUMBER>).

## What changes

- **Server-only OSS config.** `OssClient._resolve_config` now requires
  `Endpoint`/`Bucket`/`Region` from `/get_token?account=primary`. If
  the admin does not advertise a complete config, OSS is simply
  unavailable — no env fallback. `ROCK_OSS_BUCKET_NAME`,
  `ROCK_OSS_BUCKET_ENDPOINT`, `ROCK_OSS_BUCKET_REGION`,
  `ROCK_OSS_ENABLE` are no longer read by the SDK.
- **Prefix-aware object keys.** `_compute_object_name` now accepts a
  `prefix` argument (passed in from the resolved server config) and
  produces `{clean_prefix}/{sha256}-{filename}`. Sanitization handles
  None, empty, whitespace-only, leading/trailing slash, and collapses
  internal `//` so the resulting key never starts with `/` and never
  contains `//`.
- **Tests.** `tests/unit/sdk/sandbox/test_oss_client.py` is rewritten
  around the server-only contract and gains 4 new edge tests for
  prefix sanitization. Integration test `test_file_system.py` is
  updated to stop relying on the deleted env vars.

## What does not change

- `ROCK_OSS_TIMEOUT` is still honored.
- Admin server (`sandbox_proxy_service.py`, `env_vars.py`) still reads
  the OSS env vars — that migration is intentionally out of scope here.
- Public function signatures (upload/download) are unchanged.

## Risk & migration

- **Forward-only:** users who still have `ROCK_OSS_BUCKET_*` in their
  env can safely leave them — they are silently ignored.
- **Bucket alignment guarantee:** because both bucket and STS now come
  from the same `/get_token` call, the historical 403 caused by env-vs-
  STS drift is gone by construction.
- **Prefix backward compat:** when the server returns no Prefix the SDK
  falls back to the legacy flat layout, so deployments not yet pushing
  Prefix continue to work.

## Verification

- `pytest tests/unit/sdk/sandbox/test_oss_client.py` → **44 passed**.
- Full unit suite green locally.
- Manual smoke against pre-prod admin (server returns
  `prefix=rock-transfer/`) — uploads land under `rock-transfer/...`,
  RAM policy and lifecycle pick them up.

## File list (3 files, ≤ 8)

- `rock/sdk/sandbox/oss_client.py`
- `tests/unit/sdk/sandbox/test_oss_client.py`
- `tests/integration/sdk/sandbox/test_file_system.py`

Fixes #1150 