### PR TITLE
chore(release/v1.9): backport 6 commits from master (archive cleanup, admin guard, fiber overcut, server-first OSS SDK)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ build-backend = "setuptools.build_meta"
 authors = [{ name = "chatos@alibaba" }]
 requires-python = "<4.0,>=3.10"
 name = "rl-rock"
+
 version = "1.9.3"
 description = "ROCK-Reinforcement Open Construction Kit"
 readme = "README.md"

--- a/rock/admin/scheduler/tasks/file_cleanup_task.py
+++ b/rock/admin/scheduler/tasks/file_cleanup_task.py
@@ -107,7 +107,10 @@ class FileCleanupTask(BaseTask):
             interval_seconds: Execution interval in seconds, default 24 hours
             target_dirs: List of TargetDirConfig, each specifying a directory path
                 and its own exclude_dirs/exclude_files.
-            max_age_mins: Max file age in minutes since last modification, default 7 days (10080 mins)
+            max_age_mins: Max file age in minutes since last modification, default 7 days (10080 mins).
+                Also used as the minimum age guard for empty-directory deletion in Step 2,
+                so a freshly-mkdir'd sandbox dir that has not yet flushed its first log
+                file is not race-deleted out from under a live sandbox.
             max_file_size: Max file size threshold (e.g. "500M", "1G"), files exceeding this will be removed
 
         Raises:
@@ -262,7 +265,19 @@ class FileCleanupTask(BaseTask):
         Steps:
             1. Delete files (with exclusions) older than max_age_mins OR
                exceeding max_file_size.
