### PR TITLE
feat(sdk): inject sandbox_image and sandbox_id into harbor labels

### DIFF
--- a/rock/sdk/job/trial/harbor.py
+++ b/rock/sdk/job/trial/harbor.py
@@ -52,10 +52,18 @@ class HarborTrial(AbstractTrial):
 
     async def setup(self, sandbox) -> None:
         await super().setup(sandbox)
+        self._inject_runtime_labels(sandbox)
         # Write Harbor YAML config to sandbox
         yaml_content = self._config.to_harbor_yaml()
         config_path = f"{USER_DEFINED_LOGS}/rock_job_{self._config.job_name}.yaml"
         await sandbox.write_file_by_path(yaml_content, config_path)
+
+    def _inject_runtime_labels(self, sandbox) -> None:
+        labels = self._config.labels
+        if self._config.environment.image:
+            labels.setdefault("rock_sandbox_image", self._config.environment.image)
+        if sandbox.sandbox_id:
+            labels.setdefault("rock_sandbox_id", sandbox.sandbox_id)
 
     def build(self) -> str:
         config_path = f"{USER_DEFINED_LOGS}/rock_job_{self._config.job_name}.yaml"

--- a/tests/unit/sdk/job/test_blue_green_equivalence.py
+++ b/tests/unit/sdk/job/test_blue_green_equivalence.py
@@ -113,7 +113,10 @@ class TestBlueGreenEquivalence:
         with patch("rock.sdk.job.executor.Sandbox", return_value=mock_green):
             green_result = await GreenJob(_make_config()).run()
 
-        assert blue_result.labels == green_result.labels == {"team": "rl", "step": "1"}
+        user_labels = {"team": "rl", "step": "1"}
+        assert user_labels.items() <= blue_result.labels.items()
+        assert user_labels.items() <= green_result.labels.items()
+        assert green_result.labels == {**user_labels, "rock_sandbox_id": "sb-bg", "rock_sandbox_image": "python:3.11"}
 
     async def test_raw_output_and_exit_code_populated_on_both(self):
         from rock.sdk.bench import Job as BlueJob

--- a/tests/unit/sdk/job/test_proxy_integration.py
+++ b/tests/unit/sdk/job/test_proxy_integration.py
@@ -258,6 +258,7 @@ class TestHarborTrialSetupCallsProxy:
         trial = HarborTrial(cfg)
 
         sandbox = AsyncMock()
+        sandbox.sandbox_id = "sb-test"
         sandbox.write_file_by_path = AsyncMock()
 
         order: list[str] = []

--- a/tests/unit/sdk/job/test_trial_harbor.py
+++ b/tests/unit/sdk/job/test_trial_harbor.py
@@ -52,6 +52,7 @@ class TestHarborTrialSetup:
         cfg = HarborJobConfig(job_name="test", experiment_id="exp-1")
         trial = HarborTrial(cfg)
         mock_sandbox = AsyncMock()
+        mock_sandbox.sandbox_id = "sb-test"
         mock_sandbox.fs.upload_dir = AsyncMock(return_value=_success_obs())
         mock_sandbox.write_file_by_path = AsyncMock()
 


### PR DESCRIPTION
HarborTrial.setup() auto-injects sandbox_image and sandbox_id into config.labels before serializing YAML, so they appear in harbor's config.json and are available for downstream consumption.

(cherry picked from commit 0966d8b5a0e8ccb9c6bc7feee7e44880e1e8b583)