### PR TITLE
feat(sdk-ts): server-first OSS config + prefix-aware object keys (hardened) + perf

### DIFF
--- a/rock/ts-sdk/CHANGELOG.md
+++ b/rock/ts-sdk/CHANGELOG.md
@@ -5,6 +5,56 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+
+- **`ROCK_OSS_BUCKET_NAME`, `ROCK_OSS_BUCKET_ENDPOINT`, `ROCK_OSS_BUCKET_REGION` env vars
+  are no longer read by the SDK.** OSS bucket/endpoint/region are now resolved
+  exclusively from the admin `/get_token?account=primary` response. Users who
+  still have these env vars set can safely leave them — they are simply ignored.
+- **`ROCK_OSS_ENABLE` env var is no longer read by the SDK.** OSS availability
+  is determined solely by whether the admin returns a complete config. If the
+  server provides Bucket/Endpoint/Region, OSS is enabled; otherwise it is
+  unavailable. The auto-mode upload/download threshold (1 MB) is unchanged.
+- `resolveOssConfig` no longer returns an `enabledViaEnv` field.
+
+### Changed
+
+- **`getOssStsCredentials()` now requests `account=primary`.** Previously it
+  hit `/get_token` with no query, which the admin defaulted to `legacy`.
+  This ensures the STS-issuing account matches the bucket the server
+  advertises.
+
+### Added
+
+- `Sandbox.resolveOssConfig(credentials)` static helper that resolves OSS
+  config from the server `/get_token` response (returns `null` when incomplete).
+- `Sandbox.buildOssObjectName(prefix, baseName)` static helper that prepends
+  the server-supplied OSS prefix to object keys. Sanitization: whitespace
+  trimmed, leading/trailing slashes stripped, internal duplicate slashes
+  (`rock//transfer`) collapsed, and any leading slashes on `baseName` stripped
+  so the resulting key never produces `//` runs or bucket-root absolute paths.
+- `Sandbox.normalizeRegion(region)` static helper that strips the leading
+  `oss-` prefix accepted by ali-oss / ossutil. Centralizes the previously
+  duplicated `replace(/^oss-/, '')` calls in `setupOss` and `downloadViaOss`.
+
+### Performance
+
+- `downloadViaOss` / `uploadViaOss` now reuse the STS credentials fetched in
+  `setupOss` instead of issuing a second `/get_token` request per transfer.
+  The cache is invalidated together with the bucket via the existing
+  `isTokenExpired()` 5-minute buffer.
+
+### Fixed
+
+- **OSS 403 AccessDenied on uploads/downloads.** `uploadViaOss` and
+  `downloadViaOss` previously wrote to the bucket root (e.g.
+  `1700000000-file.tar.gz`), but primary-account STS tokens carry a RAM
+  policy that only permits writes under the advertised prefix (typically
+  `rock-transfer/`). The SDK now prepends `ossConfig.prefix` to the object
+  key, matching the Python SDK `OssClient._compute_object_name` behavior.
+
 ## [1.3.9] - 2026-03-29
 
 ### Added

--- a/rock/ts-sdk/README.md
+++ b/rock/ts-sdk/README.md
@@ -222,9 +222,7 @@ console.log(result.output);
 | `ROCK_BASE_URL` | ROCK 服务基础 URL | `http://localhost:8080` |
 | `ROCK_ENVHUB_BASE_URL` | EnvHub 服务 URL | `http://localhost:8081` |
 | `ROCK_SANDBOX_STARTUP_TIMEOUT_SECONDS` | 沙箱启动超时时间 | `180` |
-| `ROCK_OSS_ENABLE` | 是否启用 OSS 上传/下载 | `false` |
-| `ROCK_OSS_BUCKET_ENDPOINT` | OSS Endpoint | - |
-| `ROCK_OSS_BUCKET_NAME` | OSS Bucket 名称 | - |
+| `ROCK_OSS_TIMEOUT` | OSS 操作超时时间 (ms) | `300000` |
 
 ### SandboxConfig 选项
 

--- a/rock/ts-sdk/docs/DEVELOPER_GUIDE.md
+++ b/rock/ts-sdk/docs/DEVELOPER_GUIDE.md
@@ -297,10 +297,9 @@ ROCK_ENVHUB_BASE_URL=http://your-envhub-server:8081
 ROCK_SANDBOX_STARTUP_TIMEOUT_SECONDS=300
 
 # OSS 配置 (大文件上传/下载)