-            2. Remove empty directories left behind (with exclusions).
+            2. Remove empty directories left behind (with exclusions),
+               guarded by ``-mmin +max_age_mins``.
+
+        Why Step 2 needs the same age guard as Step 1:
+            ``find -depth -type d -empty -delete`` with no age check will race
+            against any sandbox that has just done ``mkdir -p`` for its log
+            directory but not yet flushed its first log file. The directory is
+            transiently empty for a few seconds-to-minutes; if cleanup fires in
+            that window, the live sandbox's log path disappears and subsequent
+            writes fail. Reusing ``max_age_mins`` here means a directory must be
+            both empty AND not modified within the same retention window we
+            apply to files — same threshold, same intent ("nothing recent
+            lives here"), no extra knob to misconfigure.
 
         Args:
             dir_config: The target directory configuration with its exclusions
@@ -281,7 +296,8 @@ class FileCleanupTask(BaseTask):
         dir_exclude_expr = " ".join(dir_exclude_not_parts) + " " if dir_exclude_not_parts else ""
 
         # Step 1: Delete files (with exclusions) older than max_age_mins OR exceeding max_file_size
-        # Step 2: Remove empty directories (bottom-up with -depth, excluding configured dirs)
+        # Step 2: Remove empty directories (bottom-up with -depth, excluding configured dirs),
+        #         only if the directory itself has not been modified within max_age_mins.
         command = (
             f'if [ -d "{target_dir}" ]; then '
             f'find "{target_dir}" {exclude_expr}'
@@ -289,7 +305,7 @@ class FileCleanupTask(BaseTask):
             f"\\( -mmin +{self.max_age_mins} -o {size_find_expr} \\) "
             f"-delete; "
             f'find "{target_dir}" -depth {dir_exclude_expr}'
-            f"-type d -empty -delete; "
+            f"-type d -empty -mmin +{self.max_age_mins} -delete; "
             f'echo "cleanup_done"; '
             f'else echo "dir_not_found"; fi'
         )

--- a/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
+++ b/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
@@ -150,6 +150,8 @@ class SandboxLogArchiveTask(BaseTask):
         keep_days = int(log_cfg.keep_days_before_archive or 3)
         archive_prefix = log_cfg.archive_prefix or ""
 
+        await self._cleanup_stale_archives(runtime)
+
         # Step 1: discover candidate sandbox_ids on this worker
         candidate_ids = await self._discover_candidates(runtime)
         if not candidate_ids:
@@ -253,6 +255,16 @@ class SandboxLogArchiveTask(BaseTask):
         except (ValueError, TypeError):
             return None
 
+    async def _cleanup_stale_archives(self, runtime: RemoteSandboxRuntime) -> None:
+        """Remove sb-archive-* temp dirs abandoned by SIGKILL'd archive processes."""
+        cmd = "find /tmp -maxdepth 1 -name 'sb-archive-*' -type d -mmin +120 -exec rm -rf {} + 2>/dev/null || true"
+        try:
+            await runtime.execute(
+                Command(command=cmd, shell=True, check=False, sandbox_id="scheduler-task")
+            )
+        except Exception as e:
+            logger.warning(f"[{self.type}] stale archive cleanup failed: {e}")
+
     async def _archive_one(
         self,
         runtime: RemoteSandboxRuntime,
@@ -278,6 +290,7 @@ class SandboxLogArchiveTask(BaseTask):
                 command=cmd,
                 shell=True,
                 check=True,
+                timeout=3600,
                 env={
                     "OSS_ACCESS_KEY_ID": access_key_id,
                     "OSS_ACCESS_KEY_SECRET": access_key_secret,

--- a/rock/sdk/sandbox/oss_client.py
+++ b/rock/sdk/sandbox/oss_client.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import re
 import shlex
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -16,7 +17,6 @@ from typing import TYPE_CHECKING
 
 import oss2
 
-from rock import env_vars
 from rock.actions.sandbox.request import Command
 from rock.actions.sandbox.response import DownloadFileResponse, UploadResponse
 from rock.logger import init_logger
@@ -30,13 +30,12 @@ logger = init_logger(__name__)
 
 @dataclass
 class OssClientConfig:
-    """Resolved OSS configuration (Layer 1 env or Layer 2 server)."""
+    """Resolved OSS configuration from admin /get_token response."""
 
     endpoint: str
     bucket: str
     region: str
-    enabled_via_env: bool  # True = Layer 1 (gated by ROCK_OSS_ENABLE); False = Layer 2
-    prefix: str = ""  # Transfer-object key prefix (Layer 1 from env; Layer 2 from server response)
+    prefix: str = ""  # Transfer-object key prefix from server response (e.g. "rock-transfer/")
 
 
 class OssClient:
@@ -63,27 +62,19 @@ class OssClient:
         digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
         filename = Path(sandbox_path).name or Path(local_path).name
         # Honor server-pushed Prefix so chatos-rock's rock-transfer/ lifecycle catches the object.
-        clean_prefix = (prefix or "").strip("/")
+        # Sanitize: trim whitespace, strip leading/trailing slashes, collapse internal "//" runs.
+        # Without this, a stray prefix like " ", "/rock-transfer/" or "rock//transfer" would
+        # produce a malformed OSS key (e.g. "   /file", "//file", "rock//transfer/file").
+        clean_prefix = re.sub(r"/+", "/", (prefix or "").strip().strip("/"))
+        clean_filename = f"{digest}-{filename}".lstrip("/")
         if clean_prefix:
-            return f"{clean_prefix}/{digest}-{filename}"
-        return f"{digest}-{filename}"
+            return f"{clean_prefix}/{clean_filename}"
+        return clean_filename
 
     @staticmethod
     def _resolve_config(sts_response: dict) -> OssClientConfig | None:
-        # Layer 1: env var (highest priority)
-        env_endpoint = env_vars.ROCK_OSS_BUCKET_ENDPOINT
-        env_bucket = env_vars.ROCK_OSS_BUCKET_NAME
-        env_region = env_vars.ROCK_OSS_BUCKET_REGION
-        if env_endpoint and env_bucket and env_region:
-            return OssClientConfig(
-                endpoint=env_endpoint,
-                bucket=env_bucket,
-                region=env_region,
-                enabled_via_env=True,
-                prefix=env_vars.ROCK_OSS_TRANSFER_PREFIX or "",  # NEW: env can carry prefix too
-            )
-
-        # Layer 2: server response (fallback default)
+        # Server-only: admin /get_token must return a complete OSS config.
+        # If it doesn't, OSS is simply unavailable (no env fallback).
         resp_endpoint = sts_response.get("Endpoint")
         resp_bucket = sts_response.get("Bucket")
         resp_region = sts_response.get("Region")
@@ -92,11 +83,10 @@ class OssClient:
                 endpoint=resp_endpoint,
                 bucket=resp_bucket,
                 region=resp_region,
-                enabled_via_env=False,
-                prefix=sts_response.get("Prefix") or "",  # NEW: pull prefix from server
+                prefix=sts_response.get("Prefix") or "",
             )
 
-        # Layer 3: OSS unavailable
+        # OSS unavailable: server did not supply a complete config.
         return None
 
     async def _get_sts_credentials(self) -> dict:
@@ -150,10 +140,6 @@ class OssClient:
 
         config = self._resolve_config(sts_response)
         if config is None:
-            return False
-
-        # Layer 1 also requires ROCK_OSS_ENABLE
-        if config.enabled_via_env and not env_vars.ROCK_OSS_ENABLE:
             return False
 
         try:

--- a/rock/ts-sdk/CHANGELOG.md
+++ b/rock/ts-sdk/CHANGELOG.md
@@ -5,6 +5,56 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+
+- **`ROCK_OSS_BUCKET_NAME`, `ROCK_OSS_BUCKET_ENDPOINT`, `ROCK_OSS_BUCKET_REGION` env vars
+  are no longer read by the SDK.** OSS bucket/endpoint/region are now resolved
+  exclusively from the admin `/get_token?account=primary` response. Users who
+  still have these env vars set can safely leave them — they are simply ignored.
+- **`ROCK_OSS_ENABLE` env var is no longer read by the SDK.** OSS availability
+  is determined solely by whether the admin returns a complete config. If the
+  server provides Bucket/Endpoint/Region, OSS is enabled; otherwise it is
+  unavailable. The auto-mode upload/download threshold (1 MB) is unchanged.
+- `resolveOssConfig` no longer returns an `enabledViaEnv` field.
+
+### Changed
+
+- **`getOssStsCredentials()` now requests `account=primary`.** Previously it
+  hit `/get_token` with no query, which the admin defaulted to `legacy`.
+  This ensures the STS-issuing account matches the bucket the server
+  advertises.
+
+### Added
+
+- `Sandbox.resolveOssConfig(credentials)` static helper that resolves OSS
+  config from the server `/get_token` response (returns `null` when incomplete).
+- `Sandbox.buildOssObjectName(prefix, baseName)` static helper that prepends
+  the server-supplied OSS prefix to object keys. Sanitization: whitespace
+  trimmed, leading/trailing slashes stripped, internal duplicate slashes
+  (`rock//transfer`) collapsed, and any leading slashes on `baseName` stripped
+  so the resulting key never produces `//` runs or bucket-root absolute paths.
+- `Sandbox.normalizeRegion(region)` static helper that strips the leading
+  `oss-` prefix accepted by ali-oss / ossutil. Centralizes the previously
+  duplicated `replace(/^oss-/, '')` calls in `setupOss` and `downloadViaOss`.
+
+### Performance
+
+- `downloadViaOss` / `uploadViaOss` now reuse the STS credentials fetched in
+  `setupOss` instead of issuing a second `/get_token` request per transfer.
+  The cache is invalidated together with the bucket via the existing
+  `isTokenExpired()` 5-minute buffer.
+
+### Fixed
+
+- **OSS 403 AccessDenied on uploads/downloads.** `uploadViaOss` and
+  `downloadViaOss` previously wrote to the bucket root (e.g.
+  `1700000000-file.tar.gz`), but primary-account STS tokens carry a RAM
+  policy that only permits writes under the advertised prefix (typically
+  `rock-transfer/`). The SDK now prepends `ossConfig.prefix` to the object
+  key, matching the Python SDK `OssClient._compute_object_name` behavior.
+
 ## [1.3.9] - 2026-03-29
 
 ### Added

--- a/rock/ts-sdk/README.md
+++ b/rock/ts-sdk/README.md
@@ -222,9 +222,7 @@ console.log(result.output);
 | `ROCK_BASE_URL` | ROCK 服务基础 URL | `http://localhost:8080` |
 | `ROCK_ENVHUB_BASE_URL` | EnvHub 服务 URL | `http://localhost:8081` |
 | `ROCK_SANDBOX_STARTUP_TIMEOUT_SECONDS` | 沙箱启动超时时间 | `180` |
-| `ROCK_OSS_ENABLE` | 是否启用 OSS 上传/下载 | `false` |
-| `ROCK_OSS_BUCKET_ENDPOINT` | OSS Endpoint | - |
-| `ROCK_OSS_BUCKET_NAME` | OSS Bucket 名称 | - |
+| `ROCK_OSS_TIMEOUT` | OSS 操作超时时间 (ms) | `300000` |
 
 ### SandboxConfig 选项
 

--- a/rock/ts-sdk/docs/DEVELOPER_GUIDE.md
+++ b/rock/ts-sdk/docs/DEVELOPER_GUIDE.md
@@ -297,10 +297,9 @@ ROCK_ENVHUB_BASE_URL=http://your-envhub-server:8081
 ROCK_SANDBOX_STARTUP_TIMEOUT_SECONDS=300
 
 # OSS 配置 (大文件上传/下载)
-ROCK_OSS_ENABLE=true
-ROCK_OSS_BUCKET_ENDPOINT=https://oss-cn-hangzhou.aliyuncs.com
-ROCK_OSS_BUCKET_NAME=your-bucket
-ROCK_OSS_BUCKET_REGION=oss-cn-hangzhou
+# OSS bucket/endpoint/region 由 admin /get_token 接口自动返回，无需手动配置。
+# 仅 timeout 可通过环境变量覆盖：
+ROCK_OSS_TIMEOUT=300000
 
 # 日志配置
 ROCK_LOGGING_PATH=/var/log/rock
@@ -637,11 +636,7 @@ console.log(`Port mapping: ${JSON.stringify(status.portMapping)}`);
 ### Q: 如何处理大文件上传？
 
 ```typescript
-// 启用 OSS 上传 (> 1MB 自动使用 OSS)
-process.env.ROCK_OSS_ENABLE = 'true';
-process.env.ROCK_OSS_BUCKET_NAME = 'your-bucket';
-// ... 其他 OSS 配置
-
+// > 1MB 自动使用 OSS 上传（OSS 配置由 admin /get_token 自动返回）
 await sandbox.upload({
   sourcePath: './large-file.zip',
   targetPath: '/remote/large-file.zip',

--- a/rock/ts-sdk/src/env_vars.ts
+++ b/rock/ts-sdk/src/env_vars.ts
@@ -99,22 +99,6 @@ export const envVars = {
   },
 
   // OSS
-  get ROCK_OSS_ENABLE(): boolean {
-    return getEnv('ROCK_OSS_ENABLE', 'false')?.toLowerCase() === 'true';
-  },
-
-  get ROCK_OSS_BUCKET_ENDPOINT(): string | undefined {
-    return getEnv('ROCK_OSS_BUCKET_ENDPOINT');
-  },
-
-  get ROCK_OSS_BUCKET_NAME(): string | undefined {
-    return getEnv('ROCK_OSS_BUCKET_NAME');
-  },
-
-  get ROCK_OSS_BUCKET_REGION(): string | undefined {
-    return getEnv('ROCK_OSS_BUCKET_REGION');
-  },
-
   get ROCK_OSS_TIMEOUT(): number {
     return parseInt(getEnv('ROCK_OSS_TIMEOUT', '300000')!, 10); // Default: 5 minutes
   },

--- a/rock/ts-sdk/src/sandbox/client.ts
+++ b/rock/ts-sdk/src/sandbox/client.ts
@@ -111,6 +111,21 @@ export class Sandbox extends AbstractSandbox {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private ossBucket: any = null;
   private ossTokenExpireTime: string = '';
+  // Cache of the most recent STS credentials fetched via getOssStsCredentials.
+  // setupOss already retrieves a token; downloadViaOss/uploadViaOss need the
+  // raw credentials again to pass to the in-sandbox ossutil command. Caching
+  // avoids a second /get_token round trip per transfer (latency-sensitive
+  // path). The cache is invalidated together with the bucket via the existing
+  // isTokenExpired() check.
+  private cachedOssCredentials: OssCredentials | null = null;
+  // Resolved OSS config (server-first; env is only fallback when admin is too
+  // old to advertise Bucket/Endpoint/Region in /get_token).
+  private ossConfig: {
+    endpoint: string;
+    bucket: string;
+    region: string;
+    prefix: string;
+  } | null = null;
 
   // Sub-components
   private deploy: Deploy;
@@ -673,10 +688,9 @@ export class Sandbox extends AbstractSandbox {
       // Check if we should use OSS upload
       const stats = await fs.stat(sourcePath);
       const fileSize = stats.size;
-      const ossEnabled = envVars.ROCK_OSS_ENABLE;
       const ossThreshold = 1024 * 1024; // 1MB
 
-      if (uploadMode === 'oss' || (uploadMode === 'auto' && ossEnabled && fileSize > ossThreshold)) {
+      if (uploadMode === 'oss' || (uploadMode === 'auto' && fileSize > ossThreshold)) {
         return this.uploadViaOss(sourcePath, targetPath, timeout, onProgress);
       }
 
@@ -705,7 +719,10 @@ export class Sandbox extends AbstractSandbox {
    * Get OSS STS credentials from sandbox
    */
   async getOssStsCredentials(): Promise<OssCredentials> {
-    const url = `${this.url}/get_token`;
+    // Always request the primary account: SDK >= 1.8 uses chatos-rock; the
+    // server returns matching Bucket/Endpoint/Region in this case, which the
+    // server-first config resolution relies on.
+    const url = `${this.url}/get_token?account=primary`;
     const headers = this.buildHeaders();
 
     const response = await HttpUtils.get<OssCredentials>(url, headers);
@@ -716,8 +733,25 @@ export class Sandbox extends AbstractSandbox {
 
     const credentials = OssCredentialsSchema.parse(response.result);
     this.ossTokenExpireTime = credentials.expiration;
+    this.cachedOssCredentials = credentials;
 
     return credentials;
+  }
+
+  /**
+   * Return the cached OSS STS credentials when still fresh; otherwise refetch.
+   *
+   * downloadViaOss/uploadViaOss need to pass raw credentials to the in-sandbox
+   * ossutil command. setupOss already fetched a token, so reusing that token
+   * avoids a second /get_token round trip per transfer. The 5-minute expiry
+   * buffer in isTokenExpired() guarantees we refresh before the credentials
+   * actually become invalid mid-transfer.
+   */
+  private async getCachedOssStsCredentials(): Promise<OssCredentials> {
+    if (this.cachedOssCredentials && !this.isTokenExpired()) {
+      return this.cachedOssCredentials;
+    }
+    return this.getOssStsCredentials();
   }
 
   /**
@@ -787,10 +821,9 @@ export class Sandbox extends AbstractSandbox {
 
     const fileSize = parseInt(sizeResult.stdout.trim(), 10);
     const ossThreshold = 1024 * 1024; // 1MB
-    const ossEnabled = envVars.ROCK_OSS_ENABLE;
 
-    // OSS enabled AND file >= 1MB: use OSS
-    if (ossEnabled && fileSize >= ossThreshold) {
+    // File >= 1MB: use OSS (if server provides OSS config, setupOss will succeed)
+    if (fileSize >= ossThreshold) {
       return this.downloadViaOss(remotePath, localPath, timeout, onProgress);
     }
 
@@ -826,21 +859,13 @@ export class Sandbox extends AbstractSandbox {
    * Download file via OSS as intermediary
    */
   private async downloadViaOss(remotePath: string, localPath: string, timeout?: number, onProgress?: (info: ProgressInfo) => void): Promise<DownloadFileResponse> {
-    // Check OSS is enabled
-    if (!envVars.ROCK_OSS_ENABLE) {
-      return {
-        success: false,
-        message: 'OSS download is not enabled. Please set ROCK_OSS_ENABLE=true',
-      };
-    }
-
     try {
       // Setup OSS bucket if needed
       if (this.ossBucket === null || this.isTokenExpired()) {
         await this.setupOss(timeout);
       }
 
-      if (!this.ossBucket) {
+      if (!this.ossBucket || !this.ossConfig) {
         return { success: false, message: 'Failed to setup OSS bucket' };
       }
 
@@ -850,15 +875,18 @@ export class Sandbox extends AbstractSandbox {
       // Generate unique object name
       const timestamp = Date.now();
       const fileName = remotePath.split('/').pop() ?? 'file';
-      const objectName = `download-${timestamp}-${fileName}`;
+      // Prepend server-supplied prefix (e.g. "rock-transfer/") so the OSS key
+      // matches the STS RAM policy. The primary-account STS only permits
+      // writes under this prefix; bucket-root writes return 403 AccessDenied.
+      const objectName = Sandbox.buildOssObjectName(this.ossConfig?.prefix, `download-${timestamp}-${fileName}`);
 
-      // Get STS credentials for ossutil
-      const credentials = await this.getOssStsCredentials();
-      const bucketName = envVars.ROCK_OSS_BUCKET_NAME ?? '';
-      const region = (envVars.ROCK_OSS_BUCKET_REGION ?? '').replace(/^oss-/, ''); // Normalize: remove "oss-" prefix if present
-      // Use ROCK_OSS_BUCKET_ENDPOINT if available, otherwise build from region
-      // Endpoint format: "oss-cn-hangzhou.aliyuncs.com" (no protocol prefix)
-      const endpoint = envVars.ROCK_OSS_BUCKET_ENDPOINT ?? `oss-${region}.aliyuncs.com`;
+      // Get STS credentials for ossutil. setupOss above already fetched and
+      // cached a token; reuse it to avoid a redundant /get_token round trip.
+      const credentials = await this.getCachedOssStsCredentials();
+      const bucketName = this.ossConfig.bucket;
+      const region = Sandbox.normalizeRegion(this.ossConfig.region);
+      // Endpoint comes from resolved config (server or env). Format: "oss-cn-hangzhou.aliyuncs.com".
+      const endpoint = this.ossConfig.endpoint;
 
       // Upload from sandbox to OSS via ossutil v2
       // ossutil v2 uses command-line parameters for credentials (no separate config needed)
@@ -913,7 +941,10 @@ export class Sandbox extends AbstractSandbox {
 
       const timestamp = Date.now();
       const fileName = sourcePath.split('/').pop() ?? 'file';
-      const objectName = `${timestamp}-${fileName}`;
+      // Prepend server-supplied prefix (e.g. "rock-transfer/") so the OSS key
+      // matches the STS RAM policy. The primary-account STS only permits
+      // writes under this prefix; bucket-root writes return 403 AccessDenied.
+      const objectName = Sandbox.buildOssObjectName(this.ossConfig?.prefix, `${timestamp}-${fileName}`);
 
       // Check file size to determine upload method
       const fs = await import('fs/promises');
@@ -977,22 +1008,97 @@ export class Sandbox extends AbstractSandbox {
    * Setup OSS bucket with STS credentials
    * @param timeout - Optional timeout in milliseconds (defaults to ROCK_OSS_TIMEOUT env var or 300000ms)
    */
+  /**
+   * Compose an OSS object key by prepending the server-supplied prefix.
+   *
+   * STS tokens issued by the primary account carry a RAM policy that only
+   * permits writes under the advertised prefix (typically "rock-transfer/").
+   * Writing to the bucket root returns 403 AccessDenied. This helper applies
+   * the prefix consistently for upload and download paths.
+   *
+   * Sanitization:
+   *   - whitespace trimmed
+   *   - leading/trailing slashes stripped
+   *   - internal duplicate slashes collapsed (e.g. "rock//transfer" -> "rock/transfer")
+   *   - leading slashes on baseName stripped (defensive; callers already pass
+   *     `${timestamp}-${name}` which never starts with '/').
+   *
+   * Mirrors the Python `OssClient._compute_object_name` prefix handling.
+   */
+  static buildOssObjectName(prefix: string | undefined | null, baseName: string): string {
+    const clean = (prefix ?? '')
+      .trim()
+      .replace(/^\/+|\/+$/g, '')
+      .replace(/\/+/g, '/');
+    const cleanBase = baseName.replace(/^\/+/, '');
+    return clean ? `${clean}/${cleanBase}` : cleanBase;
+  }
+
+  /**
+   * Normalize an OSS region string for ali-oss / ossutil.
+   *
+   * `ali-oss` rejects region values with the "oss-" prefix; ossutil accepts
+   * either form but is consistent only when normalized. Server responses
+   * sometimes carry the prefix and sometimes don't, so we always strip it.
+   */
+  static normalizeRegion(region: string): string {
+    return region.replace(/^oss-/, '');
+  }
+
+  /**
+   * Resolve OSS config from server response.
+   *
+   * Admin /get_token must return a complete OSS config (Bucket, Endpoint,
+   * Region). If it doesn't, OSS is unavailable (returns null).
+   *
+   * Mirrors the Python `OssClient._resolve_config` implementation.
+   */
+  static resolveOssConfig(credentials: OssCredentials): {
+    endpoint: string;
+    bucket: string;
+    region: string;
+    prefix: string;
+  } | null {
+    if (credentials.endpoint && credentials.bucket && credentials.region) {
+      return {
+        endpoint: credentials.endpoint,
+        bucket: credentials.bucket,
+        region: credentials.region,
+        prefix: credentials.prefix ?? '',
+      };
+    }
+    return null;
+  }
+
   private async setupOss(timeout?: number): Promise<void> {
     const credentials = await this.getOssStsCredentials();
+
+    const resolved = Sandbox.resolveOssConfig(credentials);
+    if (!resolved) {
+      throw new Error(
+        'OSS config unavailable: admin /get_token did not return Bucket/Endpoint/Region'
+      );
+    }
+
+    this.ossConfig = resolved;
 
     const OSS = (await import('ali-oss')).default;
 
     // Priority: parameter > env var > default (300000ms = 5 minutes)
     const ossTimeout = timeout ?? envVars.ROCK_OSS_TIMEOUT;
 
+    // ali-oss expects region without "oss-" prefix; endpoint normalization
+    // is handled separately in downloadViaOss when building ossutil commands.
+    const aliRegion = Sandbox.normalizeRegion(resolved.region);
+
     this.ossBucket = new OSS({
       secure: true, // Use HTTPS for OSS connections
       timeout: ossTimeout,
-      region: envVars.ROCK_OSS_BUCKET_REGION ?? '',
+      region: aliRegion,
       accessKeyId: credentials.accessKeyId,
       accessKeySecret: credentials.accessKeySecret,
       stsToken: credentials.securityToken,
-      bucket: envVars.ROCK_OSS_BUCKET_NAME ?? '',
+      bucket: resolved.bucket,
       refreshSTSToken: async () => {
         const newCreds = await this.getOssStsCredentials();
         return {

--- a/rock/ts-sdk/src/sandbox/oss-secure.test.ts
+++ b/rock/ts-sdk/src/sandbox/oss-secure.test.ts
@@ -71,11 +71,6 @@ describe('OSS client configuration', () => {
       get: mockGet,
     });
 
-    // Set OSS environment variables
-    process.env.ROCK_OSS_ENABLE = 'true';
-    process.env.ROCK_OSS_BUCKET_NAME = 'test-bucket';
-    process.env.ROCK_OSS_BUCKET_REGION = 'cn-hangzhou';
-
     sandbox = new Sandbox({
       image: 'test:latest',
       startupTimeout: 2,
@@ -83,9 +78,6 @@ describe('OSS client configuration', () => {
   });
 
   afterEach(() => {
-    delete process.env.ROCK_OSS_ENABLE;
-    delete process.env.ROCK_OSS_BUCKET_NAME;
-    delete process.env.ROCK_OSS_BUCKET_REGION;
   });
 
   describe('getOssStsCredentials()', () => {
@@ -165,6 +157,122 @@ describe('OSS client configuration', () => {
       });
 
       await expect(sandbox.getOssStsCredentials()).rejects.toThrow();
+    });
+
+    test('caches credentials so a second call within validity window does not refetch', async () => {
+      // Reviewer point 5: setupOss already fetches a token; downloadViaOss
+      // must not issue a redundant /get_token round trip on every transfer.
+      mockPost.mockResolvedValueOnce({
+        data: {
+          status: 'Success',
+          result: {
+            sandbox_id: 'test-id',
+            host_name: 'test-host',
+            host_ip: '127.0.0.1',
+          },
+        },
+        headers: {},
+      });
+      mockGet.mockResolvedValueOnce({
+        data: {
+          status: 'Success',
+          result: { is_alive: true },
+        },
+        headers: {},
+      });
+      await sandbox.start();
+
+      const oneHourLater = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      mockGet.mockResolvedValueOnce({
+        data: {
+          status: 'Success',
+          result: {
+            access_key_id: 'STS.FIRST',
+            access_key_secret: 'S1',
+            security_token: 'T1',
+            expiration: oneHourLater,
+          },
+        },
+        headers: {},
+      });
+
+      // First call hits the network.
+      const first = await sandbox.getOssStsCredentials();
+      expect(first.accessKeyId).toBe('STS.FIRST');
+      const getCallCountAfterFirst = mockGet.mock.calls.length;
+
+      // Second call via the cache helper must NOT call mockGet again while
+      // the token is still fresh.
+      const cached = await (
+        sandbox as unknown as {
+          getCachedOssStsCredentials(): Promise<typeof first>;
+        }
+      ).getCachedOssStsCredentials();
+
+      expect(cached).toBe(first);
+      expect(mockGet.mock.calls.length).toBe(getCallCountAfterFirst);
+    });
+
+    test('refetches credentials when cached token is expired', async () => {
+      mockPost.mockResolvedValueOnce({
+        data: {
+          status: 'Success',
+          result: {
+            sandbox_id: 'test-id',
+            host_name: 'test-host',
+            host_ip: '127.0.0.1',
+          },
+        },
+        headers: {},
+      });
+      mockGet.mockResolvedValueOnce({
+        data: {
+          status: 'Success',
+          result: { is_alive: true },
+        },
+        headers: {},
+      });
+      await sandbox.start();
+
+      const oneHourLater = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+      mockGet.mockResolvedValueOnce({
+        data: {
+          status: 'Success',
+          result: {
+            access_key_id: 'STS.FIRST',
+            access_key_secret: 'S1',
+            security_token: 'T1',
+            expiration: oneHourLater,
+          },
+        },
+        headers: {},
+      });
+      await sandbox.getOssStsCredentials();
+
+      // Manually expire the token.
+      (sandbox as unknown as { ossTokenExpireTime: string }).ossTokenExpireTime =
+        '2020-01-01T00:00:00Z';
+
+      mockGet.mockResolvedValueOnce({
+        data: {
+          status: 'Success',
+          result: {
+            access_key_id: 'STS.SECOND',
+            access_key_secret: 'S2',
+            security_token: 'T2',
+            expiration: oneHourLater,
+          },
+        },
+        headers: {},
+      });
+
+      const refreshed = await (
+        sandbox as unknown as {
+          getCachedOssStsCredentials(): Promise<{ accessKeyId: string }>;
+        }
+      ).getCachedOssStsCredentials();
+
+      expect(refreshed.accessKeyId).toBe('STS.SECOND');
     });
   });
 
@@ -509,6 +617,198 @@ describe('nohup mode PATH handling', () => {
     // With bash -c: uses bash which has correct PATH
     const hasBashWrapper = true;
     expect(hasBashWrapper).toBe(true);
+  });
+});
+
+/**
+ * Server-only OSS config resolution tests
+ *
+ * The SDK resolves OSS config exclusively from the admin /get_token response.
+ * No env-var fallback exists — if the server doesn't return complete config,
+ * OSS is unavailable.
+ */
+describe('Server-only OSS config resolution', () => {
+  let sandbox: Sandbox;
+  let mockPost: jest.Mock;
+  let mockGet: jest.Mock;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockPost = jest.fn();
+    mockGet = jest.fn();
+    mockedAxios.create = jest.fn().mockReturnValue({
+      post: mockPost,
+      get: mockGet,
+    });
+
+    sandbox = new Sandbox({ image: 'test:latest', startupTimeout: 2 });
+
+    mockPost.mockResolvedValueOnce({
+      data: {
+        status: 'Success',
+        result: { sandbox_id: 'test-id', host_name: 'test-host', host_ip: '127.0.0.1' },
+      },
+      headers: {},
+    });
+    mockGet.mockResolvedValue({
+      data: { status: 'Success', result: { is_alive: true } },
+      headers: {},
+    });
+    await sandbox.start();
+  });
+
+  test('getOssStsCredentials requests account=primary', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        status: 'Success',
+        result: {
+          access_key_id: 'STS.PRIMARY',
+          access_key_secret: 'sec',
+          security_token: 'tok',
+          expiration: '2099-01-01T00:00:00Z',
+        },
+      },
+      headers: {},
+    });
+
+    await sandbox.getOssStsCredentials();
+
+    const calledUrl = mockGet.mock.calls.at(-1)?.[0] as string;
+    expect(calledUrl).toContain('/get_token');
+    expect(calledUrl).toContain('account=primary');
+  });
+
+  test('resolves config from server response', () => {
+    const credentials = {
+      accessKeyId: 'STS.PRIMARY',
+      accessKeySecret: 'sec',
+      securityToken: 'tok',
+      expiration: '2099-01-01T00:00:00Z',
+      endpoint: 'oss-cn-hangzhou.aliyuncs.com',
+      bucket: 'chatos-rock',
+      region: 'cn-hangzhou',
+      prefix: 'rock-transfer/',
+    };
+
+    const resolved = Sandbox.resolveOssConfig(credentials);
+
+    expect(resolved).not.toBeNull();
+    expect(resolved!.bucket).toBe('chatos-rock');
+    expect(resolved!.endpoint).toBe('oss-cn-hangzhou.aliyuncs.com');
+    expect(resolved!.region).toBe('cn-hangzhou');
+    expect(resolved!.prefix).toBe('rock-transfer/');
+  });
+
+  test('returns null when server does not provide complete config', () => {
+    const credentials = {
+      accessKeyId: 'STS',
+      accessKeySecret: 'sec',
+      securityToken: 'tok',
+      expiration: '2099-01-01T00:00:00Z',
+    };
+
+    expect(Sandbox.resolveOssConfig(credentials)).toBeNull();
+  });
+
+  test('returns null when server response is partial (missing bucket)', () => {
+    const credentials = {
+      accessKeyId: 'STS',
+      accessKeySecret: 'sec',
+      securityToken: 'tok',
+      expiration: '2099-01-01T00:00:00Z',
+      endpoint: 'oss-cn-hangzhou.aliyuncs.com',
+      region: 'cn-hangzhou',
+      // bucket missing → incomplete → null
+    };
+
+    expect(Sandbox.resolveOssConfig(credentials)).toBeNull();
+  });
+});
+
+/**
+ * OSS object name prefix tests
+ *
+ * Regression guard for: STS tokens from account=primary carry a RAM policy
+ * restricting writes to the advertised Prefix (e.g. "rock-transfer/").
+ * Writing to bucket root returns 403 AccessDenied — both uploadViaOss and
+ * downloadViaOss must prepend the prefix to the object key.
+ */
+describe('Sandbox.buildOssObjectName', () => {
+  test('prepends server-supplied prefix to base name', () => {
+    expect(Sandbox.buildOssObjectName('rock-transfer/', '1700000000-foo.tar.gz'))
+      .toBe('rock-transfer/1700000000-foo.tar.gz');
+  });
+
+  test('normalizes leading and trailing slashes', () => {
+    expect(Sandbox.buildOssObjectName('/rock-transfer/', 'obj')).toBe('rock-transfer/obj');
+    expect(Sandbox.buildOssObjectName('rock-transfer', 'obj')).toBe('rock-transfer/obj');
+    expect(Sandbox.buildOssObjectName('///rock-transfer///', 'obj')).toBe('rock-transfer/obj');
+  });
+
+  test('returns base name unchanged when prefix is empty/null/undefined', () => {
+    expect(Sandbox.buildOssObjectName('', 'obj')).toBe('obj');
+    expect(Sandbox.buildOssObjectName(null, 'obj')).toBe('obj');
+    expect(Sandbox.buildOssObjectName(undefined, 'obj')).toBe('obj');
+  });
+
+  test('returns base name unchanged when prefix is only slashes', () => {
+    expect(Sandbox.buildOssObjectName('/', 'obj')).toBe('obj');
+    expect(Sandbox.buildOssObjectName('////', 'obj')).toBe('obj');
+  });
+
+  test('supports nested multi-segment prefix', () => {
+    expect(Sandbox.buildOssObjectName('rock-transfer/sub/', 'obj'))
+      .toBe('rock-transfer/sub/obj');
+  });
+
+  test('preserves download- prefix on base name', () => {
+    // downloadViaOss uses "download-{ts}-{name}" as base; full key must still
+    // sit under the policy-allowed prefix.
+    expect(Sandbox.buildOssObjectName('rock-transfer/', 'download-123-a.txt'))
+      .toBe('rock-transfer/download-123-a.txt');
+  });
+
+  test('treats whitespace-only prefix as empty (no "   /file")', () => {
+    expect(Sandbox.buildOssObjectName('   ', 'obj')).toBe('obj');
+    expect(Sandbox.buildOssObjectName('\t\n ', 'obj')).toBe('obj');
+  });
+
+  test('collapses internal duplicate slashes in prefix', () => {
+    expect(Sandbox.buildOssObjectName('rock//transfer', 'obj'))
+      .toBe('rock/transfer/obj');
+    expect(Sandbox.buildOssObjectName('rock///transfer///sub', 'obj'))
+      .toBe('rock/transfer/sub/obj');
+  });
+
+  test('strips leading slashes from base name to avoid "//"', () => {
+    expect(Sandbox.buildOssObjectName('rock-transfer/', '/data.tar'))
+      .toBe('rock-transfer/data.tar');
+    expect(Sandbox.buildOssObjectName('rock-transfer/', '///data.tar'))
+      .toBe('rock-transfer/data.tar');
+    // Even without a prefix, a leading-slash baseName must not produce a
+    // bucket-rooted absolute key.
+    expect(Sandbox.buildOssObjectName('', '/data.tar')).toBe('data.tar');
+  });
+});
+
+describe('Sandbox.normalizeRegion', () => {
+  test('strips leading "oss-" prefix', () => {
+    expect(Sandbox.normalizeRegion('oss-cn-hangzhou')).toBe('cn-hangzhou');
+    expect(Sandbox.normalizeRegion('oss-cn-shanghai')).toBe('cn-shanghai');
+  });
+
+  test('passes through already-normalized region unchanged', () => {
+    expect(Sandbox.normalizeRegion('cn-hangzhou')).toBe('cn-hangzhou');
+  });
+
+  test('only strips leading prefix, not internal occurrences', () => {
+    // Defensive: a hypothetical region containing "oss-" mid-string must not
+    // be mangled.
+    expect(Sandbox.normalizeRegion('cn-oss-hangzhou')).toBe('cn-oss-hangzhou');
+  });
+
+  test('handles empty string', () => {
+    expect(Sandbox.normalizeRegion('')).toBe('');
   });
 });
 

--- a/rock/ts-sdk/src/types/responses.ts
+++ b/rock/ts-sdk/src/types/responses.ts
@@ -193,6 +193,13 @@ export const OssCredentialsSchema = z.object({
   accessKeySecret: z.string(),
   securityToken: z.string(),
   expiration: z.string(),
+  // Server-supplied OSS config (optional; only new admin returns these).
+  // When present, takes priority over ROCK_OSS_BUCKET_* env vars so the bucket
+  // matches the STS-issuing account.
+  endpoint: z.string().optional(),
+  bucket: z.string().optional(),
+  region: z.string().optional(),
+  prefix: z.string().optional(),
 });
 
 export type OssCredentials = z.infer<typeof OssCredentialsSchema>;

--- a/rock/utils/archive_command.py
+++ b/rock/utils/archive_command.py
@@ -49,6 +49,13 @@ class ArchiveCommand:
         any step fails, so the caller can rely on the exit code to retry.
         The scratch dir is removed via ``trap EXIT`` regardless of outcome.
 
+        Soft kills (SIGINT/SIGTERM/SIGHUP) are also trapped — they ``exit``
+        with conventional ``128 + signo`` codes so the EXIT trap can fire and
+        clean up. This catches Ctrl-C, ``kill <pid>`` (k8s graceful shutdown
+        first phase, ``runtime.execute(...)`` timeout), and SSH disconnect.
+        SIGKILL still cannot be trapped — for that case we rely on the
+        task-level / command-level ``find -mmin +120 -delete`` sweep.
+
         Before tar+upload, ``ossutil stat`` checks whether the OSS object
         already exists (previous tar+upload succeeded but the process was
         killed before ``rm -rf <log_dir>``). If it does, tar+upload is
@@ -68,12 +75,20 @@ class ArchiveCommand:
         #
         # ossutil stat || { tar && ossutil cp; } — if the object already
         # exists on OSS the || short-circuits and skips tar+upload.
+        #
+        # trap 'exit' INT TERM HUP forwards soft signals to a normal exit so
+        # the EXIT trap (rm -rf "$ARCHIVE_DIR") still fires; SIGKILL can't be
+        # trapped and is covered by the leading find sweep + task-level
+        # _cleanup_stale_archives() in SandboxLogArchiveTask.
         return textwrap.dedent(
             f"""\
             find /tmp -maxdepth 1 -name 'sb-archive-*' -type d -mmin +120 -exec rm -rf {{}} + 2>/dev/null; \\
             set -e \\
             && ARCHIVE_DIR=$(mktemp -d -t sb-archive-XXXXXX) \\
             && trap 'rm -rf "$ARCHIVE_DIR"' EXIT \\
+            && trap 'exit 130' INT \\
+            && trap 'exit 143' TERM \\
+            && trap 'exit 129' HUP \\
             && umask 077 \\
             && printf '[Credentials]\\nlanguage=EN\\nendpoint=%s\\naccessKeyID=%s\\naccessKeySecret=%s\\n' \\
             {endpoint_q} "$OSS_ACCESS_KEY_ID" "$OSS_ACCESS_KEY_SECRET" \\

--- a/rock/utils/archive_command.py
+++ b/rock/utils/archive_command.py
@@ -48,6 +48,14 @@ class ArchiveCommand:
         ``set -e`` aborts the chain before the final ``rm -rf <log_dir>`` if
         any step fails, so the caller can rely on the exit code to retry.
         The scratch dir is removed via ``trap EXIT`` regardless of outcome.
+
+        Before tar+upload, ``ossutil stat`` checks whether the OSS object
+        already exists (previous tar+upload succeeded but the process was
+        killed before ``rm -rf <log_dir>``). If it does, tar+upload is
+        skipped entirely — only the final ``rm -rf`` runs.
+
+        Stale ``sb-archive-*`` temp dirs older than 2 hours (left by
+        SIGKILL'd archive processes) are cleaned up at the start.
         """
         log_path = Path(log_dir)
         parent = shlex.quote(str(log_path.parent))
@@ -57,8 +65,12 @@ class ArchiveCommand:
         log_dir_q = shlex.quote(log_dir)
         # textwrap.dedent strips the common leading whitespace so the source can be
         # indented for readability without polluting the emitted shell string.
+        #
+        # ossutil stat || { tar && ossutil cp; } — if the object already
+        # exists on OSS the || short-circuits and skips tar+upload.
         return textwrap.dedent(
             f"""\
+            find /tmp -maxdepth 1 -name 'sb-archive-*' -type d -mmin +120 -exec rm -rf {{}} + 2>/dev/null; \\
             set -e \\
             && ARCHIVE_DIR=$(mktemp -d -t sb-archive-XXXXXX) \\
             && trap 'rm -rf "$ARCHIVE_DIR"' EXIT \\
@@ -66,7 +78,8 @@ class ArchiveCommand:
             && printf '[Credentials]\\nlanguage=EN\\nendpoint=%s\\naccessKeyID=%s\\naccessKeySecret=%s\\n' \\
             {endpoint_q} "$OSS_ACCESS_KEY_ID" "$OSS_ACCESS_KEY_SECRET" \\
             > "$ARCHIVE_DIR/ossconfig" \\
-            && tar -czf "$ARCHIVE_DIR/archive.tar.gz" -C {parent} {name} \\
-            && ossutil cp -c "$ARCHIVE_DIR/ossconfig" -f "$ARCHIVE_DIR/archive.tar.gz" {oss_url_q} \\
+            && {{ ossutil stat -c "$ARCHIVE_DIR/ossconfig" {oss_url_q} >/dev/null 2>&1 \\
+            || {{ tar -czf "$ARCHIVE_DIR/archive.tar.gz" -C {parent} {name} \\
+            && ossutil cp -c "$ARCHIVE_DIR/ossconfig" -f "$ARCHIVE_DIR/archive.tar.gz" {oss_url_q}; }}; }} \\
             && rm -rf {log_dir_q}"""
         )

--- a/tests/integration/sdk/sandbox/test_file_system.py
+++ b/tests/integration/sdk/sandbox/test_file_system.py
@@ -9,7 +9,6 @@ from unittest.mock import Mock
 import oss2
 import pytest
 
-from rock import env_vars
 from rock.actions.sandbox.request import ChmodRequest, ChownRequest, Command, CreateBashSessionRequest, WriteFileRequest
 from rock.actions.sandbox.response import ChmodResponse, ChownResponse, CommandResponse, Observation
 from rock.sdk.sandbox.client import Sandbox
@@ -95,9 +94,18 @@ async def test_download_file(sandbox_instance: Sandbox, monkeypatch):
     assert isinstance(sandbox_instance.fs, LinuxFileSystem)
 
     try:
-        #  Test 1: OSS disabled
-        logger.info("=== Test 1: OSS disabled ===")
-        monkeypatch.setattr(env_vars, "ROCK_OSS_ENABLE", False)
+        #  Test 1: OSS disabled (server returns no OSS config)
+        logger.info("=== Test 1: OSS disabled (no server config) ===")
+
+        async def mock_sts_no_config():
+            return {
+                "AccessKeyId": "mock_ak",
+                "AccessKeySecret": "mock_sk",
+                "SecurityToken": "mock_token",
+                "Expiration": "2026-03-15T00:00:00Z",
+            }
+
+        monkeypatch.setattr(sandbox_instance._oss, "_get_sts_credentials", mock_sts_no_config)
 
         response = await sandbox_instance.fs.download_file(
             remote_path="/tmp/test.txt", local_path=str(tmp_path / "test.txt")
@@ -109,18 +117,16 @@ async def test_download_file(sandbox_instance: Sandbox, monkeypatch):
         ), f"Error message should mention OSS unavailable: {response.message}"
         logger.info("✓ OSS disabled error handling works correctly")
 
-        # Setup mocks for remaining tests
-        monkeypatch.setattr(env_vars, "ROCK_OSS_ENABLE", True)
-        monkeypatch.setattr(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "oss-cn-test.aliyuncs.com")
-        monkeypatch.setattr(env_vars, "ROCK_OSS_BUCKET_NAME", "test-bucket")
-        monkeypatch.setattr(env_vars, "ROCK_OSS_BUCKET_REGION", "cn-test")
-
+        # Setup mocks for remaining tests (server returns full OSS config)
         async def mock_get_sts_credentials():
             return {
                 "AccessKeyId": "mock_ak",
                 "AccessKeySecret": "mock_sk",
                 "SecurityToken": "mock_token",
                 "Expiration": "2026-03-15T00:00:00Z",
+                "Endpoint": "oss-cn-test.aliyuncs.com",
+                "Bucket": "test-bucket",
+                "Region": "cn-test",
             }
 
         monkeypatch.setattr(sandbox_instance._oss, "_get_sts_credentials", mock_get_sts_credentials)

--- a/tests/unit/admin/scheduler/test_file_cleanup_task.py
+++ b/tests/unit/admin/scheduler/test_file_cleanup_task.py
@@ -129,7 +129,10 @@ class TestBuildCleanupCommand:
     def test_command_uses_delete_for_empty_dirs(self):
         task = self._new_task()
         cmd = task._build_cleanup_command(TargetDirConfig(path="/data/cache"))
-        assert "-type d -empty -delete" in cmd
+        # Step 2 reuses self.max_age_mins (default 10080) as its -mmin guard so
+        # transiently-empty sandbox dirs that have not yet flushed their first
+        # log are never race-deleted. The trailing `-delete;` token must remain.
+        assert "-type d -empty -mmin +10080 -delete;" in cmd
         assert "-exec rmdir" not in cmd
 
     def test_command_includes_target_dir_existence_check(self):
@@ -205,7 +208,7 @@ class TestBuildCleanupCommand:
         task = self._new_task(target_dirs=[dir_cfg])
         cmd = task._build_cleanup_command(dir_cfg)
         parts = cmd.split(";")
-        empty_dir_find = [p for p in parts if "-type d -empty -delete" in p][0]
+        empty_dir_find = [p for p in parts if "-type d -empty" in p][0]
         assert '-not -path "*/docker"' in empty_dir_find
         assert '-not -path "*/docker/*"' in empty_dir_find
 
@@ -214,7 +217,7 @@ class TestBuildCleanupCommand:
         task = self._new_task(target_dirs=[dir_cfg])
         cmd = task._build_cleanup_command(dir_cfg)
         parts = cmd.split(";")
-        empty_dir_find = [p for p in parts if "-type d -empty -delete" in p][0]
+        empty_dir_find = [p for p in parts if "-type d -empty" in p][0]
         assert '-not -path "/data/logs/special"' in empty_dir_find
         assert '-not -path "/data/logs/special/*"' in empty_dir_find
 
@@ -223,9 +226,78 @@ class TestBuildCleanupCommand:
         task = self._new_task(target_dirs=[dir_cfg])
         cmd = task._build_cleanup_command(dir_cfg)
         parts = cmd.split(";")
-        empty_dir_find = [p for p in parts if "-type d -empty -delete" in p][0]
+        empty_dir_find = [p for p in parts if "-type d -empty" in p][0]
         assert '-not -path "/data/logs/sub/dir"' in empty_dir_find
         assert '-not -path "/data/logs/sub/dir/*"' in empty_dir_find
+
+    # ----------------------------------------------------------------------- #
+    # Regression: empty-dir deletion in Step 2 must inherit max_age_mins.
+    #
+    # Pre-fix bug: ``find -depth -type d -empty -delete`` had no age guard, so
+    # a sandbox dir that had just been mkdir'd but had not yet flushed its first
+    # log file (i.e. transiently empty for a few seconds–minutes) would be
+    # deleted out from under the live sandbox by the next hourly cleanup run.
+    # The fix wires self.max_age_mins into Step 2's -mmin so an empty dir must
+    # also be unmodified within the retention window before it can be removed.
+    # ----------------------------------------------------------------------- #
+
+    def test_step2_includes_mmin_guard_default(self):
+        task = self._new_task()  # default max_age_mins=10080
+        cmd = task._build_cleanup_command(TargetDirConfig(path="/data/cache"))
+        parts = cmd.split(";")
+        empty_dir_find = [p for p in parts if "-type d -empty" in p][0]
+        assert "-mmin +10080" in empty_dir_find
+        # Both -empty and -mmin must precede -delete; -delete is the terminal
+        # action and must not appear before either predicate.
+        empty_idx = empty_dir_find.index("-empty")
+        mmin_idx = empty_dir_find.index("-mmin")
+        delete_idx = empty_dir_find.index("-delete")
+        assert empty_idx < delete_idx
+        assert mmin_idx < delete_idx
+
+    def test_step2_mmin_matches_custom_max_age_mins(self):
+        # Custom retention window must propagate from Step 1 into Step 2 so
+        # operators tuning max_age_mins do not need a second knob to keep the
+        # two find passes consistent.
+        task = self._new_task(max_age_mins=4320)
+        cmd = task._build_cleanup_command(TargetDirConfig(path="/data/cache"))
+        parts = cmd.split(";")
+        empty_dir_find = [p for p in parts if "-type d -empty" in p][0]
+        assert "-mmin +4320" in empty_dir_find
+
+    def test_step2_mmin_present_with_excludes(self):
+        # The -mmin guard must remain present even when -not -path expressions
+        # are interleaved into the empty-dir find invocation.
+        dir_cfg = TargetDirConfig(
+            path="/data/logs",
+            exclude_dirs=["docker"],
+            exclude_files=["docuum.log"],
+        )
+        task = self._new_task(target_dirs=[dir_cfg], max_age_mins=1440)
+        cmd = task._build_cleanup_command(dir_cfg)
+        parts = cmd.split(";")
+        empty_dir_find = [p for p in parts if "-type d -empty" in p][0]
+        assert "-mmin +1440" in empty_dir_find
+        assert '-not -path "*/docker"' in empty_dir_find
+        assert '-not -path "*/docker/*"' in empty_dir_find
+
+    def test_step2_no_unguarded_empty_delete_anywhere(self):
+        # Hard regression guard: the bare token `-empty -delete` (no -mmin
+        # between them) must never appear in any generated command. If a future
+        # refactor accidentally drops the guard, this assertion will fire
+        # before the change reaches production.
+        for max_age in (60, 1440, 10080, 43200):
+            for cfg in (
+                TargetDirConfig(path="/data/cache"),
+                TargetDirConfig(path="/data/logs", exclude_dirs=["docker"]),
+                TargetDirConfig(path="/data/logs", exclude_files=["rocklet.log"]),
+            ):
+                task = self._new_task(target_dirs=[cfg], max_age_mins=max_age)
+                cmd = task._build_cleanup_command(cfg)
+                assert "-empty -delete" not in cmd, (
+                    f"unguarded empty-dir delete leaked into command for "
+                    f"max_age_mins={max_age}, dir_cfg={cfg}: {cmd}"
+                )
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/admin/scheduler/test_sandbox_log_archive_task.py
+++ b/tests/unit/admin/scheduler/test_sandbox_log_archive_task.py
@@ -187,7 +187,7 @@ class TestDiscovery:
         set_rock_config_provider(lambda: _fake_rock_config())
 
         task = SandboxLogArchiveTask(log_root="/data/logs")
-        runtime = _runtime([_FakeExecResult(stdout="")])
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="")])
 
         result = await task.run_action(runtime)
 
@@ -209,10 +209,11 @@ class TestDiscovery:
         set_rock_config_provider(lambda: _fake_rock_config())
 
         task = SandboxLogArchiveTask(log_root="/data/logs")
-        runtime = _runtime([_FakeExecResult(stdout="")])
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="")])
         await task.run_action(runtime)
 
-        cmd = runtime.execute.await_args_list[0].args[0].command
+        # index 1: discover command (index 0 is stale archive cleanup)
+        cmd = runtime.execute.await_args_list[1].args[0].command
         assert "-type d" in cmd, "discovery must restrict to directories"
         assert "-maxdepth 1" in cmd, "must not recurse into sandbox log subdirs"
         assert cmd.lstrip().startswith("find "), f"expected find, got: {cmd[:50]}"
@@ -232,7 +233,7 @@ class TestClassification:
         fake_table.list_by_in = AsyncMock(return_value=[])
 
         task = SandboxLogArchiveTask(log_root="/data/logs")
-        runtime = _runtime([_FakeExecResult(stdout="sb-orphan")])
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="sb-orphan")])
 
         result = await task.run_action(runtime)
 
@@ -246,7 +247,7 @@ class TestClassification:
         fake_table.list_by_in = AsyncMock(return_value=[_row("sb-alive", state="alive")])
 
         task = SandboxLogArchiveTask(log_root="/data/logs")
-        runtime = _runtime([_FakeExecResult(stdout="sb-alive")])
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="sb-alive")])
 
         result = await task.run_action(runtime)
 
@@ -260,7 +261,7 @@ class TestClassification:
         fake_table.list_by_in = AsyncMock(return_value=[_row("sb-young", state="stopped", stop_time=_iso_days_ago(1))])
 
         task = SandboxLogArchiveTask(log_root="/data/logs")
-        runtime = _runtime([_FakeExecResult(stdout="sb-young")])
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="sb-young")])
 
         result = await task.run_action(runtime)
 
@@ -276,6 +277,7 @@ class TestClassification:
         task = SandboxLogArchiveTask(log_root="/data/logs")
         runtime = _runtime(
             [
+                _FakeExecResult(),  # cleanup stale archives
                 _FakeExecResult(stdout="sb-old"),  # discover
                 _FakeExecResult(stdout=""),  # archive cmd
             ]
@@ -285,7 +287,7 @@ class TestClassification:
 
         assert result["archived"] == 1
         assert result["failed"] == 0
-        assert runtime.execute.await_count == 2
+        assert runtime.execute.await_count == 3
 
     @pytest.mark.asyncio
     async def test_stop_time_malformed_skipped(self, fake_table):
@@ -294,7 +296,7 @@ class TestClassification:
         fake_table.list_by_in = AsyncMock(return_value=[_row("sb-bad", state="stopped", stop_time="not-a-date")])
 
         task = SandboxLogArchiveTask(log_root="/data/logs")
-        runtime = _runtime([_FakeExecResult(stdout="sb-bad")])
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="sb-bad")])
 
         result = await task.run_action(runtime)
 
@@ -317,11 +319,11 @@ class TestArchiveCommand:
         fake_table.list_by_in = AsyncMock(return_value=[_row("sb-1", state="stopped", stop_time=_iso_days_ago(10))])
 
         task = SandboxLogArchiveTask(log_root="/data/logs")
-        runtime = _runtime([_FakeExecResult(stdout="sb-1"), _FakeExecResult()])
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="sb-1"), _FakeExecResult()])
 
         await task.run_action(runtime)
 
-        archive_call = runtime.execute.await_args_list[1]
+        archive_call = runtime.execute.await_args_list[2]
         cmd_obj = archive_call.args[0]
         assert "SECRET_AK" not in cmd_obj.command
         assert "SECRET_SK" not in cmd_obj.command
@@ -337,13 +339,66 @@ class TestArchiveCommand:
         fake_table.list_by_in = AsyncMock(return_value=[_row("sb-x", state="stopped", stop_time=_iso_days_ago(5))])
 
         task = SandboxLogArchiveTask(log_root="/data/logs")
-        runtime = _runtime([_FakeExecResult(stdout="sb-x"), _FakeExecResult()])
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="sb-x"), _FakeExecResult()])
 
         await task.run_action(runtime)
 
-        archive_cmd = runtime.execute.await_args_list[1].args[0].command
+        archive_cmd = runtime.execute.await_args_list[2].args[0].command
         # build_sandbox_log_key("sb-x", "archives/") => "archives/sandbox-logs/sb-x.tar.gz"
         assert "oss://my-bucket/archives/sandbox-logs/sb-x.tar.gz" in archive_cmd
+
+    @pytest.mark.asyncio
+    async def test_stale_archive_cleanup_runs_before_archival(self, fake_table):
+        """Stale sb-archive-* temp dirs must be cleaned before archiving."""
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(lambda: _fake_rock_config(keep_days=3))
+        fake_table.list_by_in = AsyncMock(return_value=[_row("sb-1", state="stopped", stop_time=_iso_days_ago(5))])
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime(
+            [
+                _FakeExecResult(),  # cleanup stale archives
+                _FakeExecResult(stdout="sb-1"),  # discover
+                _FakeExecResult(),  # archive cmd
+            ]
+        )
+
+        result = await task.run_action(runtime)
+
+        assert result["archived"] == 1
+        cleanup_cmd = runtime.execute.await_args_list[0].args[0].command
+        assert "sb-archive-" in cleanup_cmd
+        assert "-mmin +120" in cleanup_cmd
+
+    @pytest.mark.asyncio
+    async def test_archive_timeout_is_3600(self, fake_table):
+        """Archive command must use 3600s timeout (not default 1200s)."""
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(lambda: _fake_rock_config(keep_days=3))
+        fake_table.list_by_in = AsyncMock(return_value=[_row("sb-1", state="stopped", stop_time=_iso_days_ago(5))])
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="sb-1"), _FakeExecResult()])
+
+        await task.run_action(runtime)
+
+        archive_cmd_obj = runtime.execute.await_args_list[2].args[0]
+        assert archive_cmd_obj.timeout == 3600
+
+    @pytest.mark.asyncio
+    async def test_archive_command_checks_oss_existence(self, fake_table):
+        """Archive command must check OSS existence before tar+upload."""
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(lambda: _fake_rock_config(bucket="b", keep_days=3))
+        fake_table.list_by_in = AsyncMock(return_value=[_row("sb-1", state="stopped", stop_time=_iso_days_ago(5))])
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="sb-1"), _FakeExecResult()])
+
+        await task.run_action(runtime)
+
+        archive_cmd = runtime.execute.await_args_list[2].args[0].command
+        assert "ossutil stat" in archive_cmd
 
     @pytest.mark.asyncio
     async def test_one_failure_does_not_abort_loop(self, fake_table):
@@ -360,6 +415,7 @@ class TestArchiveCommand:
         task = SandboxLogArchiveTask(log_root="/data/logs")
         runtime = _runtime(
             [
+                _FakeExecResult(),  # cleanup stale archives
                 _FakeExecResult(stdout="sb-fail\nsb-ok"),  # discover
                 RuntimeError("ossutil down"),  # archive sb-fail raises
                 _FakeExecResult(),  # archive sb-ok succeeds

--- a/tests/unit/sdk/sandbox/test_oss_client.py
+++ b/tests/unit/sdk/sandbox/test_oss_client.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from rock import env_vars
 from rock.actions.sandbox.response import DownloadFileResponse, UploadResponse
 from rock.sdk.sandbox.oss_client import OssClient, OssClientConfig
 
@@ -59,83 +58,34 @@ class TestComputeObjectName:
 
 
 class TestResolveConfig:
-    def test_layer1_env_takes_precedence_over_server(self):
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.endpoint"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", "env-bucket"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", "env-region"),
-        ):
-            cfg = OssClient._resolve_config(
-                {
-                    "Endpoint": "srv.endpoint",
-                    "Bucket": "srv-bucket",
-                    "Region": "srv-region",
-                }
-            )
-        assert cfg.endpoint == "env.endpoint"
-        assert cfg.bucket == "env-bucket"
-        assert cfg.region == "env-region"
-        assert cfg.enabled_via_env is True
-
-    def test_layer2_used_when_env_not_all_set(self):
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
-        ):
-            cfg = OssClient._resolve_config(
-                {
-                    "Endpoint": "srv.endpoint",
-                    "Bucket": "srv-bucket",
-                    "Region": "srv-region",
-                }
-            )
+    def test_complete_server_response_returns_config(self):
+        cfg = OssClient._resolve_config(
+            {"Endpoint": "srv.endpoint", "Bucket": "srv-bucket", "Region": "srv-region"}
+        )
+        assert cfg is not None
         assert cfg.endpoint == "srv.endpoint"
-        assert cfg.enabled_via_env is False
+        assert cfg.bucket == "srv-bucket"
+        assert cfg.region == "srv-region"
+        assert cfg.prefix == ""
 
-    def test_partial_env_does_not_promote_to_layer1(self):
-        # Only endpoint set; bucket / region missing -> not Layer 1, fall back to Layer 2
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.endpoint"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
-        ):
-            cfg = OssClient._resolve_config(
-                {
-                    "Endpoint": "srv.endpoint",
-                    "Bucket": "srv-bucket",
-                    "Region": "srv-region",
-                }
-            )
-        assert cfg.endpoint == "srv.endpoint"
-        assert cfg.enabled_via_env is False
+    def test_server_response_with_prefix(self):
+        cfg = OssClient._resolve_config(
+            {"Endpoint": "srv", "Bucket": "b", "Region": "r", "Prefix": "rock-transfer/"}
+        )
+        assert cfg is not None
+        assert cfg.prefix == "rock-transfer/"
 
-    def test_layer3_returns_none_when_neither_layer_complete(self):
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
-        ):
-            cfg = OssClient._resolve_config({"Endpoint": None, "Bucket": None, "Region": None})
+    def test_partial_server_response_returns_none(self):
+        # Missing Region → incomplete
+        cfg = OssClient._resolve_config({"Endpoint": "srv", "Bucket": "b", "Region": None})
         assert cfg is None
 
-    def test_server_partial_treated_as_unavailable(self):
-        # Server returns endpoint/bucket but no region -> Layer 2 incomplete -> unavailable
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
-        ):
-            cfg = OssClient._resolve_config({"Endpoint": "x", "Bucket": "y", "Region": None})
+    def test_empty_response_returns_none(self):
+        cfg = OssClient._resolve_config({})
         assert cfg is None
 
-    def test_empty_dict_returns_none(self):
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
-        ):
-            cfg = OssClient._resolve_config({})
+    def test_all_none_returns_none(self):
+        cfg = OssClient._resolve_config({"Endpoint": None, "Bucket": None, "Region": None})
         assert cfg is None
 
 
@@ -203,74 +153,11 @@ class TestIsTokenExpired:
 
 
 class TestSetup:
-    async def test_layer1_env_with_enable_true(self):
+    async def test_server_config_sets_up_bucket(self):
         sandbox = _make_sandbox()
         client = OssClient(sandbox)
 
         with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.endpoint"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", "env-bucket"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", "env-region"),
-            patch.object(env_vars, "ROCK_OSS_ENABLE", True),
-            patch("rock.sdk.sandbox.oss_client.HttpUtils") as mock_http,
-            patch("rock.sdk.sandbox.oss_client.oss2") as mock_oss2,
-        ):
-            mock_http.get = AsyncMock(
-                return_value={
-                    "status": "Success",
-                    "result": {
-                        "AccessKeyId": "ak",
-                        "AccessKeySecret": "sk",
-                        "SecurityToken": "tok",
-                        "Expiration": "2099-01-01T00:00:00Z",
-                    },
-                }
-            )
-            mock_oss2.Bucket = MagicMock(return_value="bucket-instance")
-            ok = await client.ensure_setup()
-
-        assert ok is True
-        assert client.is_available is True
-        mock_oss2.Bucket.assert_called_once()
-        kwargs = mock_oss2.Bucket.call_args.kwargs
-        assert kwargs["endpoint"] == "env.endpoint"
-        assert kwargs["bucket_name"] == "env-bucket"
-
-    async def test_layer1_env_with_enable_false_returns_unavailable(self):
-        sandbox = _make_sandbox()
-        client = OssClient(sandbox)
-
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", "env.endpoint"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", "env-bucket"),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", "env-region"),
-            patch.object(env_vars, "ROCK_OSS_ENABLE", False),
-            patch("rock.sdk.sandbox.oss_client.HttpUtils") as mock_http,
-        ):
-            mock_http.get = AsyncMock(
-                return_value={
-                    "status": "Success",
-                    "result": {
-                        "AccessKeyId": "ak",
-                        "AccessKeySecret": "sk",
-                        "SecurityToken": "tok",
-                        "Expiration": "2099-01-01T00:00:00Z",
-                    },
-                }
-            )
-            ok = await client.ensure_setup()
-
-        assert ok is False
-        assert client.is_available is False
-
-    async def test_layer2_server_response_used_when_env_unset(self):
-        sandbox = _make_sandbox()
-        client = OssClient(sandbox)
-
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
             patch("rock.sdk.sandbox.oss_client.HttpUtils") as mock_http,
             patch("rock.sdk.sandbox.oss_client.oss2") as mock_oss2,
         ):
@@ -293,19 +180,17 @@ class TestSetup:
 
         assert ok is True
         assert client.is_available is True
+        mock_oss2.Bucket.assert_called_once()
         kwargs = mock_oss2.Bucket.call_args.kwargs
         assert kwargs["endpoint"] == "srv.endpoint"
+        assert kwargs["bucket_name"] == "srv-bucket"
+        assert kwargs["region"] == "srv-region"
 
-    async def test_layer3_unavailable_when_neither_set(self):
+    async def test_unavailable_when_server_does_not_return_config(self):
         sandbox = _make_sandbox()
         client = OssClient(sandbox)
 
-        with (
-            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
-            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
-            patch("rock.sdk.sandbox.oss_client.HttpUtils") as mock_http,
-        ):
+        with patch("rock.sdk.sandbox.oss_client.HttpUtils") as mock_http:
             mock_http.get = AsyncMock(
                 return_value={
                     "status": "Success",
@@ -492,7 +377,7 @@ class TestDownloadViaOss:
 
         client = OssClient(sandbox)
         client._bucket = MagicMock()
-        client._client_config = OssClientConfig("ep", "bk", "rg", enabled_via_env=False)
+        client._client_config = OssClientConfig("ep", "bk", "rg")
 
         response = await client.download_via_oss("/sandbox/foo.txt", tmp_path / "foo.txt")
         assert response.success is False
@@ -608,3 +493,48 @@ def test_compute_object_name_no_prefix_keeps_legacy_layout():
         sandbox_path="/data/x",
     )
     assert "/" not in name  # flat layout
+
+
+def test_compute_object_name_whitespace_only_prefix_treated_as_empty():
+    """A prefix that is just whitespace must NOT produce '   /<digest>-x'."""
+    name = OssClient._compute_object_name(
+        sandbox_id="sb-1",
+        local_path="/tmp/x",
+        sandbox_path="/data/x",
+        prefix="   ",
+    )
+    assert "/" not in name
+    assert " " not in name
+    assert name.endswith("-x")
+
+
+def test_compute_object_name_collapses_internal_double_slashes():
+    """Server-pushed prefix with stray '//' should be normalized in the OSS key."""
+    name = OssClient._compute_object_name(
+        sandbox_id="sb-1",
+        local_path="/tmp/x",
+        sandbox_path="/data/x",
+        prefix="rock//transfer///",
+    )
+    assert name.startswith("rock/transfer/")
+    assert "//" not in name
+
+
+def test_compute_object_name_none_prefix_is_treated_as_empty():
+    name = OssClient._compute_object_name(
+        sandbox_id="sb-1",
+        local_path="/tmp/x",
+        sandbox_path="/data/x",
+        prefix=None,
+    )
+    assert "/" not in name
+
+
+def test_compute_object_name_empty_string_prefix_is_treated_as_empty():
+    name = OssClient._compute_object_name(
+        sandbox_id="sb-1",
+        local_path="/tmp/x",
+        sandbox_path="/data/x",
+        prefix="",
+    )
+    assert "/" not in name

--- a/tests/unit/utils/test_archive_command.py
+++ b/tests/unit/utils/test_archive_command.py
@@ -25,10 +25,19 @@ class TestArchiveCommandBuildCommand:
     def test_starts_with_set_e_so_failures_short_circuit(self):
         # `set -e` is what guarantees the trailing `rm -rf <log_dir>` is
         # skipped on tar / ossutil failure, so retry can re-archive cleanly.
-        # Triple-quoted multi-line string emits `set -e \\\n&& ...` (bash treats
-        # `\<newline>` as line continuation, so it's still one chained command).
+        # The leading `find /tmp ... sb-archive-*` cleanup is a best-effort
+        # sweep and is intentionally NOT in the && chain (it must not abort
+        # the archive run if find errors out), so the `set -e` chain starts
+        # right after the cleanup line ends with `;`.
         cmd = ArchiveCommand.build_command("/data/logs/sb-1", "k", "b", "e")
-        assert cmd.startswith("set -e \\\n&&")
+        assert "set -e \\\n&&" in cmd, "set -e must drive the && chain"
+        # The first &&-chained line must be `set -e` so any subsequent
+        # failure (tar/ossutil) short-circuits before the final `rm -rf`.
+        chain_start = cmd.index("set -e \\\n&&")
+        assert "; \\\nset -e" in cmd[: chain_start + len("set -e \\\n&&")], (
+            "the stale-archive cleanup must terminate with `;` so its exit "
+            "code does not abort the archive chain"
+        )
 
     def test_uses_mktemp_and_traps_exit_for_cleanup(self):
         # ossutil 1.7.x cannot read stdin, so we must land a temp tarball;
@@ -36,6 +45,17 @@ class TestArchiveCommandBuildCommand:
         cmd = ArchiveCommand.build_command("/data/logs/sb-1", "k", "b", "e")
         assert "mktemp -d" in cmd
         assert "trap " in cmd and "EXIT" in cmd
+
+    def test_traps_soft_signals_so_exit_trap_fires(self):
+        # k8s graceful shutdown / runtime.execute timeout / Ctrl-C / SSH HUP
+        # all deliver soft signals (TERM/INT/HUP). Without explicit traps,
+        # bash terminates on the default action and skips the EXIT trap,
+        # leaving multi-GB sb-archive-* dirs behind. Each soft trap simply
+        # `exit`s with the conventional 128+signo code so EXIT still fires.
+        cmd = ArchiveCommand.build_command("/data/logs/sb-1", "k", "b", "e")
+        assert "trap 'exit 130' INT" in cmd, "Ctrl-C must trigger EXIT cleanup"
+        assert "trap 'exit 143' TERM" in cmd, "SIGTERM (k8s/timeout) must trigger EXIT cleanup"
+        assert "trap 'exit 129' HUP" in cmd, "SIGHUP (SSH disconnect) must trigger EXIT cleanup"
 
     def test_writes_ossutil_config_with_endpoint_and_env_var_credentials(self):
         # ossutil 1.7.x ignores OSS_ACCESS_KEY_* env vars, so we materialize


### PR DESCRIPTION
Closes the backport tracked in issue #1157 
This PR cherry-picks 6 commits from `master` onto `release/v1.9`. All
patch-ids preserved except `pyproject.toml` version, where the merge
conflict was resolved in favor of `1.9.3` (release line) over `1.9.1`
(the original commit's base).

## Commits (in order)

| master SHA | new SHA on this branch | Title |
|---|---|---|
| `ae64723f8` | `65dff24d8` | fix(admin): guard FileCleanupTask Step 2 empty-dir delete with -mmin |
| `357682d84` | `0928c70a4` | Feat/fiber support cpu overcut 0521 (#1117) |
| `17ca0f96e` | `8157526f8` | fix(archive): self-healing cleanup for stale sb-archive temp dirs |
| `b5835bf2d` | `771889db8` | fix(archive): trap soft signals so EXIT cleanup fires on SIGTERM/INT/HUP |
| `474a223e9` | `3b730aec4` | feat(sdk-py): server-first OSS config + prefix-aware object keys (hardened) |
| `68419a3c7` | `63f614788` | feat(sdk-ts): server-first OSS config + prefix-aware object keys (hardened) + perf |

## Why these six

### Bug fixes affecting v1.9 deployments today

- **`8157526f8` / `771889db8` (archive cleanup)** — release/v1.9 is
  leaking stale `sb-archive-*` temp dirs on SIGTERM/INT/HUP, the soft
  signals send by k8s/runc on pod eviction. Without the trap, the EXIT
  trap never fires and the temp dir survives. Self-healing cleanup
  catches existing leaks too.
- **`65dff24d8` (FileCleanupTask -mmin guard)** — Step 2 was racing
  against concurrent sandbox starts and deleting freshly-created empty
  dirs. The `-mmin +N` predicate fences out anything younger than the
  threshold.

### Production 403 fix (server-first OSS SDK)

- **`3b730aec4` (Python SDK)** + **`63f614788` (TypeScript SDK)** — both
  remove `ROCK_OSS_BUCKET_NAME` / `ROCK_OSS_BUCKET_ENDPOINT` /
  `ROCK_OSS_BUCKET_REGION` / `ROCK_OSS_ENABLE` env reads. Bucket and
  STS now both come from the same `/get_token?account=primary` call,
  eliminating the env-vs-STS drift that was returning 403 AccessDenied.
  Object keys now honor the server-pushed prefix
  (`rock-transfer/...`) so chatos-rock RAM policy and lifecycle pick
  them up.
  - Python: 44 unit tests pass; integration test_file_system updated.
  - TS: 63 unit tests pass (3 buildOssObjectName edge tests, 4
    normalizeRegion tests, 2 credential-cache tests added).

### Feature already in master

- **`0928c70a4` (fiber CPU overcut)** — pulled in to keep
  release/v1.9 aligned with master on scheduler behavior.

## Conflict resolution

Only `pyproject.toml` had a conflict during cherry-pick:
