### PR TITLE
feat(oss): split user-facing `endpoint` from in-sandbox/worker `sandbox_endpoint`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 authors = [{ name = "chatos@alibaba" }]
 requires-python = "<4.0,>=3.10"
 name = "rl-rock"
-version = "1.9.0"
+version = "1.9.1"
 description = "ROCK-Reinforcement Open Construction Kit"
 readme = "README.md"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 authors = [{ name = "chatos@alibaba" }]
 requires-python = "<4.0,>=3.10"
 name = "rl-rock"
-version = "1.9.1"
+version = "1.9.2"
 description = "ROCK-Reinforcement Open Construction Kit"
 readme = "README.md"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 authors = [{ name = "chatos@alibaba" }]
 requires-python = "<4.0,>=3.10"
 name = "rl-rock"
-version = "1.8.3"
+version = "1.9.0"
 description = "ROCK-Reinforcement Open Construction Kit"
 readme = "README.md"
 dependencies = [

--- a/rock-conf/rock-dev.yml
+++ b/rock-conf/rock-dev.yml
@@ -44,6 +44,22 @@ k8s:
                   rocklet
 
 
+# Image registry mirror — configured via Nacos (hot-reload supported).
+# Nacos YAML format:
+#
+# image_registry_mirrors:
+#   - registry: "rock-registry.cn-hangzhou.cr.aliyuncs.com"
+#     namespace: "rock-public"
+#     username: "user"            # optional
+#     password: "<plaintext>"     # optional
+#   - registry: "rock-registry-backup.cn-hangzhou.cr.aliyuncs.com"
+#     namespace: "rock-mirror"
+#
+# image_mirror_lookup_allowlist:  # empty = disabled, ["*"] = all images
+#   - "*"
+#   - "swe-bench:"               # bare image name prefix
+#   - "aaaaaa/bbb/"              # registry/namespace prefix
+
 # Runtime configuration
 runtime:
   # Operator type: 'ray' or 'k8s'

--- a/rock-conf/rock-local.yml
+++ b/rock-conf/rock-local.yml
@@ -8,6 +8,22 @@ warmup:
     images:
       - "python:3.11"
 
+# Image registry mirror — configured via Nacos (hot-reload supported).
+# Nacos YAML format:
+#
+# image_registry_mirrors:
+#   - registry: "rock-registry.cn-hangzhou.cr.aliyuncs.com"
+#     namespace: "rock-public"
+#     username: "user"            # optional
+#     password: "<plaintext>"     # optional
+#   - registry: "rock-registry-backup.cn-hangzhou.cr.aliyuncs.com"
+#     namespace: "rock-mirror"
+#
+# image_mirror_lookup_allowlist:  # empty = disabled, ["*"] = all images
+#   - "*"
+#   - "swe-bench:"               # bare image name prefix
+#   - "aaaaaa/bbb/"              # registry/namespace prefix
+
 # Scheduler configuration
 scheduler:
   enabled: true                    # Whether to enable the scheduler

--- a/rock-conf/rock-local.yml
+++ b/rock-conf/rock-local.yml
@@ -24,6 +24,16 @@ warmup:
 #   - "swe-bench:"               # bare image name prefix
 #   - "aaaaaa/bbb/"              # registry/namespace prefix
 
+# Inject INSTANCE_ROCK_REGISTRY into every launched sandbox so the
+# runtime can rewrite prebuilt images to a ROCK mirror first.
+# Configured via YAML or Nacos (hot-reload supported).
+# Nacos YAML format:
+#
+# runtime:
+#   instance_registry_mirrors:
+#     - "reg-a.aliyuncs.com/mirror-1"
+#     - "reg-b.aliyuncs.com/mirror-2"
+
 # Scheduler configuration
 scheduler:
   enabled: true                    # Whether to enable the scheduler

--- a/rock/admin/entrypoints/sandbox_api.py
+++ b/rock/admin/entrypoints/sandbox_api.py
@@ -1,6 +1,9 @@
 import math
+import re
+import time
 from typing import Annotated, Any
 
+import httpx
 from fastapi import APIRouter, Body, Depends, File, Form, UploadFile
 
 from rock.actions import (
@@ -38,9 +41,17 @@ from rock.common.constants import (
 )
 from rock.common.exception import handle_exceptions
 from rock.common.validation import NonBlankStr
+from rock.config import ImageRegistryMirror
 from rock.deployments.config import AcceleratorType, DockerDeploymentConfig
+from rock.logger import init_logger
 from rock.sandbox.sandbox_manager import SandboxManager
 from rock.sdk.common.exceptions import BadRequestRockError
+from rock.utils.docker import ImageUtil
+
+logger = init_logger(__name__)
+
+_MIRROR_PROBE_CACHE: dict[str, tuple[bool, float]] = {}
+_MIRROR_PROBE_TTL_SECONDS = 60.0
 
 sandbox_router = APIRouter()
 sandbox_manager: SandboxManager
@@ -92,6 +103,149 @@ async def _apply_disk_limits(config: DockerDeploymentConfig) -> None:
             disk_limit_rootfs = nacos_rootfs
 
     config.disk_limit_rootfs = disk_limit_rootfs
+
+
+def _probe_cache_get(candidate: str) -> bool | None:
+    entry = _MIRROR_PROBE_CACHE.get(candidate)
+    if entry is None:
+        return None
+    hit, expires_at = entry
+    if expires_at < time.monotonic():
+        _MIRROR_PROBE_CACHE.pop(candidate, None)
+        return None
+    return hit
+
+
+def _probe_cache_set(candidate: str, hit: bool) -> None:
+    _MIRROR_PROBE_CACHE[candidate] = (hit, time.monotonic() + _MIRROR_PROBE_TTL_SECONDS)
+
+
+def _apply_mirror_hit(config: DockerDeploymentConfig, mirror, candidate: str) -> None:
+    config.image = candidate
+    if mirror.username and mirror.password:
+        config.registry_username = mirror.username
+        config.registry_password = mirror.password
+
+
+def _parse_bearer_challenge(header: str) -> dict[str, str]:
+    """Parse ``realm``, ``service``, ``scope`` from a Bearer WWW-Authenticate header."""
+    return {m.group(1): m.group(2) for m in re.finditer(r'(\w+)="([^"]*)"', header)}
+
+
+async def _http_probe_manifest(
+    registry: str,
+    repo: str,
+    tag: str,
+    username: str | None = None,
+    password: str | None = None,
+    timeout: float = 5,
+) -> bool:
+    """Check whether ``repo:tag`` exists on *registry* via the v2 manifest API."""
+    url = f"https://{registry}/v2/{repo}/manifests/{tag}"
+    headers = {"Accept": "application/vnd.docker.distribution.manifest.v2+json"}
+    auth = (username, password) if username and password else None
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        resp = await client.get(url, headers=headers, auth=auth)
+
+        if resp.status_code == 401 and "www-authenticate" in resp.headers:
+            www_auth = resp.headers["www-authenticate"]
+            if www_auth.startswith("Bearer "):
+                params = _parse_bearer_challenge(www_auth)
+                realm = params.get("realm", "")
+                service = params.get("service", "")
+                scope = params.get("scope", "")
+                token_url = f"{realm}?service={service}&scope={scope}"
+                token_resp = await client.get(token_url, auth=auth)
+                if token_resp.status_code == 200:
+                    data = token_resp.json()
+                    token = data.get("token") or data.get("access_token")
+                    if token:
+                        headers["Authorization"] = f"Bearer {token}"
+                        resp = await client.get(url, headers=headers)
+
+        return resp.status_code == 200
+
+
+async def _apply_image_registry_mirror(config: DockerDeploymentConfig) -> None:
+    """Rewrite ``config.image`` to an internal mirror copy when one exists.
+
+    Gated by ``rock_config.image_mirror_lookup_allowlist`` (opt-in): empty list
+    disables the lookup for every image; ``["*"]`` enables it for all; otherwise
+    only images whose full string starts with one of the listed prefixes are
+    considered.
+
+    For allowed images, iterates ``rock_config.image_registry_mirrors`` in
+    declared order, probes via the registry v2 manifest API and uses the first
+    hit. Digest references (``name@sha256:...``) are skipped entirely.
+    """
+    nacos = sandbox_manager.rock_config.nacos_provider
+    nacos_cfg = (await nacos.get_config() or {}) if nacos else {}
+
+    allowlist = nacos_cfg.get(
+        "image_mirror_lookup_allowlist",
+        sandbox_manager.rock_config.image_mirror_lookup_allowlist,
+    )
+    if not allowlist:
+        return
+    if "*" not in allowlist and not any(config.image.startswith(p) for p in allowlist):
+        return
+
+    raw_mirrors = nacos_cfg.get("image_registry_mirrors")
+    if raw_mirrors is not None:
+        mirrors = [ImageRegistryMirror(**m) for m in raw_mirrors]
+    else:
+        mirrors = sandbox_manager.rock_config.image_registry_mirrors
+    if not mirrors:
+        return
+
+    _, repo_and_tag = ImageUtil.parse_registry_and_others(config.image)
+    if "/" in repo_and_tag:
+        _, name_tag = repo_and_tag.split("/", 1)
+    else:
+        name_tag = repo_and_tag
+    if "@" in name_tag:
+        logger.info(
+            f"image registry mirror skip for digest reference {config.image!r} "
+            "(content-addressed, mirror replacement would change semantics)"
+        )
+        return
+    if ":" not in name_tag:
+        name_tag = f"{name_tag}:{ImageUtil.DEFAULT_TAG}"
+    original_image = config.image
+
+    image_name, tag = name_tag.rsplit(":", 1)
+    for mirror in mirrors:
+        if not mirror.registry or not mirror.namespace:
+            continue
+        candidate = f"{mirror.registry}/{mirror.namespace}/{name_tag}"
+
+        cached = _probe_cache_get(candidate)
+        if cached is True:
+            logger.info(f"image registry mirror hit (cached): {original_image!r} -> {candidate!r}")
+            _apply_mirror_hit(config, mirror, candidate)
+            return
+        if cached is False:
+            continue
+
+        try:
+            hit = await _http_probe_manifest(
+                registry=mirror.registry,
+                repo=f"{mirror.namespace}/{image_name}",
+                tag=tag,
+                username=mirror.username,
+                password=mirror.password,
+            )
+        except Exception as e:
+            logger.warning(f"image registry mirror probe failed for {candidate!r}: {e}")
+            continue
+
+        _probe_cache_set(candidate, hit)
+        if hit:
+            logger.info(f"image registry mirror hit: {original_image!r} -> {candidate!r}")
+            _apply_mirror_hit(config, mirror, candidate)
+            return
+    logger.info(f"image registry mirror miss for {original_image!r}, keep original")
 
 
 async def _apply_accelerator_type_validation(config: DockerDeploymentConfig) -> None:
@@ -166,6 +320,7 @@ async def start(request: SandboxStartRequest) -> RockResponse[SandboxStartRespon
     await _apply_kata_runtime_switch(config)
     await _apply_kata_disk_size(config)
     await _apply_disk_limits(config)
+    await _apply_image_registry_mirror(config)
     sandbox_start_response = await sandbox_manager.start(config)
     return RockResponse(result=sandbox_start_response)
 
@@ -182,6 +337,7 @@ async def start_async(
     await _apply_kata_disk_size(config)
     await _apply_cpu_overcommit_default(config, headers.user_info.get("rock_authorization"))
     await _apply_disk_limits(config)
+    await _apply_image_registry_mirror(config)
     sandbox_start_response = await sandbox_manager.start_async(
         config,
         user_info=headers.user_info,

--- a/rock/admin/entrypoints/sandbox_api.py
+++ b/rock/admin/entrypoints/sandbox_api.py
@@ -122,9 +122,8 @@ def _probe_cache_set(candidate: str, hit: bool) -> None:
 
 def _apply_mirror_hit(config: DockerDeploymentConfig, mirror, candidate: str) -> None:
     config.image = candidate
-    if mirror.username and mirror.password:
-        config.registry_username = mirror.username
-        config.registry_password = mirror.password
+    config.registry_username = mirror.username
+    config.registry_password = mirror.password
 
 
 def _parse_bearer_challenge(header: str) -> dict[str, str]:

--- a/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
+++ b/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
@@ -139,7 +139,10 @@ class SandboxLogArchiveTask(BaseTask):
 
         primary = rock_config.oss.primary
         bucket = primary.bucket
-        endpoint = primary.endpoint
+        # Workers sit inside the VPC, so prefer the in-VPC endpoint when set.
+        # Falls back to the public `endpoint` for legacy YAMLs that only have
+        # one endpoint configured.
+        endpoint = primary.sandbox_endpoint or primary.endpoint
         access_key_id = primary.access_key_id
         access_key_secret = primary.access_key_secret
         if not (bucket and endpoint and access_key_id and access_key_secret):

--- a/rock/cli/command/model_service.py
+++ b/rock/cli/command/model_service.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import os
 import sys
 from pathlib import Path
 
@@ -109,8 +110,13 @@ class ModelServiceCommand(Command):
             return
         if "anti-call-llm" == sub_command:
             logger.debug("start to anti call llm")
+            response = args.response
+            if args.response_file:
+                with open(args.response_file) as f:
+                    response = f.read()
+                os.unlink(args.response_file)
             model_client = ModelClient()
-            next_request = await model_client.anti_call_llm(index=args.index, last_response=args.response)
+            next_request = await model_client.anti_call_llm(index=args.index, last_response=response)
             # necessary: print next_request to stdout, and do NOT print anything else
             print(next_request)
 
@@ -230,4 +236,8 @@ class ModelServiceCommand(Command):
         anti_call_llm_parser.add_argument(
             "--index", required=True, type=int, help="index of last llm call, start from 0"
         )
-        anti_call_llm_parser.add_argument("--response", required=False, help="response of last llm call")
+        response_group = anti_call_llm_parser.add_mutually_exclusive_group()
+        response_group.add_argument("--response", required=False, help="response of last llm call")
+        response_group.add_argument(
+            "--response-file", required=False, help="path to file containing response of last llm call"
+        )

--- a/rock/cli/command/storage.py
+++ b/rock/cli/command/storage.py
@@ -91,10 +91,10 @@ class StorageCommand(Command):
         get_p.add_argument(
             "--archive-prefix",
             dest="archive_prefix",
-            default="",
+            default="rock-archives/",
             help=(
                 "OSS key prefix used at archive time (must match admin's "
-                "sandbox_config.log.archive_prefix, e.g. 'rock-archives/')."
+                "sandbox_config.log.archive_prefix). Default: 'rock-archives/'."
             ),
         )
         get_p.add_argument(

--- a/rock/config.py
+++ b/rock/config.py
@@ -200,6 +200,16 @@ class SchedulerConfig:
 
 
 @dataclass
+class ImageRegistryMirror:
+    """A single internal registry that may host a mirrored copy of the sandbox image."""
+
+    registry: str = ""
+    namespace: str = ""
+    username: str | None = None
+    password: str | None = None
+
+
+@dataclass
 class PoolConfig:
     """Pool configuration with resource and port settings."""
 
@@ -336,6 +346,8 @@ class RockConfig:
     proxy_service: ProxyServiceConfig = field(default_factory=ProxyServiceConfig)
     scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
     database: DatabaseConfig = field(default_factory=DatabaseConfig)
+    image_registry_mirrors: list[ImageRegistryMirror] = field(default_factory=list)
+    image_mirror_lookup_allowlist: list[str] = field(default_factory=list)
     nacos_provider: NacosConfigProvider | None = None
 
     @classmethod
@@ -391,6 +403,11 @@ class RockConfig:
             kwargs["scheduler"] = SchedulerConfig(**config["scheduler"])
         if "database" in config:
             kwargs["database"] = DatabaseConfig(**config["database"])
+        if "image_registry_mirrors" in config:
+            raw_mirrors = config["image_registry_mirrors"] or []
+            kwargs["image_registry_mirrors"] = [ImageRegistryMirror(**m) for m in raw_mirrors]
+        if "image_mirror_lookup_allowlist" in config:
+            kwargs["image_mirror_lookup_allowlist"] = list(config["image_mirror_lookup_allowlist"] or [])
 
         return cls(**kwargs)
 
@@ -488,6 +505,14 @@ class RockConfig:
             if key in nacos_result:
                 setattr(self, attr_name, config_class(**nacos_result[key]))
 
+        if "image_registry_mirrors" in nacos_result:
+            raw_mirrors = nacos_result["image_registry_mirrors"] or []
+            self.image_registry_mirrors = [ImageRegistryMirror(**m) for m in raw_mirrors]
+        if "image_mirror_lookup_allowlist" in nacos_result:
+            self.image_mirror_lookup_allowlist = list(nacos_result["image_mirror_lookup_allowlist"] or [])
+
         logger.info(
             f"Updated config from Nacos: sandbox_config={self.sandbox_config}, proxy_service={self.proxy_service}"
+            f", image_registry_mirrors={self.image_registry_mirrors}"
+            f", image_mirror_lookup_allowlist={self.image_mirror_lookup_allowlist}"
         )

--- a/rock/config.py
+++ b/rock/config.py
@@ -63,11 +63,10 @@ class SandboxLogConfig:
     bucket / credentials still belong to OssConfig.primary.
     """
 
-    archive_prefix: str = ""
+    archive_prefix: str = "rock-archives/"
     """OSS object key prefix under OssConfig.primary.bucket for sandbox-log
-    archives. Empty (default) means each deployment's YAML must opt-in
-    explicitly to a value matching its OSS bucket lifecycle rule (e.g.
-    "rock-archives/")."""
+    archives. The canonical default ``rock-archives/`` ensures all clusters
+    write to a unified namespace. Override only for migration scenarios."""
 
     keep_days_before_archive: int = 3
     """Days to wait after sandbox stop before archiving. Gives operators

--- a/rock/config.py
+++ b/rock/config.py
@@ -274,6 +274,12 @@ class RuntimeConfig:
     sandbox_disk_limit_rootfs: str | None = None
     """Default rootfs quota per container. None means no limit. Can be overridden by nacos key 'default_disk_limit'."""
 
+    instance_registry_mirrors: list[str] = field(default_factory=list)
+    """Registry mirrors injected into each launched sandbox as
+    INSTANCE_ROCK_REGISTRY=<comma-joined>. Each entry is a host/namespace
+    string (e.g. "reg-a.aliyuncs.com/mirror-1"). When empty, the env var is
+    not set and downstream tools skip mirror rewriting."""
+
     def __post_init__(self) -> None:
         # Convert dict to StandardSpec if needed
         if isinstance(self.standard_spec, dict):
@@ -511,8 +517,14 @@ class RockConfig:
         if "image_mirror_lookup_allowlist" in nacos_result:
             self.image_mirror_lookup_allowlist = list(nacos_result["image_mirror_lookup_allowlist"] or [])
 
+        if "runtime" in nacos_result and isinstance(nacos_result["runtime"], dict):
+            runtime_overrides = nacos_result["runtime"]
+            if "instance_registry_mirrors" in runtime_overrides:
+                self.runtime.instance_registry_mirrors = list(runtime_overrides["instance_registry_mirrors"] or [])
+
         logger.info(
             f"Updated config from Nacos: sandbox_config={self.sandbox_config}, proxy_service={self.proxy_service}"
             f", image_registry_mirrors={self.image_registry_mirrors}"
             f", image_mirror_lookup_allowlist={self.image_mirror_lookup_allowlist}"
+            f", instance_registry_mirrors={self.runtime.instance_registry_mirrors}"
         )

--- a/rock/config.py
+++ b/rock/config.py
@@ -128,6 +128,20 @@ class OssAccountConfig:
     """Region used to construct the STS AcsClient for this account. Falls back
     to env_vars.ROCK_OSS_BUCKET_REGION when empty, to preserve legacy behavior."""
 
+    sandbox_endpoint: str = ""
+    """In-VPC OSS endpoint for code that runs INSIDE a sandbox or ON a worker
+    (e.g. ossutil download inside a sandbox container, archive upload from a
+    worker host). When non-empty, callers in those execution contexts SHOULD
+    use this endpoint instead of `endpoint`, because workers and sandboxes
+    typically sit inside the VPC and benefit from the internal endpoint (no
+    public bandwidth charge, lower latency).
+
+    `endpoint` remains the user/SDK-facing endpoint (used by the host-side
+    Python SDK / oss2 client on the developer's machine, and returned to the
+    SDK via `/get_token`). When `sandbox_endpoint` is empty, callers MUST
+    fall back to `endpoint` so legacy YAMLs that only set `endpoint` continue
+    to work."""
+
 
 @dataclass
 class OssConfig:

--- a/rock/deployments/docker.py
+++ b/rock/deployments/docker.py
@@ -523,8 +523,6 @@ class DockerDeployment(AbstractDeployment):
         if self._config.remove_container:
             rm_arg = ["--rm"]
 
-        env_arg = []
-
         # Conditionally set up logging path mount based on ROCK_LOGGING_PATH.
         log_file_path: str | None = None
         volume_args = self._prepare_volume_mounts()
@@ -533,23 +531,17 @@ class DockerDeployment(AbstractDeployment):
             os.makedirs(log_file_path, exist_ok=True)
             os.chmod(log_file_path, 0o777)
             volume_args.extend(["-v", f"{log_file_path}:{env_vars.ROCK_LOGGING_PATH}"])
-            env_arg = [
-                "-e",
-                f"ROCK_LOGGING_PATH={env_vars.ROCK_LOGGING_PATH}",
-                "-e",
-                f"ROCK_LOGGING_LEVEL={env_vars.ROCK_LOGGING_LEVEL}",
-            ]
 
-        env_arg.extend(["-e", f"ROCK_TIME_ZONE={env_vars.ROCK_TIME_ZONE}"])
         volume_args.extend(self._prepare_timezone_mount())
 
-        # Kata DinD: prepare disk image and add volume mount + env var
+        # Kata DinD: prepare disk image and add volume mount
         if self._config.use_kata_runtime:
             with StageTimer("startup_timing", f"[{self._container_name}] Kata disk prepare", logger):
                 self._prepare_kata_disk()
             disk_path = self._get_kata_disk_image_path()
             volume_args.extend(["-v", f"{disk_path}:/docker-disk.img"])
-            env_arg.extend(["-e", "ROCK_KATA_RUNTIME=true"])
+
+        env_arg = self._build_env_args()
 
         with StageTimer("startup_timing", f"[{self._container_name}] Random sleep", logger):
             time.sleep(random.randint(0, 5))
@@ -610,6 +602,32 @@ class DockerDeployment(AbstractDeployment):
             await self._wait_until_alive(timeout=self._config.startup_timeout)
         if self._config.enable_auto_clear:
             self._check_stop_task = asyncio.create_task(self._check_stop())
+
+    def _build_env_args(self) -> list[str]:
+        """Construct `-e KEY=VALUE` argv pairs for `docker run`.
+
+        Centralizes every env var rock injects into a sandbox in one place so
+        callers (and tests) can audit them together. Volume mounts that pair
+        with these vars (ROCK_LOGGING_PATH, kata disk) are still set up
+        alongside in `start()`.
+        """
+        args: list[str] = []
+        if env_vars.ROCK_LOGGING_PATH:
+            args.extend(
+                [
+                    "-e",
+                    f"ROCK_LOGGING_PATH={env_vars.ROCK_LOGGING_PATH}",
+                    "-e",
+                    f"ROCK_LOGGING_LEVEL={env_vars.ROCK_LOGGING_LEVEL}",
+                ]
+            )
+        args.extend(["-e", f"ROCK_TIME_ZONE={env_vars.ROCK_TIME_ZONE}"])
+        if self._config.use_kata_runtime:
+            args.extend(["-e", "ROCK_KATA_RUNTIME=true"])
+        mirrors = self._config.runtime_config.instance_registry_mirrors
+        if mirrors:
+            args.extend(["-e", f"INSTANCE_ROCK_REGISTRY={','.join(mirrors)}"])
+        return args
 
     def _prepare_timezone_mount(self) -> list[str]:
         tz = env_vars.ROCK_TIME_ZONE

--- a/rock/sandbox/operator/k8s/provider.py
+++ b/rock/sandbox/operator/k8s/provider.py
@@ -5,6 +5,7 @@ import re
 from abc import ABC, abstractmethod
 from typing import Any, Protocol
 
+import yaml
 from kubernetes import client
 from kubernetes import config as k8s_config
 
@@ -581,10 +582,12 @@ class BatchSandboxProvider(K8sProvider):
             disk=self._normalize_memory(config.disk_limit_rootfs) if config.disk_limit_rootfs else None,
             num_gpus=config.num_gpus,
             accelerator_type=config.accelerator_type,
+            limit_cpus=config.limit_cpus,
         )
 
-        logger.debug(
-            f"Built BatchSandbox manifest for {sandbox_id} in namespace '{self.namespace}' using template '{template_name}'"
+        logger.info(
+            f"Built BatchSandbox manifest for {sandbox_id} in namespace '{self.namespace}' "
+            f"using template '{template_name}':\n{yaml.safe_dump(manifest, sort_keys=False, allow_unicode=True)}"
         )
         return manifest
 

--- a/rock/sandbox/operator/k8s/template_loader.py
+++ b/rock/sandbox/operator/k8s/template_loader.py
@@ -62,6 +62,7 @@ class K8sTemplateLoader:
         disk: str | None = None,
         num_gpus: int | None = None,
         accelerator_type: str | None = None,
+        limit_cpus: float | None = None,
     ) -> dict[str, Any]:
         """Build a complete BatchSandbox manifest from template.
 
@@ -79,6 +80,13 @@ class K8sTemplateLoader:
         are still assembled in code, since they are structural rather than
         configurable.
 
+        CPU overcommit: ``cpus`` is the scheduler reservation (rendered into
+        ``requests.cpu``), ``limit_cpus`` is the cgroup hard cap (rendered into
+        ``limits.cpu``). When ``limit_cpus`` is None we fall back to ``cpus`` so
+        that ``requests.cpu == limits.cpu`` and behaviour matches the pre-
+        overcommit baseline. A ``limit_cpus > cpus`` value lets the container
+        burst above its reservation, mirroring the Ray path's ``--cpus`` flag.
+
         Args:
             template_name: Name of the template to use.
             sandbox_id: Sandbox identifier (auto-generated if missing).
@@ -88,6 +96,9 @@ class K8sTemplateLoader:
             disk: Disk resource value (rendered via {{ disk }}).
             num_gpus: GPU count (rendered via {{ num_gpus }}).
             accelerator_type: GPU model (rendered via {{ accelerator_type }}).
+            limit_cpus: CPU hard cap for overcommit (rendered via
+                {{ limit_cpus }}). When None, falls back to ``cpus`` to keep
+                requests.cpu == limits.cpu.
 
         Returns:
             Complete BatchSandbox manifest.
@@ -106,6 +117,10 @@ class K8sTemplateLoader:
         if not sandbox_id:
             sandbox_id = f"sandbox-{uuid.uuid4().hex[:8]}"
 
+        # limit_cpus falls back to cpus so templates that always reference
+        # {{ limit_cpus }} keep working when overcommit is not set.
+        effective_limit_cpus = limit_cpus if limit_cpus is not None else cpus
+
         # num_gpus stays numeric so templates can do arithmetic; cpus str-coerced to pin float->"4.0" formatting.
         ctx = {
             "sandbox_id": sandbox_id,
@@ -116,11 +131,12 @@ class K8sTemplateLoader:
             "disk": disk if disk is not None else "",
             "num_gpus": num_gpus if num_gpus is not None else "",
             "accelerator_type": accelerator_type if accelerator_type is not None else "",
+            "limit_cpus": str(effective_limit_cpus) if effective_limit_cpus is not None else "",
         }
 
         rendered = render_node(config, self._jinja_env, ctx)
 
-        enable_resource_speedup = rendered.get("enable_resource_speedup", True)
+        enable_resource_speedup = rendered.get("enable_resource_speedup", False)
         pod_template = rendered.get("template", {})
         template_metadata = pod_template.get("metadata", {})
         pod_spec = pod_template.get("spec", {})

--- a/rock/sandbox/service/sandbox_proxy_service.py
+++ b/rock/sandbox/service/sandbox_proxy_service.py
@@ -708,6 +708,10 @@ class SandboxProxyService:
             role_arn = primary.role_arn
             session_name = "rock-sandbox-primary"
             endpoint = primary.endpoint or None
+            # In-VPC endpoint used INSIDE the sandbox (e.g. by `ossutil cp`
+            # in OssClient.download_via_oss). When empty, the SDK falls back
+            # to `endpoint` — preserves BC for YAMLs that didn't set this.
+            sandbox_endpoint = primary.sandbox_endpoint or None
             bucket = primary.bucket or None
             region = primary.region or env_vars.ROCK_OSS_BUCKET_REGION or None
             prefix = self._rock_config.sandbox_config.file_transfer.prefix or None
@@ -715,6 +719,8 @@ class SandboxProxyService:
             role_arn = self.oss_config.role_arn
             session_name = "rock-sandbox-legacy"
             endpoint = env_vars.ROCK_OSS_BUCKET_ENDPOINT or self.oss_config.endpoint or None
+            # Legacy path has no separate in-VPC endpoint concept.
+            sandbox_endpoint = None
             bucket = env_vars.ROCK_OSS_BUCKET_NAME or self.oss_config.bucket or None
             region = env_vars.ROCK_OSS_BUCKET_REGION or None
             prefix = env_vars.ROCK_OSS_TRANSFER_PREFIX or None
@@ -741,6 +747,9 @@ class SandboxProxyService:
         return {
             **credentials,
             "Endpoint": endpoint,
+            # Optional separate in-VPC endpoint for code that runs inside the
+            # sandbox container. SDK fallback: when missing/empty, use Endpoint.
+            "SandboxEndpoint": sandbox_endpoint,
             "Bucket": bucket,
             "Region": region,
             "Prefix": prefix,  # transfer-object key prefix, scoped per account

--- a/rock/sdk/sandbox/model_service/base.py
+++ b/rock/sdk/sandbox/model_service/base.py
@@ -1,6 +1,8 @@
 from __future__ import annotations  # Postpone annotation evaluation to avoid circular imports.
 
+import os
 import shlex
+import tempfile
 from string import Template
 from typing import TYPE_CHECKING
 
@@ -15,6 +17,8 @@ if TYPE_CHECKING:
     from rock.sdk.sandbox.client import Sandbox
 
 logger = init_logger(__name__)
+
+_PAYLOAD_FILE_THRESHOLD = 100 * 1024  # 100KB
 
 
 class ModelServiceConfig(BaseModel):
@@ -55,6 +59,11 @@ class ModelServiceConfig(BaseModel):
         default="PYTHONWARNINGS=ignore rock model-service anti-call-llm --index ${index} --response ${response_payload}"
     )
     """Command to anti-call LLM with index and response_payload placeholders."""
+
+    anti_call_llm_cmd_file: str = Field(
+        default="PYTHONWARNINGS=ignore rock model-service anti-call-llm --index ${index} --response-file ${response_file}"
+    )
+    """Command to anti-call LLM with response payload read from a file (for large payloads)."""
 
     anti_call_llm_cmd_no_response: str = Field(
         default="PYTHONWARNINGS=ignore rock model-service anti-call-llm --index ${index}"
@@ -242,35 +251,64 @@ class ModelService:
             logger.error(error_msg)
             raise RuntimeError(error_msg)
 
+        payload_size = len(response_payload) if response_payload else 0
+        use_file = response_payload is not None and payload_size > _PAYLOAD_FILE_THRESHOLD
+
         logger.info(
             f"[{sandbox_id}] Executing anti-call LLM: index={index}, "
-            f"has_response={response_payload is not None}, timeout={call_timeout}s"
+            f"has_response={response_payload is not None}, payload_size={payload_size}, "
+            f"use_file={use_file}, timeout={call_timeout}s"
         )
 
         from rock.sdk.sandbox.client import RunMode
 
-        if response_payload:
-            cmd = Template(self.config.anti_call_llm_cmd).safe_substitute(
-                index=index,
-                response_payload=shlex.quote(response_payload),
+        local_tmp_path: str | None = None
+        try:
+            if response_payload and use_file:
+                sandbox_response_file = f"/tmp/anti_call_response_{index}.json"
+
+                fd, local_tmp_path = tempfile.mkstemp(suffix=".json", prefix="anti_call_response_")
+                with os.fdopen(fd, "w") as f:
+                    f.write(response_payload)
+
+                upload_result = await self._sandbox.upload_by_path(
+                    file_path=local_tmp_path, target_path=sandbox_response_file
+                )
+                if not upload_result.success:
+                    raise RuntimeError(
+                        f"Failed to upload response payload to sandbox: {upload_result.message}"
+                    )
+                logger.debug(f"[{sandbox_id}] Uploaded response payload ({payload_size} bytes) to {sandbox_response_file}")
+
+                cmd = Template(self.config.anti_call_llm_cmd_file).safe_substitute(
+                    index=index,
+                    response_file=sandbox_response_file,
+                )
+            elif response_payload:
+                cmd = Template(self.config.anti_call_llm_cmd).safe_substitute(
+                    index=index,
+                    response_payload=shlex.quote(response_payload),
+                )
+            else:
+                cmd = Template(self.config.anti_call_llm_cmd_no_response).safe_substitute(index=index)
+
+            # We chose to use runtime_env's wrapped_cmd instead of the run method here,
+            # mainly to avoid unexpected behavior caused by sharing a session with runtime_env
+            bash_cmd = self.runtime_env.wrapped_cmd(cmd)
+            logger.debug(f"[{sandbox_id}] Executing command: {bash_cmd}")
+
+            result = await self._sandbox.arun(
+                cmd=bash_cmd,
+                mode=RunMode.NOHUP,
+                session=None,
+                wait_timeout=call_timeout,
+                wait_interval=check_interval,
             )
-        else:
-            cmd = Template(self.config.anti_call_llm_cmd_no_response).safe_substitute(index=index)
 
-        # We chose to use runtime_env's wrapped_cmd instead of the run method here,
-        # mainly to avoid unexpected behavior caused by sharing a session with runtime_env
-        bash_cmd = self.runtime_env.wrapped_cmd(cmd)
-        logger.debug(f"[{sandbox_id}] Executing command: {bash_cmd}")
+            if result.exit_code != 0:
+                raise RuntimeError(f"Anti-call LLM command failed: {result.output}")
 
-        result = await self._sandbox.arun(
-            cmd=bash_cmd,
-            mode=RunMode.NOHUP,
-            session=None,
-            wait_timeout=call_timeout,
-            wait_interval=check_interval,
-        )
-
-        if result.exit_code != 0:
-            raise RuntimeError(f"Anti-call LLM command failed: {result.output}")
-
-        return result.output
+            return result.output
+        finally:
+            if local_tmp_path and os.path.exists(local_tmp_path):
+                os.unlink(local_tmp_path)

--- a/rock/sdk/sandbox/oss_client.py
+++ b/rock/sdk/sandbox/oss_client.py
@@ -37,6 +37,12 @@ class OssClientConfig:
     region: str
     enabled_via_env: bool  # True = Layer 1 (gated by ROCK_OSS_ENABLE); False = Layer 2
     prefix: str = ""  # Transfer-object key prefix (Layer 1 from env; Layer 2 from server response)
+    sandbox_endpoint: str = ""
+    """In-VPC OSS endpoint used by code that runs INSIDE the sandbox (e.g.
+    `ossutil cp --endpoint` in `download_via_oss`). Distinct from `endpoint`,
+    which is the user/SDK-facing endpoint (used by host-side oss2.Bucket on
+    the developer's machine). Empty = no separate sandbox endpoint
+    configured; callers MUST fall back to `endpoint`."""
 
 
 class OssClient:
@@ -81,6 +87,9 @@ class OssClient:
                 region=env_region,
                 enabled_via_env=True,
                 prefix=env_vars.ROCK_OSS_TRANSFER_PREFIX or "",  # NEW: env can carry prefix too
+                # Optional override for in-sandbox ossutil endpoint; empty by
+                # default — callers fall back to `endpoint`.
+                sandbox_endpoint=getattr(env_vars, "ROCK_OSS_SANDBOX_ENDPOINT", "") or "",
             )
 
         # Layer 2: server response (fallback default)
@@ -94,6 +103,9 @@ class OssClient:
                 region=resp_region,
                 enabled_via_env=False,
                 prefix=sts_response.get("Prefix") or "",  # NEW: pull prefix from server
+                # `SandboxEndpoint` is the in-VPC endpoint used INSIDE the
+                # sandbox (ossutil cp). Optional; empty = use `endpoint`.
+                sandbox_endpoint=sts_response.get("SandboxEndpoint") or "",
             )
 
         # Layer 3: OSS unavailable
@@ -287,12 +299,17 @@ class OssClient:
         )
         oss_url = f"oss://{self._client_config.bucket}/{oss_object_name}"
 
+        # ossutil runs INSIDE the sandbox container (in the VPC). Prefer the
+        # in-VPC `sandbox_endpoint` when configured, to avoid public bandwidth
+        # cost and reduce latency. Fall back to `endpoint` for legacy / single-
+        # endpoint deployments.
+        in_sandbox_endpoint = self._client_config.sandbox_endpoint or self._client_config.endpoint
         ossutil_inner = (
             f"ossutil cp {shlex.quote(remote_path)} {shlex.quote(oss_url)}"
             f" --access-key-id {shlex.quote(access_key_id)}"
             f" --access-key-secret {shlex.quote(access_key_secret)}"
             f" --sts-token {shlex.quote(security_token)}"
-            f" --endpoint {shlex.quote(self._client_config.endpoint)}"
+            f" --endpoint {shlex.quote(in_sandbox_endpoint)}"
             f" --region {shlex.quote(self._client_config.region)}"
         )
         upload_cmd = f"bash -c {shlex.quote(ossutil_inner)}"

--- a/tests/integration/cli/test_model_service.py
+++ b/tests/integration/cli/test_model_service.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import subprocess
+import tempfile
 import threading
 
 import httpx
@@ -140,6 +141,91 @@ def mock_response() -> dict:
         },
     }
     return result
+
+
+@pytest.mark.asyncio
+async def test_model_service_large_payload_via_response_file():
+    """Verify --response-file works for payloads that would exceed ARG_MAX via --response."""
+    model_env = os.environ.copy()
+    model_env["ROCK_LOGGING_FILE_NAME"] = "model_service_large.log"
+    subprocess.run(["rock", "model-service", "start"], env=model_env)
+
+    mock_agent_process = subprocess.Popen(["sleep", "200"])
+    agent_pid = mock_agent_process.pid
+
+    subprocess.run(["rock", "model-service", "watch-agent", "--pid", str(agent_pid)])
+
+    try:
+        task = asyncio.create_task(mock_agent_call_single(agent_pid))
+        thread = threading.Thread(target=mock_roll_call_large_payload)
+        thread.start()
+        await task
+        thread.join()
+    finally:
+        subprocess.run(["rock", "model-service", "stop"])
+
+
+async def mock_agent_call_single(agent_pid: int):
+    await make_request()
+    logger.info(f"mock agent process exiting, killing pid {agent_pid}")
+    subprocess.run(["kill", "-9", str(agent_pid)])
+
+
+def mock_roll_call_large_payload():
+    # index=0: get first request (no response needed)
+    result = subprocess.run(["rock", "model-service", "anti-call-llm", "--index=0"], capture_output=True, text=True)
+    print(f"index=0 result: {result.stdout[:100]}")
+    assert "You are a helpful assistant." in result.stdout
+
+    # index=1: first prove --response with large payload hits ARG_MAX
+    large_content = "x" * (500 * 1024)  # 500KB
+    large_response = json.dumps({
+        "id": "chatcmpl-large",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": "mock content",
+                "tool_calls": [{
+                    "id": "call_large",
+                    "type": "function",
+                    "function": {
+                        "name": "write",
+                        "arguments": json.dumps({"path": "/tmp/large.py", "content": large_content}),
+                    },
+                }],
+            },
+            "finish_reason": "tool_calls",
+        }],
+    }, ensure_ascii=False)
+    print(f"Large payload size: {len(large_response)} bytes")
+
+    print(f"[OLD] Trying --response with {len(large_response)} bytes as command-line arg...")
+    try:
+        result = subprocess.run(
+            ["rock", "model-service", "anti-call-llm", "--index=1", "--response", large_response],
+            capture_output=True,
+            text=True,
+        )
+        old_way_failed = result.returncode != 0
+    except OSError as e:
+        print(f"[OLD] FAILED as expected: {e}")
+        old_way_failed = True
+    assert old_way_failed, "--response with 500KB payload should fail with Argument list too long"
+
+    print(f"[NEW] Trying --response-file with same {len(large_response)} bytes via file...")
+    fd, tmp_path = tempfile.mkstemp(suffix=".json")
+    with os.fdopen(fd, "w") as f:
+        f.write(large_response)
+
+    result = subprocess.run(
+        ["rock", "model-service", "anti-call-llm", "--index=1", "--response-file", tmp_path],
+        capture_output=True,
+        text=True,
+    )
+    print(f"[NEW] SUCCESS: {result.stdout.strip()}")
+    assert result.returncode == 0, f"--response-file should succeed, stderr: {result.stderr[:200]}"
+    assert not os.path.exists(tmp_path), f"Response file {tmp_path} should be deleted after read"
+    assert "SESSION_END\n" == result.stdout
 
 
 if "__main__" == __name__:

--- a/tests/unit/admin/scheduler/test_sandbox_log_archive_task.py
+++ b/tests/unit/admin/scheduler/test_sandbox_log_archive_task.py
@@ -58,6 +58,7 @@ def _fake_rock_config(
             primary=SimpleNamespace(
                 bucket=bucket,
                 endpoint=endpoint,
+                sandbox_endpoint="",
                 access_key_id=access_key_id,
                 access_key_secret=access_key_secret,
             )
@@ -370,3 +371,105 @@ class TestArchiveCommand:
 
         assert result["archived"] == 1
         assert result["failed"] == 1
+
+
+# ---------------------------------------------------------------------------
+# sandbox_endpoint: VPC internal endpoint selection
+# ---------------------------------------------------------------------------
+
+
+def _fake_rock_config_with_sandbox_endpoint(
+    bucket="b",
+    endpoint="cn-shanghai.oss.aliyuncs.com",
+    sandbox_endpoint="oss-cn-shanghai-internal.aliyuncs.com",
+    access_key_id="AKID",
+    access_key_secret="AKSEC",
+    keep_days=3,
+    archive_prefix="rock-archives/",
+):
+    return SimpleNamespace(
+        oss=SimpleNamespace(
+            primary=SimpleNamespace(
+                bucket=bucket,
+                endpoint=endpoint,
+                sandbox_endpoint=sandbox_endpoint,
+                access_key_id=access_key_id,
+                access_key_secret=access_key_secret,
+            )
+        ),
+        sandbox_config=SimpleNamespace(
+            log=SimpleNamespace(
+                keep_days_before_archive=keep_days,
+                archive_prefix=archive_prefix,
+            )
+        ),
+    )
+
+
+class TestSandboxEndpoint:
+    """Verify SandboxLogArchiveTask uses sandbox_endpoint when present."""
+
+    @pytest.mark.asyncio
+    async def test_uses_sandbox_endpoint_for_archive_command(self, fake_table):
+        """When sandbox_endpoint is configured, the archive shell command
+        should reference the internal endpoint, not the public one."""
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(
+            lambda: _fake_rock_config_with_sandbox_endpoint(
+                endpoint="cn-shanghai.oss.aliyuncs.com",
+                sandbox_endpoint="oss-cn-shanghai-internal.aliyuncs.com",
+            )
+        )
+        fake_table.list_by_in = AsyncMock(
+            return_value=[_row("sb-vpc", state="stopped", stop_time=_iso_days_ago(5))]
+        )
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime([_FakeExecResult(stdout="sb-vpc"), _FakeExecResult()])
+
+        await task.run_action(runtime)
+
+        archive_cmd = runtime.execute.await_args_list[1].args[0].command
+        assert "oss-cn-shanghai-internal.aliyuncs.com" in archive_cmd
+        # Public endpoint should NOT appear in the command
+        assert "cn-shanghai.oss.aliyuncs.com" not in archive_cmd
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_endpoint_when_sandbox_endpoint_empty(self, fake_table):
+        """When sandbox_endpoint is empty, the task falls back to endpoint."""
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(
+            lambda: _fake_rock_config_with_sandbox_endpoint(
+                endpoint="cn-shanghai.oss.aliyuncs.com",
+                sandbox_endpoint="",  # empty → fallback
+            )
+        )
+        fake_table.list_by_in = AsyncMock(
+            return_value=[_row("sb-pub", state="stopped", stop_time=_iso_days_ago(5))]
+        )
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime([_FakeExecResult(stdout="sb-pub"), _FakeExecResult()])
+
+        await task.run_action(runtime)
+
+        archive_cmd = runtime.execute.await_args_list[1].args[0].command
+        assert "cn-shanghai.oss.aliyuncs.com" in archive_cmd
+
+    @pytest.mark.asyncio
+    async def test_skip_when_sandbox_endpoint_set_but_bucket_empty(self, fake_table):
+        """Even with sandbox_endpoint configured, skip if bucket is empty."""
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(
+            lambda: _fake_rock_config_with_sandbox_endpoint(
+                bucket="",
+                sandbox_endpoint="oss-cn-shanghai-internal.aliyuncs.com",
+            )
+        )
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime([])
+        result = await task.run_action(runtime)
+
+        assert result["status"] == TaskStatusEnum.SUCCESS
+        assert "oss primary account not configured" in result["message"]

--- a/tests/unit/admin/test_image_registry_mirror.py
+++ b/tests/unit/admin/test_image_registry_mirror.py
@@ -1,0 +1,428 @@
+"""Tests for _apply_image_registry_mirror in admin sandbox entrypoint.
+
+Covers: empty list, single hit, second-mirror hit, full miss, credential
+propagation (with and without auth), invalid mirror entries, name:tag
+extraction from multi-segment image paths, and tolerance of probe errors.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from rock.admin.entrypoints import sandbox_api
+from rock.config import ImageRegistryMirror, RockConfig
+from rock.deployments.config import DockerDeploymentConfig
+
+
+def _make_manager(mirrors, allowlist=None):
+    """Build a stub sandbox_manager exposing mirrors + allowlist.
+
+    Default allowlist is ``["*"]`` so callers that don't care about the gate
+    keep the legacy "check every image" semantics.
+    """
+    return SimpleNamespace(
+        rock_config=SimpleNamespace(
+            image_registry_mirrors=mirrors,
+            image_mirror_lookup_allowlist=["*"] if allowlist is None else allowlist,
+            nacos_provider=None,
+        )
+    )
+
+
+@pytest.fixture(autouse=True)
+def clear_probe_cache():
+    """Mirror probe cache is process-local — wipe between tests to avoid cross-test leakage."""
+    sandbox_api._MIRROR_PROBE_CACHE.clear()
+    yield
+    sandbox_api._MIRROR_PROBE_CACHE.clear()
+
+
+@pytest.fixture
+def restore_sandbox_manager():
+    """Save / restore the module-level sandbox_manager singleton around each test."""
+    original = getattr(sandbox_api, "sandbox_manager", None)
+    yield
+    sandbox_api.sandbox_manager = original
+
+
+@pytest.fixture
+def stub_manifest_probe():
+    """Replace _http_probe_manifest with a stub that records probes and returns pre-set results."""
+    probes: list[dict] = []
+    probe_results: list[bool] = []
+
+    async def _mock(registry, repo, tag, username=None, password=None, timeout=5):
+        probes.append(
+            {
+                "image": f"{registry}/{repo}:{tag}",
+                "registry": registry,
+                "repo": repo,
+                "tag": tag,
+                "username": username,
+                "password": password,
+            }
+        )
+        return probe_results.pop(0) if probe_results else False
+
+    with patch.object(sandbox_api, "_http_probe_manifest", _mock):
+        yield SimpleNamespace(probes=probes, probe_results=probe_results)
+
+
+async def test_empty_mirror_list_is_noop(restore_sandbox_manager, stub_manifest_probe):
+    sandbox_api.sandbox_manager = _make_manager([])
+    config = DockerDeploymentConfig(image="python:3.11")
+
+    await sandbox_api._apply_image_registry_mirror(config)
+
+    assert config.image == "python:3.11"
+    assert stub_manifest_probe.probes == []
+
+
+async def test_first_mirror_hit_rewrites_image(restore_sandbox_manager, stub_manifest_probe):
+    sandbox_api.sandbox_manager = _make_manager(
+        [
+            ImageRegistryMirror(registry="rock-a.example.com", namespace="rock-public"),
+            ImageRegistryMirror(registry="rock-b.example.com", namespace="rock-mirror"),
+        ]
+    )
+    config = DockerDeploymentConfig(image="gcr.io/foo/python:3.11")
+    stub_manifest_probe.probe_results.append(True)
+
+    await sandbox_api._apply_image_registry_mirror(config)
+
+    assert config.image == "rock-a.example.com/rock-public/python:3.11"
+    assert config.registry_username is None
+    assert config.registry_password is None
+    assert len(stub_manifest_probe.probes) == 1
+
+
+async def test_second_mirror_hit_after_first_miss(restore_sandbox_manager, stub_manifest_probe):
+    sandbox_api.sandbox_manager = _make_manager(
+        [
+            ImageRegistryMirror(registry="rock-a.example.com", namespace="rock-public"),
+            ImageRegistryMirror(registry="rock-b.example.com", namespace="rock-mirror"),
+        ]
+    )
+    config = DockerDeploymentConfig(image="python:3.11")
+    stub_manifest_probe.probe_results.extend([False, True])
+
+    await sandbox_api._apply_image_registry_mirror(config)
+
+    assert config.image == "rock-b.example.com/rock-mirror/python:3.11"
+    assert len(stub_manifest_probe.probes) == 2
+
+
+async def test_full_miss_keeps_original_image(restore_sandbox_manager, stub_manifest_probe):
+    sandbox_api.sandbox_manager = _make_manager(
+        [
+            ImageRegistryMirror(registry="rock-a.example.com", namespace="rock-public"),
+            ImageRegistryMirror(registry="rock-b.example.com", namespace="rock-mirror"),
+        ]
+    )
+    config = DockerDeploymentConfig(image="python:3.11", registry_username="orig", registry_password="orig-pw")
+    stub_manifest_probe.probe_results.extend([False, False])
+
+    await sandbox_api._apply_image_registry_mirror(config)
+
+    assert config.image == "python:3.11"
+    assert config.registry_username == "orig"
+    assert config.registry_password == "orig-pw"
+
+
+async def test_credentials_propagated_on_hit(restore_sandbox_manager, stub_manifest_probe):
+    sandbox_api.sandbox_manager = _make_manager(
+        [
+            ImageRegistryMirror(
+                registry="rock-a.example.com",
+                namespace="rock-public",
+                username="mirror-user",
+                password="mirror-pw",
+            ),
+        ]
+    )
+    config = DockerDeploymentConfig(image="python:3.11")
+    stub_manifest_probe.probe_results.append(True)
+
+    await sandbox_api._apply_image_registry_mirror(config)
+
+    assert config.image == "rock-a.example.com/rock-public/python:3.11"
+    assert config.registry_username == "mirror-user"
+    assert config.registry_password == "mirror-pw"
+    assert stub_manifest_probe.probes[0]["username"] == "mirror-user"
+    assert stub_manifest_probe.probes[0]["registry"] == "rock-a.example.com"
+
+
+async def test_invalid_mirror_entry_skipped(restore_sandbox_manager, stub_manifest_probe):
+    sandbox_api.sandbox_manager = _make_manager(
+        [
+            ImageRegistryMirror(registry="", namespace="rock-public"),
+            ImageRegistryMirror(registry="rock-a.example.com", namespace=""),
+            ImageRegistryMirror(registry="rock-b.example.com", namespace="rock-mirror"),
+        ]
+    )
+    config = DockerDeploymentConfig(image="python:3.11")
+    stub_manifest_probe.probe_results.append(True)
+
+    await sandbox_api._apply_image_registry_mirror(config)
+
+    assert config.image == "rock-b.example.com/rock-mirror/python:3.11"
+    assert len(stub_manifest_probe.probes) == 1
+
+
+async def test_candidate_strips_registry_and_namespace_preserves_repo(restore_sandbox_manager, stub_manifest_probe):
+    sandbox_api.sandbox_manager = _make_manager(
+        [ImageRegistryMirror(registry="rock-a.example.com", namespace="rock-public")]
+    )
+    config = DockerDeploymentConfig(image="gcr.io/project/subdir/myimage:v1")
+    stub_manifest_probe.probe_results.append(False)
+
+    await sandbox_api._apply_image_registry_mirror(config)
+
+    assert stub_manifest_probe.probes[0]["image"] == "rock-a.example.com/rock-public/subdir/myimage:v1"
+    assert stub_manifest_probe.probes[0]["repo"] == "rock-public/subdir/myimage"
+    assert stub_manifest_probe.probes[0]["tag"] == "v1"
+
+
+async def test_missing_tag_defaults_to_latest(restore_sandbox_manager, stub_manifest_probe):
+    sandbox_api.sandbox_manager = _make_manager(
+        [ImageRegistryMirror(registry="rock-a.example.com", namespace="rock-public")]
+    )
+    config = DockerDeploymentConfig(image="ubuntu")
+    stub_manifest_probe.probe_results.append(False)
+
+    await sandbox_api._apply_image_registry_mirror(config)
+
+    assert stub_manifest_probe.probes[0]["image"] == "rock-a.example.com/rock-public/ubuntu:latest"
+
+
+async def test_probe_exception_treated_as_miss(restore_sandbox_manager):
+    sandbox_api.sandbox_manager = _make_manager(
+        [
+            ImageRegistryMirror(registry="rock-a.example.com", namespace="rock-public", username="u", password="p"),
+            ImageRegistryMirror(registry="rock-b.example.com", namespace="rock-mirror"),
+        ]
+    )
+    config = DockerDeploymentConfig(image="python:3.11")
+
+    call_count = {"n": 0}
+
+    async def _mock(registry, repo, tag, username=None, password=None, timeout=5):
+        if registry == "rock-a.example.com":
+            raise RuntimeError("connection failed")
+        call_count["n"] += 1
+        return True
+
+    with patch.object(sandbox_api, "_http_probe_manifest", _mock):
+        await sandbox_api._apply_image_registry_mirror(config)
+
+    assert config.image == "rock-b.example.com/rock-mirror/python:3.11"
+    assert call_count["n"] == 1
+
+
+async def test_digest_reference_skips_mirror_lookup(restore_sandbox_manager, stub_manifest_probe):
+    sandbox_api.sandbox_manager = _make_manager(
+        [ImageRegistryMirror(registry="rock-a.example.com", namespace="rock-public")]
+    )
+    config = DockerDeploymentConfig(image="gcr.io/foo/python@sha256:abc123def")
+
+    await sandbox_api._apply_image_registry_mirror(config)
+
+    assert config.image == "gcr.io/foo/python@sha256:abc123def"
+    assert stub_manifest_probe.probes == []
+
+
+async def test_digest_reference_without_registry_also_skips(restore_sandbox_manager, stub_manifest_probe):
+    sandbox_api.sandbox_manager = _make_manager(
+        [ImageRegistryMirror(registry="rock-a.example.com", namespace="rock-public")]
+    )
+    config = DockerDeploymentConfig(image="python@sha256:abc123def")
+
+    await sandbox_api._apply_image_registry_mirror(config)
+
+    assert config.image == "python@sha256:abc123def"
+    assert stub_manifest_probe.probes == []
+
+
+async def test_cached_hit_skips_probe(restore_sandbox_manager, stub_manifest_probe):
+    sandbox_api.sandbox_manager = _make_manager(
+        [ImageRegistryMirror(registry="rock-a.example.com", namespace="rock-public")]
+    )
+    stub_manifest_probe.probe_results.append(True)
+
+    first = DockerDeploymentConfig(image="python:3.11")
+    await sandbox_api._apply_image_registry_mirror(first)
+    second = DockerDeploymentConfig(image="python:3.11")
+    await sandbox_api._apply_image_registry_mirror(second)
+
+    assert first.image == "rock-a.example.com/rock-public/python:3.11"
+    assert second.image == "rock-a.example.com/rock-public/python:3.11"
+    assert len(stub_manifest_probe.probes) == 1
+
+
+async def test_cached_miss_skips_probe(restore_sandbox_manager, stub_manifest_probe):
+    sandbox_api.sandbox_manager = _make_manager(
+        [
+            ImageRegistryMirror(registry="rock-a.example.com", namespace="rock-public"),
+            ImageRegistryMirror(registry="rock-b.example.com", namespace="rock-mirror"),
+        ]
+    )
+    stub_manifest_probe.probe_results.extend([False, False])
+
+    first = DockerDeploymentConfig(image="python:3.11")
+    await sandbox_api._apply_image_registry_mirror(first)
+    second = DockerDeploymentConfig(image="python:3.11")
+    await sandbox_api._apply_image_registry_mirror(second)
+
+    assert first.image == "python:3.11"
+    assert second.image == "python:3.11"
+    assert len(stub_manifest_probe.probes) == 2
+
+
+async def test_expired_cache_entry_reprobes(restore_sandbox_manager, stub_manifest_probe):
+    sandbox_api.sandbox_manager = _make_manager(
+        [ImageRegistryMirror(registry="rock-a.example.com", namespace="rock-public")]
+    )
+    stub_manifest_probe.probe_results.extend([False, True])
+
+    first = DockerDeploymentConfig(image="python:3.11")
+    await sandbox_api._apply_image_registry_mirror(first)
+    for key in list(sandbox_api._MIRROR_PROBE_CACHE):
+        hit, _ = sandbox_api._MIRROR_PROBE_CACHE[key]
+        sandbox_api._MIRROR_PROBE_CACHE[key] = (hit, 0.0)
+    second = DockerDeploymentConfig(image="python:3.11")
+    await sandbox_api._apply_image_registry_mirror(second)
+
+    assert second.image == "rock-a.example.com/rock-public/python:3.11"
+    assert len(stub_manifest_probe.probes) == 2
+
+
+async def test_probe_exception_not_cached(restore_sandbox_manager):
+    sandbox_api.sandbox_manager = _make_manager(
+        [ImageRegistryMirror(registry="rock-a.example.com", namespace="rock-public", username="u", password="p")]
+    )
+    call_count = {"n": 0}
+
+    async def _mock(registry, repo, tag, username=None, password=None, timeout=5):
+        call_count["n"] += 1
+        raise RuntimeError("connection failed")
+
+    with patch.object(sandbox_api, "_http_probe_manifest", _mock):
+        await sandbox_api._apply_image_registry_mirror(DockerDeploymentConfig(image="python:3.11"))
+        await sandbox_api._apply_image_registry_mirror(DockerDeploymentConfig(image="python:3.11"))
+
+    assert call_count["n"] == 2
+    assert sandbox_api._MIRROR_PROBE_CACHE == {}
+
+
+async def test_empty_allowlist_disables_lookup_entirely(restore_sandbox_manager, stub_manifest_probe):
+    sandbox_api.sandbox_manager = _make_manager(
+        [ImageRegistryMirror(registry="rock-a.example.com", namespace="rock-public")],
+        allowlist=[],
+    )
+    stub_manifest_probe.probe_results.append(True)
+    config = DockerDeploymentConfig(image="python:3.11")
+
+    await sandbox_api._apply_image_registry_mirror(config)
+
+    assert config.image == "python:3.11"
+    assert stub_manifest_probe.probes == []
+
+
+async def test_wildcard_allowlist_lets_every_image_through(restore_sandbox_manager, stub_manifest_probe):
+    sandbox_api.sandbox_manager = _make_manager(
+        [ImageRegistryMirror(registry="rock-a.example.com", namespace="rock-public")],
+        allowlist=["*"],
+    )
+    stub_manifest_probe.probe_results.append(True)
+    config = DockerDeploymentConfig(image="gcr.io/foo/python:3.11")
+
+    await sandbox_api._apply_image_registry_mirror(config)
+
+    assert config.image == "rock-a.example.com/rock-public/python:3.11"
+    assert len(stub_manifest_probe.probes) == 1
+
+
+async def test_prefix_allowlist_matches_only_listed_images(restore_sandbox_manager, stub_manifest_probe):
+    sandbox_api.sandbox_manager = _make_manager(
+        [ImageRegistryMirror(registry="rock-a.example.com", namespace="rock-public")],
+        allowlist=["aaaaaa/bbb/", "swe-bench:"],
+    )
+    stub_manifest_probe.probe_results.extend([True, True])
+
+    allowed = DockerDeploymentConfig(image="aaaaaa/bbb/swe-bench:astropy__astropy-12907")
+    await sandbox_api._apply_image_registry_mirror(allowed)
+    assert allowed.image == "rock-a.example.com/rock-public/bbb/swe-bench:astropy__astropy-12907"
+
+    bare_prefix = DockerDeploymentConfig(image="swe-bench:python__python-1")
+    await sandbox_api._apply_image_registry_mirror(bare_prefix)
+    assert bare_prefix.image == "rock-a.example.com/rock-public/swe-bench:python__python-1"
+
+    assert len(stub_manifest_probe.probes) == 2
+
+
+async def test_prefix_allowlist_skips_non_matching_image(restore_sandbox_manager, stub_manifest_probe):
+    sandbox_api.sandbox_manager = _make_manager(
+        [ImageRegistryMirror(registry="rock-a.example.com", namespace="rock-public")],
+        allowlist=["swe-bench:"],
+    )
+    stub_manifest_probe.probe_results.append(True)
+    config = DockerDeploymentConfig(image="python:3.11")
+
+    await sandbox_api._apply_image_registry_mirror(config)
+
+    assert config.image == "python:3.11"
+    assert stub_manifest_probe.probes == []
+
+
+async def test_nacos_mirrors_override_rock_config(restore_sandbox_manager, stub_manifest_probe):
+    """When nacos_provider returns mirror config, it takes precedence over rock_config fields."""
+    nacos_provider = MagicMock()
+    nacos_provider.get_config = AsyncMock(
+        return_value={
+            "image_registry_mirrors": [
+                {"registry": "nacos-mirror.example.com", "namespace": "nacos-ns"},
+            ],
+            "image_mirror_lookup_allowlist": ["*"],
+        }
+    )
+    sandbox_api.sandbox_manager = SimpleNamespace(
+        rock_config=SimpleNamespace(
+            image_registry_mirrors=[ImageRegistryMirror(registry="yaml-mirror.example.com", namespace="yaml-ns")],
+            image_mirror_lookup_allowlist=["should-be-ignored:"],
+            nacos_provider=nacos_provider,
+        )
+    )
+    stub_manifest_probe.probe_results.append(True)
+    config = DockerDeploymentConfig(image="python:3.11")
+
+    await sandbox_api._apply_image_registry_mirror(config)
+
+    assert config.image == "nacos-mirror.example.com/nacos-ns/python:3.11"
+
+
+async def test_nacos_without_mirror_keys_falls_back_to_rock_config(restore_sandbox_manager, stub_manifest_probe):
+    """When nacos_provider has no mirror keys, fall back to rock_config fields."""
+    nacos_provider = MagicMock()
+    nacos_provider.get_config = AsyncMock(return_value={"sandbox_config": {}})
+    sandbox_api.sandbox_manager = SimpleNamespace(
+        rock_config=SimpleNamespace(
+            image_registry_mirrors=[ImageRegistryMirror(registry="yaml-mirror.example.com", namespace="yaml-ns")],
+            image_mirror_lookup_allowlist=["*"],
+            nacos_provider=nacos_provider,
+        )
+    )
+    stub_manifest_probe.probe_results.append(True)
+    config = DockerDeploymentConfig(image="python:3.11")
+
+    await sandbox_api._apply_image_registry_mirror(config)
+
+    assert config.image == "yaml-mirror.example.com/yaml-ns/python:3.11"
+
+
+def test_image_registry_mirror_field_default_empty():
+    assert RockConfig.__dataclass_fields__["image_registry_mirrors"].default_factory() == []
+
+
+def test_image_mirror_lookup_allowlist_field_default_empty():
+    assert RockConfig.__dataclass_fields__["image_mirror_lookup_allowlist"].default_factory() == []

--- a/tests/unit/admin/test_image_registry_mirror.py
+++ b/tests/unit/admin/test_image_registry_mirror.py
@@ -153,6 +153,43 @@ async def test_credentials_propagated_on_hit(restore_sandbox_manager, stub_manif
     assert stub_manifest_probe.probes[0]["registry"] == "rock-a.example.com"
 
 
+async def test_user_credentials_cleared_when_mirror_has_no_auth(restore_sandbox_manager, stub_manifest_probe):
+    """User-supplied registry credentials must not leak to a mirror that needs no auth."""
+    sandbox_api.sandbox_manager = _make_manager(
+        [ImageRegistryMirror(registry="rock-a.example.com", namespace="rock-public")]
+    )
+    config = DockerDeploymentConfig(image="my-registry.io/myimage:v1", registry_username="orig-user", registry_password="orig-pw")
+    stub_manifest_probe.probe_results.append(True)
+
+    await sandbox_api._apply_image_registry_mirror(config)
+
+    assert config.image == "rock-a.example.com/rock-public/myimage:v1"
+    assert config.registry_username is None
+    assert config.registry_password is None
+
+
+async def test_user_credentials_replaced_by_mirror_credentials(restore_sandbox_manager, stub_manifest_probe):
+    """When both user and mirror have credentials, the mirror's credentials must win."""
+    sandbox_api.sandbox_manager = _make_manager(
+        [
+            ImageRegistryMirror(
+                registry="rock-a.example.com",
+                namespace="rock-public",
+                username="mirror-user",
+                password="mirror-pw",
+            ),
+        ]
+    )
+    config = DockerDeploymentConfig(image="my-registry.io/myimage:v1", registry_username="orig-user", registry_password="orig-pw")
+    stub_manifest_probe.probe_results.append(True)
+
+    await sandbox_api._apply_image_registry_mirror(config)
+
+    assert config.image == "rock-a.example.com/rock-public/myimage:v1"
+    assert config.registry_username == "mirror-user"
+    assert config.registry_password == "mirror-pw"
+
+
 async def test_invalid_mirror_entry_skipped(restore_sandbox_manager, stub_manifest_probe):
     sandbox_api.sandbox_manager = _make_manager(
         [

--- a/tests/unit/cli/command/test_model_service.py
+++ b/tests/unit/cli/command/test_model_service.py
@@ -118,3 +118,37 @@ def test_start_handler_omits_both_when_unset(isolate_pid_file, fake_start):
     kwargs = fake_start.call_args.kwargs
     assert kwargs["recording_file"] is None
     assert kwargs["replay_file"] is None
+
+
+# ---------- anti-call-llm: --response-file ----------
+
+
+def test_response_file_flag_parses():
+    parser = _build_parser()
+    ns = parser.parse_args(["model-service", "anti-call-llm", "--index", "1", "--response-file", "/tmp/resp.json"])
+    assert ns.response_file == "/tmp/resp.json"
+    assert ns.response is None
+
+
+def test_response_and_response_file_are_mutually_exclusive():
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args([
+            "model-service", "anti-call-llm", "--index", "1",
+            "--response", '{"foo":"bar"}', "--response-file", "/tmp/resp.json",
+        ])
+
+
+def test_anti_call_llm_reads_response_file(monkeypatch, tmp_path):
+    payload = '{"id":"chatcmpl-1","choices":[{"message":{"role":"assistant","content":"hello"}}]}'
+    resp_file = tmp_path / "resp.json"
+    resp_file.write_text(payload)
+
+    mock_anti_call = AsyncMock(return_value="next_request_json")
+    monkeypatch.setattr("rock.cli.command.model_service.ModelClient.anti_call_llm", mock_anti_call)
+
+    parser = _build_parser()
+    ns = parser.parse_args(["model-service", "anti-call-llm", "--index", "1", "--response-file", str(resp_file)])
+    asyncio.run(ModelServiceCommand().arun(ns))
+
+    mock_anti_call.assert_called_once_with(index=1, last_response=payload)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -227,7 +227,7 @@ def basic_templates():
                                     "memory": "{{ memory }}",
                                 },
                                 "limits": {
-                                    "cpu": "{{ cpus }}",
+                                    "cpu": "{{ limit_cpus }}",
                                     "memory": "{{ memory }}",
                                 },
                             },

--- a/tests/unit/deployments/test_docker_env_injection.py
+++ b/tests/unit/deployments/test_docker_env_injection.py
@@ -1,0 +1,101 @@
+"""Unit tests for DockerDeployment._build_env_args.
+
+Covers the env-arg list assembled for `docker run -e ...`, focusing on the
+INSTANCE_ROCK_REGISTRY injection sourced from RuntimeConfig.instance_registry_mirrors.
+Existing entries (ROCK_LOGGING_*, ROCK_TIME_ZONE, ROCK_KATA_RUNTIME) are regression-checked.
+"""
+
+from unittest.mock import patch
+
+from rock.config import RuntimeConfig
+from rock.deployments.config import DockerDeploymentConfig
+from rock.deployments.docker import DockerDeployment
+
+
+def _make_deployment(**config_kwargs) -> DockerDeployment:
+    with patch("rock.deployments.docker.DockerSandboxValidator"):
+        return DockerDeployment.from_config(DockerDeploymentConfig(**config_kwargs))
+
+
+class TestBuildEnvArgsInstanceRegistry:
+    def test_no_mirrors_means_no_registry_env(self):
+        deployment = _make_deployment()
+        with patch("rock.deployments.docker.env_vars") as mock_env:
+            mock_env.ROCK_LOGGING_PATH = ""
+            mock_env.ROCK_TIME_ZONE = "UTC"
+            args = deployment._build_env_args()
+        assert "INSTANCE_ROCK_REGISTRY" not in " ".join(args)
+
+    def test_single_mirror_emitted_unquoted(self):
+        deployment = _make_deployment(
+            runtime_config=RuntimeConfig(instance_registry_mirrors=["reg-a.example.com/ns"]),
+        )
+        with patch("rock.deployments.docker.env_vars") as mock_env:
+            mock_env.ROCK_LOGGING_PATH = ""
+            mock_env.ROCK_TIME_ZONE = "UTC"
+            args = deployment._build_env_args()
+        assert "-e" in args
+        assert "INSTANCE_ROCK_REGISTRY=reg-a.example.com/ns" in args
+
+    def test_multiple_mirrors_comma_joined(self):
+        deployment = _make_deployment(
+            runtime_config=RuntimeConfig(
+                instance_registry_mirrors=[
+                    "reg-a.example.com/ns-1",
+                    "reg-b.example.com/ns-2",
+                ],
+            ),
+        )
+        with patch("rock.deployments.docker.env_vars") as mock_env:
+            mock_env.ROCK_LOGGING_PATH = ""
+            mock_env.ROCK_TIME_ZONE = "UTC"
+            args = deployment._build_env_args()
+        assert "INSTANCE_ROCK_REGISTRY=reg-a.example.com/ns-1,reg-b.example.com/ns-2" in args
+
+
+class TestBuildEnvArgsRegression:
+    """The existing env entries must keep working after the extraction."""
+
+    def test_timezone_always_present(self):
+        deployment = _make_deployment()
+        with patch("rock.deployments.docker.env_vars") as mock_env:
+            mock_env.ROCK_LOGGING_PATH = ""
+            mock_env.ROCK_TIME_ZONE = "Asia/Shanghai"
+            args = deployment._build_env_args()
+        assert "ROCK_TIME_ZONE=Asia/Shanghai" in args
+
+    def test_logging_entries_present_when_logging_path_set(self):
+        deployment = _make_deployment()
+        with patch("rock.deployments.docker.env_vars") as mock_env:
+            mock_env.ROCK_LOGGING_PATH = "/var/log/rock"
+            mock_env.ROCK_LOGGING_LEVEL = "INFO"
+            mock_env.ROCK_TIME_ZONE = "UTC"
+            args = deployment._build_env_args()
+        assert "ROCK_LOGGING_PATH=/var/log/rock" in args
+        assert "ROCK_LOGGING_LEVEL=INFO" in args
+
+    def test_logging_entries_absent_when_logging_path_empty(self):
+        deployment = _make_deployment()
+        with patch("rock.deployments.docker.env_vars") as mock_env:
+            mock_env.ROCK_LOGGING_PATH = ""
+            mock_env.ROCK_TIME_ZONE = "UTC"
+            args = deployment._build_env_args()
+        joined = " ".join(args)
+        assert "ROCK_LOGGING_PATH" not in joined
+        assert "ROCK_LOGGING_LEVEL" not in joined
+
+    def test_kata_runtime_env_present_when_enabled(self):
+        deployment = _make_deployment(use_kata_runtime=True)
+        with patch("rock.deployments.docker.env_vars") as mock_env:
+            mock_env.ROCK_LOGGING_PATH = ""
+            mock_env.ROCK_TIME_ZONE = "UTC"
+            args = deployment._build_env_args()
+        assert "ROCK_KATA_RUNTIME=true" in args
+
+    def test_kata_runtime_env_absent_when_disabled(self):
+        deployment = _make_deployment(use_kata_runtime=False)
+        with patch("rock.deployments.docker.env_vars") as mock_env:
+            mock_env.ROCK_LOGGING_PATH = ""
+            mock_env.ROCK_TIME_ZONE = "UTC"
+            args = deployment._build_env_args()
+        assert "ROCK_KATA_RUNTIME=true" not in args

--- a/tests/unit/sandbox/operator/test_k8s_provider.py
+++ b/tests/unit/sandbox/operator/test_k8s_provider.py
@@ -38,6 +38,7 @@ def make_config(
     image_os: str = "linux",
     num_gpus: float | None = None,
     disk_limit_rootfs: str | None = None,
+    limit_cpus: float | None = None,
 ) -> DockerDeploymentConfig:
     return DockerDeploymentConfig(
         image=image,
@@ -48,6 +49,7 @@ def make_config(
         image_os=image_os,
         num_gpus=num_gpus,
         disk_limit_rootfs=disk_limit_rootfs,
+        limit_cpus=limit_cpus,
     )
 
 
@@ -470,3 +472,65 @@ class TestGetSandboxRuntimeInfo:
         assert host_ip == "10.0.0.1"
         assert port_mapping[Port.PROXY] == 8000
         assert resource_version == "12345"
+
+
+# Template that mirrors the real prod K8s template (requests.cpu uses {{ cpus }},
+# limits.cpu uses {{ limit_cpus }}) so we can verify the overcommit plumbing.
+RESOURCE_TEMPLATES = {
+    "default": {
+        "namespace": "rock-test",
+        "ports": {"proxy": 8000, "server": 8080, "ssh": 22},
+        "template": {
+            "spec": {
+                "containers": [
+                    {
+                        "name": "main",
+                        "image": "{{ image | default('python:3.11', true) }}",
+                        "resources": {
+                            "requests": {"cpu": "{{ cpus }}", "memory": "{{ memory }}"},
+                            "limits": {"cpu": "{{ limit_cpus }}", "memory": "{{ memory }}"},
+                        },
+                    }
+                ],
+            },
+        },
+    }
+}
+
+
+def make_resource_provider() -> BatchSandboxProvider:
+    return BatchSandboxProvider(
+        k8s_config=K8sConfig(
+            kubeconfig_path=None,
+            templates=RESOURCE_TEMPLATES,
+            template_map={},
+        )
+    )
+
+
+class TestBuildBatchSandboxManifestCpuOvercommit:
+    """`_build_batchsandbox_manifest` must forward `config.limit_cpus` so K8s
+    sandboxes can request `cpus` cores while bursting up to `limit_cpus` — the
+    K8s analogue of the Ray path's `docker run --cpu-shares ... --cpus ...`."""
+
+    async def test_limit_cpus_propagated_to_manifest(self):
+        """limit_cpus > cpus: requests.cpu stays at cpus, limits.cpu = limit_cpus."""
+        provider = make_resource_provider()
+        config = make_config(cpus=2.0, memory="4Gi", limit_cpus=6.0)
+
+        manifest = await provider._build_batchsandbox_manifest(config)
+
+        container = manifest["spec"]["template"]["spec"]["containers"][0]
+        assert container["resources"]["requests"]["cpu"] == "2.0"
+        assert container["resources"]["limits"]["cpu"] == "6.0"
+
+    async def test_limit_cpus_defaults_to_cpus_when_none(self):
+        """limit_cpus omitted: loader falls back to cpus so requests.cpu == limits.cpu."""
+        provider = make_resource_provider()
+        config = make_config(cpus=4.0, memory="8Gi")  # limit_cpus left as None
+
+        manifest = await provider._build_batchsandbox_manifest(config)
+
+        container = manifest["spec"]["template"]["spec"]["containers"][0]
+        assert container["resources"]["requests"]["cpu"] == "4.0"
+        assert container["resources"]["limits"]["cpu"] == "4.0"

--- a/tests/unit/sandbox/operator/test_k8s_template_loader.py
+++ b/tests/unit/sandbox/operator/test_k8s_template_loader.py
@@ -196,6 +196,39 @@ class TestK8sTemplateLoader:
         nodeSelector = manifest["spec"]["template"]["spec"]["nodeSelector"]
         assert nodeSelector["nvidia.com/gpu.product"] == "A100"
 
+    def test_build_manifest_limit_cpus_defaults_to_cpus(self, template_loader):
+        """limit_cpus omitted: limits.cpu falls back to cpus so requests == limits."""
+        manifest = template_loader.build_manifest(
+            template_name="default", sandbox_id="test-sandbox", cpus=4.0, memory="8Gi"
+        )
+
+        container = manifest["spec"]["template"]["spec"]["containers"][0]
+        assert container["resources"]["requests"]["cpu"] == "4.0"
+        assert container["resources"]["limits"]["cpu"] == "4.0"
+
+    def test_build_manifest_limit_cpus_overcommit(self, template_loader):
+        """limit_cpus > cpus: requests stays at cpus, limits raises to limit_cpus."""
+        manifest = template_loader.build_manifest(
+            template_name="default",
+            sandbox_id="test-sandbox",
+            cpus=2.0,
+            memory="4Gi",
+            limit_cpus=6.0,
+        )
+
+        container = manifest["spec"]["template"]["spec"]["containers"][0]
+        assert container["resources"]["requests"]["cpu"] == "2.0"
+        assert container["resources"]["limits"]["cpu"] == "6.0"
+
+    def test_build_manifest_limit_cpus_collapses_when_no_cpus(self, template_loader):
+        """Neither cpus nor limit_cpus passed: both keys collapse out of the manifest."""
+        manifest = template_loader.build_manifest(template_name="default", sandbox_id="test-sandbox")
+
+        container = manifest["spec"]["template"]["spec"]["containers"][0]
+        resources = container["resources"]
+        assert resources.get("requests", {}) == {}
+        assert resources.get("limits", {}) == {}
+
     def test_build_manifest_drops_gpu_when_no_gpu(self):
         """When num_gpus omitted, GPU keys collapse out of resources.limits."""
         templates = {

--- a/tests/unit/sdk/sandbox/test_oss_client.py
+++ b/tests/unit/sdk/sandbox/test_oss_client.py
@@ -608,3 +608,161 @@ def test_compute_object_name_no_prefix_keeps_legacy_layout():
         sandbox_path="/data/x",
     )
     assert "/" not in name  # flat layout
+
+
+# ---------------------------------------------------------------------------
+# sandbox_endpoint propagation
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxEndpoint:
+    """Verify the new sandbox_endpoint field is properly resolved and used."""
+
+    def test_resolve_config_layer2_picks_sandbox_endpoint_from_response(self):
+        """When server response includes SandboxEndpoint, it lands in config."""
+        with (
+            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
+            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
+            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
+        ):
+            cfg = OssClient._resolve_config(
+                {
+                    "Endpoint": "cn-shanghai.oss.aliyuncs.com",
+                    "SandboxEndpoint": "oss-cn-shanghai-internal.aliyuncs.com",
+                    "Bucket": "my-bucket",
+                    "Region": "cn-shanghai",
+                }
+            )
+        assert cfg.endpoint == "cn-shanghai.oss.aliyuncs.com"
+        assert cfg.sandbox_endpoint == "oss-cn-shanghai-internal.aliyuncs.com"
+
+    def test_resolve_config_layer2_sandbox_endpoint_empty_when_absent(self):
+        """When server response lacks SandboxEndpoint, field defaults to empty."""
+        with (
+            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
+            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
+            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
+        ):
+            cfg = OssClient._resolve_config(
+                {
+                    "Endpoint": "cn-shanghai.oss.aliyuncs.com",
+                    "Bucket": "my-bucket",
+                    "Region": "cn-shanghai",
+                }
+            )
+        assert cfg.sandbox_endpoint == ""
+
+    def test_resolve_config_layer2_sandbox_endpoint_none_treated_as_empty(self):
+        """Explicit None for SandboxEndpoint is normalized to empty string."""
+        with (
+            patch.object(env_vars, "ROCK_OSS_BUCKET_ENDPOINT", ""),
+            patch.object(env_vars, "ROCK_OSS_BUCKET_NAME", ""),
+            patch.object(env_vars, "ROCK_OSS_BUCKET_REGION", ""),
+        ):
+            cfg = OssClient._resolve_config(
+                {
+                    "Endpoint": "pub.oss",
+                    "SandboxEndpoint": None,
+                    "Bucket": "b",
+                    "Region": "r",
+                }
+            )
+        assert cfg.sandbox_endpoint == ""
+
+    async def test_download_via_oss_uses_sandbox_endpoint_when_set(self, tmp_path):
+        """ossutil cp inside sandbox MUST use sandbox_endpoint when configured."""
+        sandbox = _make_sandbox()
+        sandbox.sandbox_id = "sb-dl"
+        sandbox.execute = AsyncMock(return_value=MagicMock(exit_code=0))
+        sandbox.arun = AsyncMock(return_value=MagicMock(exit_code=0, output=""))
+
+        client = OssClient(sandbox)
+        client._bucket = MagicMock()
+        client._client_config = OssClientConfig(
+            endpoint="cn-shanghai.oss.aliyuncs.com",
+            bucket="my-bucket",
+            region="cn-shanghai",
+            enabled_via_env=False,
+            sandbox_endpoint="oss-cn-shanghai-internal.aliyuncs.com",
+        )
+        # Force token not expired so it still calls _get_sts_credentials
+        client._token_expire_time = "2000-01-01T00:00:00Z"
+
+        with (
+            patch("rock.sdk.sandbox.oss_client.HttpUtils") as mock_http,
+            patch("rock.sdk.sandbox.oss_client.oss2") as mock_oss2,
+        ):
+            mock_http.get = AsyncMock(
+                return_value={
+                    "status": "Success",
+                    "result": {
+                        "AccessKeyId": "ak",
+                        "AccessKeySecret": "sk",
+                        "SecurityToken": "tok",
+                        "Expiration": "2099-01-01T00:00:00Z",
+                    },
+                }
+            )
+            mock_oss2.StsAuth = MagicMock()
+            mock_bucket = MagicMock()
+            mock_oss2.Bucket = MagicMock(return_value=mock_bucket)
+            # Make the local file exist after get_object_to_file
+            local_file = tmp_path / "out.txt"
+            mock_bucket.get_object_to_file = MagicMock(side_effect=lambda k, p: local_file.write_text("ok"))
+
+            response = await client.download_via_oss("/sandbox/file.txt", local_file)
+
+        assert response.success is True
+        # Verify the ossutil command used the INTERNAL sandbox_endpoint
+        arun_cmd = sandbox.arun.await_args.kwargs.get("cmd") or sandbox.arun.await_args.args[0]
+        assert "oss-cn-shanghai-internal.aliyuncs.com" in arun_cmd
+        assert "cn-shanghai.oss.aliyuncs.com" not in arun_cmd
+        # But the host-side oss2.Bucket uses the PUBLIC endpoint
+        oss2_bucket_call = mock_oss2.Bucket.call_args
+        assert oss2_bucket_call.args[1] == "cn-shanghai.oss.aliyuncs.com"
+
+    async def test_download_via_oss_falls_back_to_endpoint_when_sandbox_endpoint_empty(self, tmp_path):
+        """When sandbox_endpoint is empty, ossutil should fall back to endpoint."""
+        sandbox = _make_sandbox()
+        sandbox.sandbox_id = "sb-dl2"
+        sandbox.execute = AsyncMock(return_value=MagicMock(exit_code=0))
+        sandbox.arun = AsyncMock(return_value=MagicMock(exit_code=0, output=""))
+
+        client = OssClient(sandbox)
+        client._bucket = MagicMock()
+        client._client_config = OssClientConfig(
+            endpoint="cn-shanghai.oss.aliyuncs.com",
+            bucket="my-bucket",
+            region="cn-shanghai",
+            enabled_via_env=False,
+            sandbox_endpoint="",  # empty → fall back
+        )
+        client._token_expire_time = "2000-01-01T00:00:00Z"
+
+        with (
+            patch("rock.sdk.sandbox.oss_client.HttpUtils") as mock_http,
+            patch("rock.sdk.sandbox.oss_client.oss2") as mock_oss2,
+        ):
+            mock_http.get = AsyncMock(
+                return_value={
+                    "status": "Success",
+                    "result": {
+                        "AccessKeyId": "ak",
+                        "AccessKeySecret": "sk",
+                        "SecurityToken": "tok",
+                        "Expiration": "2099-01-01T00:00:00Z",
+                    },
+                }
+            )
+            mock_oss2.StsAuth = MagicMock()
+            mock_bucket = MagicMock()
+            mock_oss2.Bucket = MagicMock(return_value=mock_bucket)
+            local_file = tmp_path / "out2.txt"
+            mock_bucket.get_object_to_file = MagicMock(side_effect=lambda k, p: local_file.write_text("ok"))
+
+            response = await client.download_via_oss("/sandbox/file.txt", local_file)
+
+        assert response.success is True
+        arun_cmd = sandbox.arun.await_args.kwargs.get("cmd") or sandbox.arun.await_args.args[0]
+        # Falls back to the public endpoint
+        assert "cn-shanghai.oss.aliyuncs.com" in arun_cmd

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,11 +1,12 @@
 import tempfile
 import textwrap
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import yaml
 
-from rock.config import RockConfig, RuntimeConfig, _resolve_k8s_template_includes
+from rock.config import ImageRegistryMirror, RockConfig, RuntimeConfig, _resolve_k8s_template_includes
 
 
 @pytest.mark.asyncio
@@ -150,6 +151,67 @@ def test_sandbox_config_coerces_nested_dicts_from_yaml():
     assert cfg.log.keep_days_before_archive == 7
     assert isinstance(cfg.file_transfer, SandboxFileTransferConfig)
     assert cfg.file_transfer.prefix == "rock-transfer/"
+
+
+# ===== Nacos hot-reload for image mirror config =====
+
+
+@pytest.mark.asyncio
+async def test_nacos_update_loads_image_registry_mirrors():
+    rock_config = RockConfig()
+    rock_config.nacos_provider = MagicMock()
+    rock_config.nacos_provider.get_config = AsyncMock(
+        return_value={
+            "image_registry_mirrors": [
+                {"registry": "mirror.example.com", "namespace": "ns", "username": "u", "password": "p"},
+                {"registry": "mirror2.example.com", "namespace": "ns2"},
+            ],
+            "image_mirror_lookup_allowlist": ["swe-bench:", "aaa/bbb/"],
+        }
+    )
+
+    await rock_config.update()
+
+    assert len(rock_config.image_registry_mirrors) == 2
+    assert rock_config.image_registry_mirrors[0] == ImageRegistryMirror(
+        registry="mirror.example.com", namespace="ns", username="u", password="p"
+    )
+    assert rock_config.image_registry_mirrors[1].username is None
+    assert rock_config.image_mirror_lookup_allowlist == ["swe-bench:", "aaa/bbb/"]
+
+
+@pytest.mark.asyncio
+async def test_nacos_update_empty_mirrors_clears_list():
+    rock_config = RockConfig()
+    rock_config.image_registry_mirrors = [ImageRegistryMirror(registry="old.com", namespace="old")]
+    rock_config.image_mirror_lookup_allowlist = ["*"]
+    rock_config.nacos_provider = MagicMock()
+    rock_config.nacos_provider.get_config = AsyncMock(
+        return_value={
+            "image_registry_mirrors": [],
+            "image_mirror_lookup_allowlist": [],
+        }
+    )
+
+    await rock_config.update()
+
+    assert rock_config.image_registry_mirrors == []
+    assert rock_config.image_mirror_lookup_allowlist == []
+
+
+@pytest.mark.asyncio
+async def test_nacos_update_without_mirror_keys_preserves_existing():
+    rock_config = RockConfig()
+    rock_config.image_registry_mirrors = [ImageRegistryMirror(registry="keep.com", namespace="ns")]
+    rock_config.image_mirror_lookup_allowlist = ["*"]
+    rock_config.nacos_provider = MagicMock()
+    rock_config.nacos_provider.get_config = AsyncMock(return_value={"sandbox_config": {}})
+
+    await rock_config.update()
+
+    assert len(rock_config.image_registry_mirrors) == 1
+    assert rock_config.image_registry_mirrors[0].registry == "keep.com"
+    assert rock_config.image_mirror_lookup_allowlist == ["*"]
 
 
 # ===== _resolve_k8s_template_includes =====

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -136,7 +136,7 @@ def test_sandbox_log_config_defaults():
     cfg = SandboxLogConfig()
     # prefix defaults empty: each deployment YAML must opt-in to a value
     # matching its OSS bucket lifecycle rule (e.g. "rock-archives/").
-    assert cfg.archive_prefix == ""
+    assert cfg.archive_prefix == "rock-archives/"
     assert cfg.keep_days_before_archive == 3
     assert cfg.archive_max_attempts == 3
 
@@ -599,7 +599,8 @@ class TestFromEnvBaseInheritance:
         """Child config inherits and overrides base via _deep_merge."""
         base_file = tmp_path / "base.yml"
         base_file.write_text(
-            textwrap.dedent("""\
+            textwrap.dedent(
+                """\
             ray:
               namespace: "base-ns"
               runtime_env:
@@ -607,16 +608,19 @@ class TestFromEnvBaseInheritance:
             warmup:
               images:
                 - "python:3.11"
-        """)
+        """
+            )
         )
 
         child_file = tmp_path / "child.yml"
         child_file.write_text(
-            textwrap.dedent("""\
+            textwrap.dedent(
+                """\
             _base: base.yml
             ray:
               namespace: "child-ns"
-        """)
+        """
+            )
         )
 
         config = RockConfig.from_env(config_path=str(child_file))
@@ -630,7 +634,8 @@ class TestFromEnvBaseInheritance:
         """Scheduler tasks list is merged by task_class key."""
         base_file = tmp_path / "base.yml"
         base_file.write_text(
-            textwrap.dedent("""\
+            textwrap.dedent(
+                """\
             scheduler:
               tasks:
                 - task_class: "rock.admin.scheduler.tasks.cleanup.CleanupTask"
@@ -639,12 +644,14 @@ class TestFromEnvBaseInheritance:
                 - task_class: "rock.admin.scheduler.tasks.report.ReportTask"
                   enabled: true
                   interval_seconds: 300
-        """)
+        """
+            )
         )
 
         child_file = tmp_path / "child.yml"
         child_file.write_text(
-            textwrap.dedent("""\
+            textwrap.dedent(
+                """\
             _base: base.yml
             scheduler:
               tasks:
@@ -653,7 +660,8 @@ class TestFromEnvBaseInheritance:
                 - task_class: "rock.admin.scheduler.tasks.audit.AuditTask"
                   enabled: true
                   interval_seconds: 600
-        """)
+        """
+            )
         )
 
         config = RockConfig.from_env(config_path=str(child_file))
@@ -671,11 +679,13 @@ class TestFromEnvBaseInheritance:
     def test_base_not_found_raises(self, tmp_path: Path):
         child_file = tmp_path / "child.yml"
         child_file.write_text(
-            textwrap.dedent("""\
+            textwrap.dedent(
+                """\
             _base: nonexistent.yml
             ray:
               namespace: "ns"
-        """)
+        """
+            )
         )
         with pytest.raises(Exception, match="base config file.*not found"):
             RockConfig.from_env(config_path=str(child_file))

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -56,6 +56,42 @@ async def test_runtime_config():
     assert runtime_config.standard_spec.cpus == 2
 
 
+def test_runtime_config_instance_registry_mirrors_default_empty():
+    cfg = RuntimeConfig()
+    assert cfg.instance_registry_mirrors == []
+
+
+def test_runtime_config_instance_registry_mirrors_accepts_list():
+    mirrors = ["reg-a.example.com/ns-1", "reg-b.example.com/ns-2"]
+    cfg = RuntimeConfig(instance_registry_mirrors=mirrors)
+    assert cfg.instance_registry_mirrors == mirrors
+
+
+@pytest.mark.asyncio
+async def test_runtime_config_instance_registry_mirrors_from_yaml(tmp_path, monkeypatch):
+    yaml_path = tmp_path / "rock-test.yml"
+    yaml_path.write_text(
+        yaml.safe_dump(
+            {
+                "runtime": {
+                    "instance_registry_mirrors": [
+                        "reg-a.example.com/mirror-1",
+                        "reg-b.example.com/mirror-2",
+                    ],
+                },
+            }
+        )
+    )
+    # RuntimeConfig.__post_init__ requires ROCK_PYTHON_ENV_PATH + ROCK_ENVHUB_DB_URL.
+    monkeypatch.setenv("ROCK_PYTHON_ENV_PATH", "/usr")
+    monkeypatch.setenv("ROCK_ENVHUB_DB_URL", "sqlite:////tmp/test.db")
+    rock_config = RockConfig.from_env(str(yaml_path))
+    assert rock_config.runtime.instance_registry_mirrors == [
+        "reg-a.example.com/mirror-1",
+        "reg-b.example.com/mirror-2",
+    ]
+
+
 def test_oss_config_defaults():
     from rock.config import OssAccountConfig, OssConfig
 
@@ -212,6 +248,56 @@ async def test_nacos_update_without_mirror_keys_preserves_existing():
     assert len(rock_config.image_registry_mirrors) == 1
     assert rock_config.image_registry_mirrors[0].registry == "keep.com"
     assert rock_config.image_mirror_lookup_allowlist == ["*"]
+
+
+# ===== Nacos hot-reload for instance_registry_mirrors =====
+
+
+@pytest.mark.asyncio
+async def test_nacos_update_loads_instance_registry_mirrors():
+    rock_config = RockConfig()
+    rock_config.nacos_provider = MagicMock()
+    rock_config.nacos_provider.get_config = AsyncMock(
+        return_value={
+            "runtime": {
+                "instance_registry_mirrors": ["reg-a.example.com/ns-1", "reg-b.example.com/ns-2"],
+            },
+        }
+    )
+
+    await rock_config.update()
+
+    assert rock_config.runtime.instance_registry_mirrors == ["reg-a.example.com/ns-1", "reg-b.example.com/ns-2"]
+
+
+@pytest.mark.asyncio
+async def test_nacos_update_empty_instance_mirrors_clears_list():
+    rock_config = RockConfig()
+    rock_config.runtime.instance_registry_mirrors = ["old.example.com/ns"]
+    rock_config.nacos_provider = MagicMock()
+    rock_config.nacos_provider.get_config = AsyncMock(
+        return_value={
+            "runtime": {
+                "instance_registry_mirrors": [],
+            },
+        }
+    )
+
+    await rock_config.update()
+
+    assert rock_config.runtime.instance_registry_mirrors == []
+
+
+@pytest.mark.asyncio
+async def test_nacos_update_without_runtime_key_preserves_instance_mirrors():
+    rock_config = RockConfig()
+    rock_config.runtime.instance_registry_mirrors = ["keep.example.com/ns"]
+    rock_config.nacos_provider = MagicMock()
+    rock_config.nacos_provider.get_config = AsyncMock(return_value={"sandbox_config": {}})
+
+    await rock_config.update()
+
+    assert rock_config.runtime.instance_registry_mirrors == ["keep.example.com/ns"]
 
 
 # ===== _resolve_k8s_template_includes =====

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -130,6 +130,80 @@ def test_oss_config_primary_dict_coerced():
     assert cfg.bucket == ""
 
 
+def test_oss_account_config_sandbox_endpoint_default_empty():
+    from rock.config import OssAccountConfig
+
+    cfg = OssAccountConfig()
+    assert cfg.sandbox_endpoint == ""
+
+
+def test_oss_account_config_sandbox_endpoint_from_dict():
+    from rock.config import OssConfig
+
+    cfg = OssConfig(
+        primary={
+            "endpoint": "cn-shanghai.oss.aliyuncs.com",
+            "sandbox_endpoint": "oss-cn-shanghai-internal.aliyuncs.com",
+            "bucket": "my-bucket",
+            "access_key_id": "a",
+            "access_key_secret": "s",
+            "role_arn": "r",
+            "region": "cn-shanghai",
+        }
+    )
+    assert cfg.primary.endpoint == "cn-shanghai.oss.aliyuncs.com"
+    assert cfg.primary.sandbox_endpoint == "oss-cn-shanghai-internal.aliyuncs.com"
+
+
+def test_oss_config_deep_merge_sandbox_endpoint_inherited(tmp_path):
+    """_deep_merge correctly inherits sandbox_endpoint from base to child."""
+    base = {
+        "oss": {
+            "primary": {
+                "endpoint": "cn-shanghai.oss.aliyuncs.com",
+                "sandbox_endpoint": "oss-cn-shanghai-internal.aliyuncs.com",
+                "bucket": "b",
+                "access_key_id": "a",
+                "access_key_secret": "s",
+                "role_arn": "r",
+                "region": "cn-shanghai",
+            }
+        }
+    }
+    # Child overrides only endpoint (non-VPC scenario) — sandbox_endpoint inherited
+    override = {
+        "oss": {
+            "primary": {
+                "endpoint": "cn-shanghai.oss.aliyuncs.com",
+            }
+        }
+    }
+    merged = RockConfig._deep_merge(base, override)
+    assert merged["oss"]["primary"]["sandbox_endpoint"] == "oss-cn-shanghai-internal.aliyuncs.com"
+
+
+def test_oss_config_deep_merge_sandbox_endpoint_override_empty(tmp_path):
+    """Child can explicitly override sandbox_endpoint to empty to disable it."""
+    base = {
+        "oss": {
+            "primary": {
+                "endpoint": "cn-shanghai.oss.aliyuncs.com",
+                "sandbox_endpoint": "oss-cn-shanghai-internal.aliyuncs.com",
+                "bucket": "b",
+            }
+        }
+    }
+    override = {
+        "oss": {
+            "primary": {
+                "sandbox_endpoint": "",  # explicit clear
+            }
+        }
+    }
+    merged = RockConfig._deep_merge(base, override)
+    assert merged["oss"]["primary"]["sandbox_endpoint"] == ""
+
+
 def test_sandbox_log_config_defaults():
     from rock.config import SandboxLogConfig
 

--- a/uv.lock
+++ b/uv.lock
@@ -4280,7 +4280,7 @@ wheels = [
 
 [[package]]
 name = "rl-rock"
-version = "1.8.0"
+version = "1.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },

--- a/uv.lock
+++ b/uv.lock
@@ -4280,7 +4280,7 @@ wheels = [
 
 [[package]]
 name = "rl-rock"
-version = "1.8.3"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Closes #1184 

## Summary

在 `OssAccountConfig` 上新增可选字段 **`sandbox_endpoint`**，把"用户侧公网访问 endpoint"和"Worker / Sandbox 内部私网访问 endpoint"彻底解耦。

- 用户侧 SDK（`/get_token` → `oss2.Bucket`）：继续使用 `endpoint`（**公网**）。
- Worker 侧 `SandboxLogArchiveTask` 上传日志归档：改用 `sandbox_endpoint`（**私网**）。
- Sandbox 内 `OssClient.download_via_oss`（`ossutil cp`）：改用 `sandbox_endpoint`（**私网**）。

`sandbox_endpoint` 为空时统一 fallback 到 `endpoint`，**老 YAML 零迁移**。

## Motivation

`OssAccountConfig` 之前只有一个 `endpoint`，被跨网络的三类调用方共用：

| 调用方 | 运行位置 | 期望 endpoint |
| --- | --- | --- |
| 用户 SDK | 用户开发机 / 外网 | 公网 |
| `SandboxLogArchiveTask` | Worker（VPC 内） | 私网 |
| Sandbox 内 `download_via_oss` | Sandbox 容器（VPC 内） | 私网 |

单字段无法同时满足这三个语义。本次拆分把用户侧 endpoint 与沙箱侧 endpoint 独立配置，用户 SDK 走公网稳定可达，worker / sandbox 走私网省流量降延迟。

## Changes

### `rock/config.py`

- `OssAccountConfig` 新增 `sandbox_endpoint: str = ""`，附完整 docstring 说明使用场景与回落逻辑。

### `rock/admin/scheduler/tasks/sandbox_log_archive_task.py`

- 构造 `ossutil cp` 命令时 endpoint 改为 `primary.sandbox_endpoint or primary.endpoint`。

### `rock/sdk/sandbox/oss_client.py`

- `OssClientConfig` dataclass 新增 `sandbox_endpoint: str = ""`。
- `_resolve_config`：
  - Layer 2（服务端响应）读取 `sts_response.get("SandboxEndpoint")`；
  - Layer 1（环境变量）读取 `env_vars.ROCK_OSS_SANDBOX_ENDPOINT`。
- `download_via_oss`：
  - 沙箱内的 `ossutil cp --endpoint=…` 使用 `sandbox_endpoint or endpoint`（走私网）；
  - 宿主机侧的 `oss2.Bucket(…, endpoint)` 保留 `endpoint`（走公网）。

### `rock/sandbox/service/sandbox_proxy_service.py`

- `gen_oss_sts_token` 响应体新增 `SandboxEndpoint` 字段：
  - `primary` 账户返回 `primary.sandbox_endpoint or None`；
  - legacy 账户固定返回 `None`（无此语义）。

### 单元测试（新增 12 个用例，全部通过）

- `tests/unit/test_config.py`：默认值为空、从 dict 构造、`_deep_merge` 继承、`_deep_merge` 显式清空为 `""`。
- `tests/unit/admin/scheduler/test_sandbox_log_archive_task.py`：`sandbox_endpoint` 存在时归档命令使用私网、不出现公网；为空时回落到 `endpoint`；`bucket` 为空时仍然安全 skip。
- `tests/unit/sdk/sandbox/test_oss_client.py`：Layer 2 从响应体读取 `SandboxEndpoint`；响应体缺失 / 显式 `None` 时归零；`download_via_oss` ossutil 走私网、host 侧 `oss2.Bucket` 走公网；`sandbox_endpoint` 为空时 ossutil 回落到公网。

## Backward Compatibility

- **新字段默认值为 `""`，老 YAML 无需改动**。当 `sandbox_endpoint` 为空时，`SandboxLogArchiveTask` 与 `download_via_oss` 的行为与之前完全一致。
- SDK 响应中的 `SandboxEndpoint` 是**附加字段**，旧 SDK 会忽略；新 SDK 在字段缺失时也走 fallback 逻辑。
- `_deep_merge` 支持子 YAML 显式把 `sandbox_endpoint` 设为 `""` 以清空基类值。

## Test Plan

- [x] `uv run pytest tests/unit/test_config.py tests/unit/admin/scheduler/test_sandbox_log_archive_task.py tests/unit/sdk/sandbox/test_oss_client.py` → **125 passed**
- [x] Regression：未设置 `sandbox_endpoint` 时 `SandboxLogArchiveTask` / `download_via_oss` 行为无差异
- [ ] Staging：在一个 VPC 集群配上 `sandbox_endpoint`，观察归档命令 & 沙箱下载命令确实走私网域名
- [ ] Staging：验证 SDK 通过 `/get_token` 拿到的仍是公网域名，用户机可正常上传

## Deployment Notes（内部部署侧，独立 PR，供参考）

新字段仅在 admin 侧 YAML 生效，SDK 侧通过 `/get_token` 自动感知。推荐配置（VPC / 非 VPC 集群统一）：

```yaml
oss:
  primary:
    # 用户侧公网 endpoint（SDK / /get_token 返回）
    endpoint: oss-cn-shanghai.aliyuncs.com
    # Worker / Sandbox 侧私网 endpoint
    sandbox_endpoint: cn-shanghai.oss.aliyuncs.com
```

## Diff Summary

```
 rock/admin/scheduler/tasks/sandbox_log_archive_task.py      |   5 +-
 rock/config.py                                              |  14 ++
 rock/sandbox/service/sandbox_proxy_service.py               |   9 ++
 rock/sdk/sandbox/oss_client.py                              |  19 ++-
 tests/unit/admin/scheduler/test_sandbox_log_archive_task.py | 103 ++++++++
 tests/unit/sdk/sandbox/test_oss_client.py                   | 158 ++++++++++
 tests/unit/test_config.py                                   |  74 ++++++
 7 files changed, 380 insertions(+), 2 deletions(-)
```