-ROCK_OSS_ENABLE=true
-ROCK_OSS_BUCKET_ENDPOINT=https://oss-cn-hangzhou.aliyuncs.com
-ROCK_OSS_BUCKET_NAME=your-bucket
-ROCK_OSS_BUCKET_REGION=oss-cn-hangzhou
+# OSS bucket/endpoint/region 由 admin /get_token 接口自动返回，无需手动配置。
+# 仅 timeout 可通过环境变量覆盖：
+ROCK_OSS_TIMEOUT=300000
 
 # 日志配置
 ROCK_LOGGING_PATH=/var/log/rock
@@ -637,11 +636,7 @@ console.log(`Port mapping: ${JSON.stringify(status.portMapping)}`);
 ### Q: 如何处理大文件上传？
 
 ```typescript
-// 启用 OSS 上传 (> 1MB 自动使用 OSS)
-process.env.ROCK_OSS_ENABLE = 'true';
-process.env.ROCK_OSS_BUCKET_NAME = 'your-bucket';
-// ... 其他 OSS 配置
-
+// > 1MB 自动使用 OSS 上传（OSS 配置由 admin /get_token 自动返回）
 await sandbox.upload({
   sourcePath: './large-file.zip',
   targetPath: '/remote/large-file.zip',

--- a/rock/ts-sdk/src/env_vars.ts
+++ b/rock/ts-sdk/src/env_vars.ts
@@ -99,22 +99,6 @@ export const envVars = {
   },
 
   // OSS
-  get ROCK_OSS_ENABLE(): boolean {
-    return getEnv('ROCK_OSS_ENABLE', 'false')?.toLowerCase() === 'true';
-  },
-
-  get ROCK_OSS_BUCKET_ENDPOINT(): string | undefined {
-    return getEnv('ROCK_OSS_BUCKET_ENDPOINT');
-  },
-
-  get ROCK_OSS_BUCKET_NAME(): string | undefined {
-    return getEnv('ROCK_OSS_BUCKET_NAME');
-  },
-
-  get ROCK_OSS_BUCKET_REGION(): string | undefined {
-    return getEnv('ROCK_OSS_BUCKET_REGION');
-  },
-
   get ROCK_OSS_TIMEOUT(): number {
     return parseInt(getEnv('ROCK_OSS_TIMEOUT', '300000')!, 10); // Default: 5 minutes
   },

--- a/rock/ts-sdk/src/sandbox/client.ts
+++ b/rock/ts-sdk/src/sandbox/client.ts
@@ -111,6 +111,21 @@ export class Sandbox extends AbstractSandbox {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private ossBucket: any = null;
   private ossTokenExpireTime: string = '';
+  // Cache of the most recent STS credentials fetched via getOssStsCredentials.
+  // setupOss already retrieves a token; downloadViaOss/uploadViaOss need the
+  // raw credentials again to pass to the in-sandbox ossutil command. Caching
+  // avoids a second /get_token round trip per transfer (latency-sensitive
+  // path). The cache is invalidated together with the bucket via the existing
+  // isTokenExpired() check.
+  private cachedOssCredentials: OssCredentials | null = null;
+  // Resolved OSS config (server-first; env is only fallback when admin is too
+  // old to advertise Bucket/Endpoint/Region in /get_token).
+  private ossConfig: {
+    endpoint: string;
+    bucket: string;
+    region: string;
+    prefix: string;
+  } | null = null;
 
   // Sub-components
   private deploy: Deploy;
@@ -673,10 +688,9 @@ export class Sandbox extends AbstractSandbox {
       // Check if we should use OSS upload
       const stats = await fs.stat(sourcePath);
       const fileSize = stats.size;
-      const ossEnabled = envVars.ROCK_OSS_ENABLE;
       const ossThreshold = 1024 * 1024; // 1MB
 
-      if (uploadMode === 'oss' || (uploadMode === 'auto' && ossEnabled && fileSize > ossThreshold)) {
+      if (uploadMode === 'oss' || (uploadMode === 'auto' && fileSize > ossThreshold)) {
         return this.uploadViaOss(sourcePath, targetPath, timeout, onProgress);
       }
 
@@ -705,7 +719,10 @@ export class Sandbox extends AbstractSandbox {
    * Get OSS STS credentials from sandbox
    */
   async getOssStsCredentials(): Promise<OssCredentials> {
-    const url = `${this.url}/get_token`;
+    // Always request the primary account: SDK >= 1.8 uses chatos-rock; the
+    // server returns matching Bucket/Endpoint/Region in this case, which the
+    // server-first config resolution relies on.
+    const url = `${this.url}/get_token?account=primary`;
     const headers = this.buildHeaders();
 
     const response = await HttpUtils.get<OssCredentials>(url, headers);
@@ -716,8 +733,25 @@ export class Sandbox extends AbstractSandbox {
 
     const credentials = OssCredentialsSchema.parse(response.result);
     this.ossTokenExpireTime = credentials.expiration;
+    this.cachedOssCredentials = credentials;
 
     return credentials;
+  }
+
+  /**
+   * Return the cached OSS STS credentials when still fresh; otherwise refetch.
+   *
+   * downloadViaOss/uploadViaOss need to pass raw credentials to the in-sandbox
+   * ossutil command. setupOss already fetched a token, so reusing that token
+   * avoids a second /get_token round trip per transfer. The 5-minute expiry
+   * buffer in isTokenExpired() guarantees we refresh before the credentials
+   * actually become invalid mid-transfer.
+   */
+  private async getCachedOssStsCredentials(): Promise<OssCredentials> {
+    if (this.cachedOssCredentials && !this.isTokenExpired()) {
+      return this.cachedOssCredentials;
+    }
+    return this.getOssStsCredentials();
   }
 
   /**
@@ -787,10 +821,9 @@ export class Sandbox extends AbstractSandbox {
 
     const fileSize = parseInt(sizeResult.stdout.trim(), 10);
     const ossThreshold = 1024 * 1024; // 1MB
-    const ossEnabled = envVars.ROCK_OSS_ENABLE;
 
-    // OSS enabled AND file >= 1MB: use OSS
-    if (ossEnabled && fileSize >= ossThreshold) {
+    // File >= 1MB: use OSS (if server provides OSS config, setupOss will succeed)
+    if (fileSize >= ossThreshold) {
       return this.downloadViaOss(remotePath, localPath, timeout, onProgress);
     }
 
@@ -826,21 +859,13 @@ export class Sandbox extends AbstractSandbox {
    * Download file via OSS as intermediary
    */
   private async downloadViaOss(remotePath: string, localPath: string, timeout?: number, onProgress?: (info: ProgressInfo) => void): Promise<DownloadFileResponse> {
-    // Check OSS is enabled
-    if (!envVars.ROCK_OSS_ENABLE) {
-      return {
-        success: false,
-        message: 'OSS download is not enabled. Please set ROCK_OSS_ENABLE=true',
-      };
-    }
-
     try {
       // Setup OSS bucket if needed
       if (this.ossBucket === null || this.isTokenExpired()) {
         await this.setupOss(timeout);
       }
 
-      if (!this.ossBucket) {
+      if (!this.ossBucket || !this.ossConfig) {
         return { success: false, message: 'Failed to setup OSS bucket' };
       }
 
@@ -850,15 +875,18 @@ export class Sandbox extends AbstractSandbox {
       // Generate unique object name
       const timestamp = Date.now();
       const fileName = remotePath.split('/').pop() ?? 'file';
-      const objectName = `download-${timestamp}-${fileName}`;
+      // Prepend server-supplied prefix (e.g. "rock-transfer/") so the OSS key
+      // matches the STS RAM policy. The primary-account STS only permits
+      // writes under this prefix; bucket-root writes return 403 AccessDenied.
+      const objectName = Sandbox.buildOssObjectName(this.ossConfig?.prefix, `download-${timestamp}-${fileName}`);
 
-      // Get STS credentials for ossutil
-      const credentials = await this.getOssStsCredentials();
-      const bucketName = envVars.ROCK_OSS_BUCKET_NAME ?? '';
-      const region = (envVars.ROCK_OSS_BUCKET_REGION ?? '').replace(/^oss-/, ''); // Normalize: remove "oss-" prefix if present
-      // Use ROCK_OSS_BUCKET_ENDPOINT if available, otherwise build from region
-      // Endpoint format: "oss-cn-hangzhou.aliyuncs.com" (no protocol prefix)
-      const endpoint = envVars.ROCK_OSS_BUCKET_ENDPOINT ?? `oss-${region}.aliyuncs.com`;
+      // Get STS credentials for ossutil. setupOss above already fetched and
+      // cached a token; reuse it to avoid a redundant /get_token round trip.
+      const credentials = await this.getCachedOssStsCredentials();
+      const bucketName = this.ossConfig.bucket;
+      const region = Sandbox.normalizeRegion(this.ossConfig.region);
+      // Endpoint comes from resolved config (server or env). Format: "oss-cn-hangzhou.aliyuncs.com".
+      const endpoint = this.ossConfig.endpoint;
 
       // Upload from sandbox to OSS via ossutil v2
       // ossutil v2 uses command-line parameters for credentials (no separate config needed)
@@ -913,7 +941,10 @@ export class Sandbox extends AbstractSandbox {
 
       const timestamp = Date.now();
       const fileName = sourcePath.split('/').pop() ?? 'file';
-      const objectName = `${timestamp}-${fileName}`;
+      // Prepend server-supplied prefix (e.g. "rock-transfer/") so the OSS key
+      // matches the STS RAM policy. The primary-account STS only permits
+      // writes under this prefix; bucket-root writes return 403 AccessDenied.
+      const objectName = Sandbox.buildOssObjectName(this.ossConfig?.prefix, `${timestamp}-${fileName}`);
 
       // Check file size to determine upload method
       const fs = await import('fs/promises');
@@ -977,22 +1008,97 @@ export class Sandbox extends AbstractSandbox {
    * Setup OSS bucket with STS credentials
    * @param timeout - Optional timeout in milliseconds (defaults to ROCK_OSS_TIMEOUT env var or 300000ms)
    */
+  /**
+   * Compose an OSS object key by prepending the server-supplied prefix.
+   *
+   * STS tokens issued by the primary account carry a RAM policy that only
+   * permits writes under the advertised prefix (typically "rock-transfer/").
+   * Writing to the bucket root returns 403 AccessDenied. This helper applies
+   * the prefix consistently for upload and download paths.
+   *
+   * Sanitization:
+   *   - whitespace trimmed
+   *   - leading/trailing slashes stripped
+   *   - internal duplicate slashes collapsed (e.g. "rock//transfer" -> "rock/transfer")
+   *   - leading slashes on baseName stripped (defensive; callers already pass
+   *     `${timestamp}-${name}` which never starts with '/').
+   *
+   * Mirrors the Python `OssClient._compute_object_name` prefix handling.
+   */
+  static buildOssObjectName(prefix: string | undefined | null, baseName: string): string {
+    const clean = (prefix ?? '')
+      .trim()
+      .replace(/^\/+|\/+$/g, '')
+      .replace(/\/+/g, '/');
+    const cleanBase = baseName.replace(/^\/+/, '');
+    return clean ? `${clean}/${cleanBase}` : cleanBase;
+  }
+
+  /**
+   * Normalize an OSS region string for ali-oss / ossutil.
+   *
+   * `ali-oss` rejects region values with the "oss-" prefix; ossutil accepts
+   * either form but is consistent only when normalized. Server responses
+   * sometimes carry the prefix and sometimes don't, so we always strip it.
+   */
+  static normalizeRegion(region: string): string {
+    return region.replace(/^oss-/, '');
+  }
+
+  /**
+   * Resolve OSS config from server response.
+   *
+   * Admin /get_token must return a complete OSS config (Bucket, Endpoint,
+   * Region). If it doesn't, OSS is unavailable (returns null).
+   *
+   * Mirrors the Python `OssClient._resolve_config` implementation.
+   */
+  static resolveOssConfig(credentials: OssCredentials): {
+    endpoint: string;
+    bucket: string;
+    region: string;
+    prefix: string;
+  } | null {
+    if (credentials.endpoint && credentials.bucket && credentials.region) {
+      return {
+        endpoint: credentials.endpoint,
+        bucket: credentials.bucket,
+        region: credentials.region,
+        prefix: credentials.prefix ?? '',
+      };
+    }
+    return null;
+  }
+
   private async setupOss(timeout?: number): Promise<void> {
     const credentials = await this.getOssStsCredentials();
+
+    const resolved = Sandbox.resolveOssConfig(credentials);
+    if (!resolved) {
+      throw new Error(
+        'OSS config unavailable: admin /get_token did not return Bucket/Endpoint/Region'
+      );
+    }
+
+    this.ossConfig = resolved;
 
     const OSS = (await import('ali-oss')).default;
 
     // Priority: parameter > env var > default (300000ms = 5 minutes)
     const ossTimeout = timeout ?? envVars.ROCK_OSS_TIMEOUT;
 
+    // ali-oss expects region without "oss-" prefix; endpoint normalization
+    // is handled separately in downloadViaOss when building ossutil commands.
+    const aliRegion = Sandbox.normalizeRegion(resolved.region);
+
     this.ossBucket = new OSS({
       secure: true, // Use HTTPS for OSS connections
       timeout: ossTimeout,
-      region: envVars.ROCK_OSS_BUCKET_REGION ?? '',
+      region: aliRegion,
       accessKeyId: credentials.accessKeyId,
       accessKeySecret: credentials.accessKeySecret,
       stsToken: credentials.securityToken,
-      bucket: envVars.ROCK_OSS_BUCKET_NAME ?? '',
+      bucket: resolved.bucket,
       refreshSTSToken: async () => {
         const newCreds = await this.getOssStsCredentials();
         return {

--- a/rock/ts-sdk/src/sandbox/oss-secure.test.ts
+++ b/rock/ts-sdk/src/sandbox/oss-secure.test.ts
@@ -71,11 +71,6 @@ describe('OSS client configuration', () => {
       get: mockGet,
     });
 
-    // Set OSS environment variables
-    process.env.ROCK_OSS_ENABLE = 'true';
-    process.env.ROCK_OSS_BUCKET_NAME = 'test-bucket';
-    process.env.ROCK_OSS_BUCKET_REGION = 'cn-hangzhou';
-
     sandbox = new Sandbox({
       image: 'test:latest',
       startupTimeout: 2,
@@ -83,9 +78,6 @@ describe('OSS client configuration', () => {
   });
 
   afterEach(() => {
-    delete process.env.ROCK_OSS_ENABLE;
-    delete process.env.ROCK_OSS_BUCKET_NAME;
-    delete process.env.ROCK_OSS_BUCKET_REGION;
   });
 
   describe('getOssStsCredentials()', () => {
@@ -165,6 +157,122 @@ describe('OSS client configuration', () => {
       });
 
       await expect(sandbox.getOssStsCredentials()).rejects.toThrow();
+    });
+
+    test('caches credentials so a second call within validity window does not refetch', async () => {
+      // Reviewer point 5: setupOss already fetches a token; downloadViaOss
+      // must not issue a redundant /get_token round trip on every transfer.
+      mockPost.mockResolvedValueOnce({
+        data: {
+          status: 'Success',
+          result: {
+            sandbox_id: 'test-id',
+            host_name: 'test-host',
+            host_ip: '127.0.0.1',
+          },
+        },
+        headers: {},
+      });
+      mockGet.mockResolvedValueOnce({
+        data: {
+          status: 'Success',
+          result: { is_alive: true },
+        },
+        headers: {},
+      });
+      await sandbox.start();
+
+      const oneHourLater = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      mockGet.mockResolvedValueOnce({
+        data: {
+          status: 'Success',
+          result: {
+            access_key_id: 'STS.FIRST',
+            access_key_secret: 'S1',
+            security_token: 'T1',
+            expiration: oneHourLater,
+          },
+        },
+        headers: {},
+      });
+
+      // First call hits the network.
+      const first = await sandbox.getOssStsCredentials();
+      expect(first.accessKeyId).toBe('STS.FIRST');
+      const getCallCountAfterFirst = mockGet.mock.calls.length;
+
+      // Second call via the cache helper must NOT call mockGet again while
+      // the token is still fresh.
+      const cached = await (
+        sandbox as unknown as {
+          getCachedOssStsCredentials(): Promise<typeof first>;
+        }
+      ).getCachedOssStsCredentials();
+
+      expect(cached).toBe(first);
+      expect(mockGet.mock.calls.length).toBe(getCallCountAfterFirst);
+    });
+
+    test('refetches credentials when cached token is expired', async () => {
+      mockPost.mockResolvedValueOnce({
+        data: {
+          status: 'Success',
+          result: {
+            sandbox_id: 'test-id',
+            host_name: 'test-host',
+            host_ip: '127.0.0.1',
+          },
+        },
+        headers: {},
+      });
+      mockGet.mockResolvedValueOnce({
+        data: {
+          status: 'Success',
+          result: { is_alive: true },
+        },
+        headers: {},
+      });
+      await sandbox.start();
+
+      const oneHourLater = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      mockGet.mockResolvedValueOnce({
+        data: {
+          status: 'Success',
+          result: {
+            access_key_id: 'STS.FIRST',
+            access_key_secret: 'S1',
+            security_token: 'T1',
+            expiration: oneHourLater,
+          },
+        },
+        headers: {},
+      });
+      await sandbox.getOssStsCredentials();
+
+      // Manually expire the token.
+      (sandbox as unknown as { ossTokenExpireTime: string }).ossTokenExpireTime =
+        '2020-01-01T00:00:00Z';
+
+      mockGet.mockResolvedValueOnce({
+        data: {
+          status: 'Success',
+          result: {
+            access_key_id: 'STS.SECOND',
+            access_key_secret: 'S2',
+            security_token: 'T2',
+            expiration: oneHourLater,
+          },
+        },
+        headers: {},
+      });
+
+      const refreshed = await (
+        sandbox as unknown as {
+          getCachedOssStsCredentials(): Promise<{ accessKeyId: string }>;
+        }
+      ).getCachedOssStsCredentials();
+
+      expect(refreshed.accessKeyId).toBe('STS.SECOND');
     });
   });
 
@@ -509,6 +617,198 @@ describe('nohup mode PATH handling', () => {
     // With bash -c: uses bash which has correct PATH
     const hasBashWrapper = true;
     expect(hasBashWrapper).toBe(true);
+  });
+});
+
+/**
+ * Server-only OSS config resolution tests
+ *
+ * The SDK resolves OSS config exclusively from the admin /get_token response.
+ * No env-var fallback exists — if the server doesn't return complete config,
+ * OSS is unavailable.
+ */
+describe('Server-only OSS config resolution', () => {
+  let sandbox: Sandbox;
+  let mockPost: jest.Mock;
+  let mockGet: jest.Mock;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockPost = jest.fn();
+    mockGet = jest.fn();
+    mockedAxios.create = jest.fn().mockReturnValue({
+      post: mockPost,
+      get: mockGet,
+    });
+
+    sandbox = new Sandbox({ image: 'test:latest', startupTimeout: 2 });
+
+    mockPost.mockResolvedValueOnce({
+      data: {
+        status: 'Success',
+        result: { sandbox_id: 'test-id', host_name: 'test-host', host_ip: '127.0.0.1' },
+      },
+      headers: {},
+    });
+    mockGet.mockResolvedValue({
+      data: { status: 'Success', result: { is_alive: true } },
+      headers: {},
+    });
+    await sandbox.start();
+  });
+
+  test('getOssStsCredentials requests account=primary', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        status: 'Success',
+        result: {
+          access_key_id: 'STS.PRIMARY',
+          access_key_secret: 'sec',
+          security_token: 'tok',
+          expiration: '2099-01-01T00:00:00Z',
+        },
+      },
+      headers: {},
+    });
+
+    await sandbox.getOssStsCredentials();
+
+    const calledUrl = mockGet.mock.calls.at(-1)?.[0] as string;
+    expect(calledUrl).toContain('/get_token');
+    expect(calledUrl).toContain('account=primary');
+  });
+
+  test('resolves config from server response', () => {
+    const credentials = {
+      accessKeyId: 'STS.PRIMARY',
+      accessKeySecret: 'sec',
+      securityToken: 'tok',
+      expiration: '2099-01-01T00:00:00Z',
+      endpoint: 'oss-cn-hangzhou.aliyuncs.com',
+      bucket: 'chatos-rock',
+      region: 'cn-hangzhou',
+      prefix: 'rock-transfer/',
+    };
+
+    const resolved = Sandbox.resolveOssConfig(credentials);
+
+    expect(resolved).not.toBeNull();
+    expect(resolved!.bucket).toBe('chatos-rock');
+    expect(resolved!.endpoint).toBe('oss-cn-hangzhou.aliyuncs.com');
+    expect(resolved!.region).toBe('cn-hangzhou');
+    expect(resolved!.prefix).toBe('rock-transfer/');
+  });
+
+  test('returns null when server does not provide complete config', () => {
+    const credentials = {
+      accessKeyId: 'STS',
+      accessKeySecret: 'sec',
+      securityToken: 'tok',
+      expiration: '2099-01-01T00:00:00Z',
+    };
+
+    expect(Sandbox.resolveOssConfig(credentials)).toBeNull();
+  });
+
+  test('returns null when server response is partial (missing bucket)', () => {
+    const credentials = {
+      accessKeyId: 'STS',
+      accessKeySecret: 'sec',
+      securityToken: 'tok',
+      expiration: '2099-01-01T00:00:00Z',
+      endpoint: 'oss-cn-hangzhou.aliyuncs.com',
+      region: 'cn-hangzhou',
+      // bucket missing → incomplete → null
+    };
+
+    expect(Sandbox.resolveOssConfig(credentials)).toBeNull();
+  });
+});
+
+/**
+ * OSS object name prefix tests
+ *
+ * Regression guard for: STS tokens from account=primary carry a RAM policy
+ * restricting writes to the advertised Prefix (e.g. "rock-transfer/").
+ * Writing to bucket root returns 403 AccessDenied — both uploadViaOss and
+ * downloadViaOss must prepend the prefix to the object key.
+ */
+describe('Sandbox.buildOssObjectName', () => {
+  test('prepends server-supplied prefix to base name', () => {
+    expect(Sandbox.buildOssObjectName('rock-transfer/', '1700000000-foo.tar.gz'))
+      .toBe('rock-transfer/1700000000-foo.tar.gz');
+  });
+
+  test('normalizes leading and trailing slashes', () => {
+    expect(Sandbox.buildOssObjectName('/rock-transfer/', 'obj')).toBe('rock-transfer/obj');
+    expect(Sandbox.buildOssObjectName('rock-transfer', 'obj')).toBe('rock-transfer/obj');
+    expect(Sandbox.buildOssObjectName('///rock-transfer///', 'obj')).toBe('rock-transfer/obj');
+  });
+
+  test('returns base name unchanged when prefix is empty/null/undefined', () => {
+    expect(Sandbox.buildOssObjectName('', 'obj')).toBe('obj');
+    expect(Sandbox.buildOssObjectName(null, 'obj')).toBe('obj');
+    expect(Sandbox.buildOssObjectName(undefined, 'obj')).toBe('obj');
+  });
+
+  test('returns base name unchanged when prefix is only slashes', () => {
+    expect(Sandbox.buildOssObjectName('/', 'obj')).toBe('obj');
+    expect(Sandbox.buildOssObjectName('////', 'obj')).toBe('obj');
+  });
+
+  test('supports nested multi-segment prefix', () => {
+    expect(Sandbox.buildOssObjectName('rock-transfer/sub/', 'obj'))
+      .toBe('rock-transfer/sub/obj');
+  });
+
+  test('preserves download- prefix on base name', () => {
+    // downloadViaOss uses "download-{ts}-{name}" as base; full key must still
+    // sit under the policy-allowed prefix.
+    expect(Sandbox.buildOssObjectName('rock-transfer/', 'download-123-a.txt'))
+      .toBe('rock-transfer/download-123-a.txt');
+  });
+
+  test('treats whitespace-only prefix as empty (no "   /file")', () => {
+    expect(Sandbox.buildOssObjectName('   ', 'obj')).toBe('obj');
+    expect(Sandbox.buildOssObjectName('\t\n ', 'obj')).toBe('obj');
+  });
+
+  test('collapses internal duplicate slashes in prefix', () => {
+    expect(Sandbox.buildOssObjectName('rock//transfer', 'obj'))
+      .toBe('rock/transfer/obj');
+    expect(Sandbox.buildOssObjectName('rock///transfer///sub', 'obj'))
+      .toBe('rock/transfer/sub/obj');
+  });
+
+  test('strips leading slashes from base name to avoid "//"', () => {
+    expect(Sandbox.buildOssObjectName('rock-transfer/', '/data.tar'))
+      .toBe('rock-transfer/data.tar');
+    expect(Sandbox.buildOssObjectName('rock-transfer/', '///data.tar'))
+      .toBe('rock-transfer/data.tar');
+    // Even without a prefix, a leading-slash baseName must not produce a
+    // bucket-rooted absolute key.
+    expect(Sandbox.buildOssObjectName('', '/data.tar')).toBe('data.tar');
+  });
+});
+
+describe('Sandbox.normalizeRegion', () => {
+  test('strips leading "oss-" prefix', () => {
+    expect(Sandbox.normalizeRegion('oss-cn-hangzhou')).toBe('cn-hangzhou');
+    expect(Sandbox.normalizeRegion('oss-cn-shanghai')).toBe('cn-shanghai');
+  });
+
+  test('passes through already-normalized region unchanged', () => {
+    expect(Sandbox.normalizeRegion('cn-hangzhou')).toBe('cn-hangzhou');
+  });
+
+  test('only strips leading prefix, not internal occurrences', () => {
+    // Defensive: a hypothetical region containing "oss-" mid-string must not
+    // be mangled.
+    expect(Sandbox.normalizeRegion('cn-oss-hangzhou')).toBe('cn-oss-hangzhou');
+  });
+
+  test('handles empty string', () => {
+    expect(Sandbox.normalizeRegion('')).toBe('');
   });
 });
 

--- a/rock/ts-sdk/src/types/responses.ts
+++ b/rock/ts-sdk/src/types/responses.ts
@@ -193,6 +193,13 @@ export const OssCredentialsSchema = z.object({
   accessKeySecret: z.string(),
   securityToken: z.string(),
   expiration: z.string(),
+  // Server-supplied OSS config (optional; only new admin returns these).
+  // When present, takes priority over ROCK_OSS_BUCKET_* env vars so the bucket
+  // matches the STS-issuing account.
+  endpoint: z.string().optional(),
+  bucket: z.string().optional(),
+  region: z.string().optional(),
+  prefix: z.string().optional(),
 });
 
 export type OssCredentials = z.infer<typeof OssCredentialsSchema>;


### PR DESCRIPTION
Companion to the Python SDK PR #<PY_PR_NUMBER>. Same failure mode, same
fix shape, in TypeScript. Splitting from the original combined PR per
reviewer request (≤ 8 files per PR; TS and Python on separate review
trains).

## What changes

### Server-first OSS config (correctness)

- `Sandbox.resolveOssConfig(credentials)` returns
  `{ endpoint, bucket, region, prefix } | null`. Returns `null` when
  the admin response is incomplete; in that case OSS is unavailable
  and `setupOss` throws a clear error.
- `getOssStsCredentials()` now hits `/get_token?account=primary` so the
  STS-issued account matches the bucket the server advertises.
- Auto-mode upload/download is now gated on `ossConfig !== null` rather
  than the deleted `ROCK_OSS_ENABLE` env var.
- Removed `ROCK_OSS_BUCKET_NAME` / `ROCK_OSS_BUCKET_ENDPOINT` /
  `ROCK_OSS_BUCKET_REGION` / `ROCK_OSS_ENABLE` from `env_vars.ts`. The
  `ROCK_OSS_TIMEOUT` knob is kept.

### Prefix-aware object keys (hardened — addresses review feedback)

- `Sandbox.buildOssObjectName(prefix, baseName)` mirrors Python
  `_compute_object_name` semantics:
  - Treats `null`, `undefined`, empty, and whitespace-only prefix as
    "no prefix" (returns `baseName` directly).
  - Strips leading/trailing slashes from prefix and collapses internal
    `//` to a single `/`.
  - Strips leading `/` from `baseName` so the final key never starts
    with `/`.
- 3 new edge tests in `oss-secure.test.ts`.

### `Sandbox.normalizeRegion` (de-duplication — review feedback)

- Extracted the inline `region.replace(/^oss-/, '')` from `setupOss`
  and `downloadViaOss` into a single static helper.
- 4 new tests covering: with/without `oss-` prefix, idempotency, and
  empty-string input.

### Credential cache (perf — review feedback)

- New private field `cachedOssCredentials` populated by
  `getOssStsCredentials()`.
- New `getCachedOssStsCredentials()` returns the cached value when
  `!isTokenExpired()`; otherwise falls through to a fresh fetch.
- `downloadViaOss` now uses the cached credentials, eliminating the
  extra `/get_token` round trip per download that
  `setupOss` had already paid for.
- 2 new tests covering reuse-when-fresh and refetch-on-expiry.

### Docs

- `CHANGELOG.md`: documents the env removal, the new helpers, the
  performance change, and the 403 fix.
- `README.md`: replaces the 3 OSS env rows with a single
  `ROCK_OSS_TIMEOUT` row.
- `docs/DEVELOPER_GUIDE.md`: replaces the `.env` OSS config block with a
  note that OSS is auto-configured from the admin response.

## What does not change

- Public API of `Sandbox` (upload/download signatures, return types).
- `ROCK_OSS_TIMEOUT` env var.
- Existing legacy-bucket deployments without server-pushed Prefix:
  empty prefix → flat layout (backward-compatible).

## Verification

- `npm test --selectProjects unit` (rock/ts-sdk): **63 passed**
  (was 54; +9 new — 3 buildOssObjectName edges, 4 normalizeRegion,
  2 cache reuse/expiry).
- `npx tsc --noEmit` clean for the modified files
  (`client.ts`, `env_vars.ts`, `responses.ts`, `oss-secure.test.ts`).
- Manual smoke against pre-prod admin: prefix `rock-transfer/`
  honored; only one `/get_token` call observed per download.

## Cross-reference

For the Python equivalent (3-file PR with the same contract), see
PR #<PY_PR_NUMBER>. The two PRs are intended to land together so
Python and TypeScript SDK behavior remains observationally identical.

## File list (7 files, ≤ 8)

- `rock/ts-sdk/src/sandbox/client.ts`
- `rock/ts-sdk/src/sandbox/oss-secure.test.ts`
- `rock/ts-sdk/src/types/responses.ts`
- `rock/ts-sdk/src/env_vars.ts`
- `rock/ts-sdk/CHANGELOG.md`
- `rock/ts-sdk/README.md`
- `rock/ts-sdk/docs/DEVELOPER_GUIDE.md`

Fixes #1152 