### PR TITLE
feat(oss): split user-facing `endpoint` from in-sandbox/worker `sandbox_endpoint`

### DIFF
--- a/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
+++ b/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
@@ -139,7 +139,10 @@ class SandboxLogArchiveTask(BaseTask):
 
         primary = rock_config.oss.primary
         bucket = primary.bucket
-        endpoint = primary.endpoint
+        # Workers sit inside the VPC, so prefer the in-VPC endpoint when set.
+        # Falls back to the public `endpoint` for legacy YAMLs that only have
+        # one endpoint configured.
+        endpoint = primary.server_endpoint or primary.endpoint
         access_key_id = primary.access_key_id
         access_key_secret = primary.access_key_secret
         if not (bucket and endpoint and access_key_id and access_key_secret):

--- a/rock/config.py
+++ b/rock/config.py
@@ -128,6 +128,21 @@ class OssAccountConfig:
     """Region used to construct the STS AcsClient for this account. Falls back
     to env_vars.ROCK_OSS_BUCKET_REGION when empty, to preserve legacy behavior."""
 
+    server_endpoint: str = ""
+    """In-VPC OSS endpoint for code that runs on the ROCK server side —
+    i.e. inside a sandbox container, on a worker host, or in the admin
+    scheduler (e.g. ossutil download inside a sandbox container, archive
+    upload from a worker host). When non-empty, callers in those execution
+    contexts SHOULD use this endpoint instead of `endpoint`, because
+    server-side components typically sit inside the VPC and benefit from
+    the internal endpoint (no public bandwidth charge, lower latency).
+
+    `endpoint` remains the user/SDK-facing endpoint (used by the host-side
+    Python SDK / oss2 client on the developer's machine, and returned to the
+    SDK via `/get_token`). When `server_endpoint` is empty, callers MUST
+    fall back to `endpoint` so legacy YAMLs that only set `endpoint` continue
+    to work."""
+
 
 @dataclass
 class OssConfig:

--- a/rock/sandbox/service/sandbox_proxy_service.py
+++ b/rock/sandbox/service/sandbox_proxy_service.py
@@ -708,6 +708,12 @@ class SandboxProxyService:
             role_arn = primary.role_arn
             session_name = "rock-sandbox-primary"
             endpoint = primary.endpoint or None
+            # In-VPC endpoint used by ROCK server-side components (e.g. by
+            # `ossutil cp` in OssClient.download_via_oss running inside the
+            # sandbox container, and by SandboxLogArchiveTask on workers).
+            # When empty, the SDK falls back to `endpoint` — preserves BC for
+            # YAMLs that didn't set this.
+            server_endpoint = primary.server_endpoint or None
             bucket = primary.bucket or None
             region = primary.region or env_vars.ROCK_OSS_BUCKET_REGION or None
             prefix = self._rock_config.sandbox_config.file_transfer.prefix or None
@@ -715,6 +721,8 @@ class SandboxProxyService:
             role_arn = self.oss_config.role_arn
             session_name = "rock-sandbox-legacy"
             endpoint = env_vars.ROCK_OSS_BUCKET_ENDPOINT or self.oss_config.endpoint or None
+            # Legacy path has no separate in-VPC endpoint concept.
+            server_endpoint = None
             bucket = env_vars.ROCK_OSS_BUCKET_NAME or self.oss_config.bucket or None
             region = env_vars.ROCK_OSS_BUCKET_REGION or None
             prefix = env_vars.ROCK_OSS_TRANSFER_PREFIX or None
@@ -741,6 +749,10 @@ class SandboxProxyService:
         return {
             **credentials,
             "Endpoint": endpoint,
+            # Optional separate in-VPC endpoint for code that runs on the ROCK
+            # server side (sandbox containers, workers). SDK fallback: when
+            # missing/empty, use Endpoint.
+            "ServerEndpoint": server_endpoint,
             "Bucket": bucket,
             "Region": region,
             "Prefix": prefix,  # transfer-object key prefix, scoped per account

--- a/rock/sdk/sandbox/oss_client.py
+++ b/rock/sdk/sandbox/oss_client.py
@@ -36,6 +36,13 @@ class OssClientConfig:
     bucket: str
     region: str
     prefix: str = ""  # Transfer-object key prefix from server response (e.g. "rock-transfer/")
+    server_endpoint: str = ""
+    """In-VPC OSS endpoint used by code that runs on the ROCK server side —
+    e.g. `ossutil cp --endpoint` invoked INSIDE the sandbox container by
+    `download_via_oss`. Distinct from `endpoint`, which is the user/SDK-facing
+    endpoint (used by host-side oss2.Bucket on the developer's machine).
+    Empty = no separate server endpoint configured; callers MUST fall back
+    to `endpoint`."""
 
 
 class OssClient:
@@ -84,6 +91,10 @@ class OssClient:
                 bucket=resp_bucket,
                 region=resp_region,
                 prefix=sts_response.get("Prefix") or "",
+                # `ServerEndpoint` is the in-VPC endpoint used by ROCK server-side
+                # components (ossutil cp inside the sandbox container). Optional;
+                # empty = use `endpoint`.
+                server_endpoint=sts_response.get("ServerEndpoint") or "",
             )
 
         # OSS unavailable: server did not supply a complete config.
@@ -273,12 +284,17 @@ class OssClient:
         )
         oss_url = f"oss://{self._client_config.bucket}/{oss_object_name}"
 
+        # ossutil runs INSIDE the sandbox container (in the VPC). Prefer the
+        # in-VPC `server_endpoint` when configured, to avoid public bandwidth
+        # cost and reduce latency. Fall back to `endpoint` for legacy / single-
+        # endpoint deployments.
+        resolved_server_endpoint = self._client_config.server_endpoint or self._client_config.endpoint
         ossutil_inner = (
             f"ossutil cp {shlex.quote(remote_path)} {shlex.quote(oss_url)}"
             f" --access-key-id {shlex.quote(access_key_id)}"
             f" --access-key-secret {shlex.quote(access_key_secret)}"
             f" --sts-token {shlex.quote(security_token)}"
-            f" --endpoint {shlex.quote(self._client_config.endpoint)}"
+            f" --endpoint {shlex.quote(resolved_server_endpoint)}"
             f" --region {shlex.quote(self._client_config.region)}"
         )
         upload_cmd = f"bash -c {shlex.quote(ossutil_inner)}"

--- a/tests/unit/admin/scheduler/test_sandbox_log_archive_task.py
+++ b/tests/unit/admin/scheduler/test_sandbox_log_archive_task.py
@@ -58,6 +58,7 @@ def _fake_rock_config(
             primary=SimpleNamespace(
                 bucket=bucket,
                 endpoint=endpoint,
+                server_endpoint="",
                 access_key_id=access_key_id,
                 access_key_secret=access_key_secret,
             )
@@ -426,3 +427,105 @@ class TestArchiveCommand:
 
         assert result["archived"] == 1
         assert result["failed"] == 1
+
+
+# ---------------------------------------------------------------------------
+# server_endpoint: VPC internal endpoint selection
+# ---------------------------------------------------------------------------
+
+
+def _fake_rock_config_with_server_endpoint(
+    bucket="b",
+    endpoint="oss-cn-shanghai.aliyuncs.com",
+    server_endpoint="cn-shanghai.oss.aliyuncs.com",
+    access_key_id="AKID",
+    access_key_secret="AKSEC",
+    keep_days=3,
+    archive_prefix="rock-archives/",
+):
+    return SimpleNamespace(
+        oss=SimpleNamespace(
+            primary=SimpleNamespace(
+                bucket=bucket,
+                endpoint=endpoint,
+                server_endpoint=server_endpoint,
+                access_key_id=access_key_id,
+                access_key_secret=access_key_secret,
+            )
+        ),
+        sandbox_config=SimpleNamespace(
+            log=SimpleNamespace(
+                keep_days_before_archive=keep_days,
+                archive_prefix=archive_prefix,
+            )
+        ),
+    )
+
+
+class TestServerEndpoint:
+    """Verify SandboxLogArchiveTask uses server_endpoint when present."""
+
+    @pytest.mark.asyncio
+    async def test_uses_server_endpoint_for_archive_command(self, fake_table):
+        """When server_endpoint is configured, the archive shell command
+        should reference the internal endpoint, not the public one."""
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(
+            lambda: _fake_rock_config_with_server_endpoint(
+                endpoint="oss-cn-shanghai.aliyuncs.com",
+                server_endpoint="cn-shanghai.oss.aliyuncs.com",
+            )
+        )
+        fake_table.list_by_in = AsyncMock(
+            return_value=[_row("sb-vpc", state="stopped", stop_time=_iso_days_ago(5))]
+        )
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="sb-vpc"), _FakeExecResult()])
+
+        await task.run_action(runtime)
+
+        archive_cmd = runtime.execute.await_args_list[2].args[0].command
+        assert "cn-shanghai.oss.aliyuncs.com" in archive_cmd
+        # Public endpoint should NOT appear in the command
+        assert "oss-cn-shanghai.aliyuncs.com" not in archive_cmd
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_endpoint_when_server_endpoint_empty(self, fake_table):
+        """When server_endpoint is empty, the task falls back to endpoint."""
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(
+            lambda: _fake_rock_config_with_server_endpoint(
+                endpoint="oss-cn-shanghai.aliyuncs.com",
+                server_endpoint="",  # empty → fallback
+            )
+        )
+        fake_table.list_by_in = AsyncMock(
+            return_value=[_row("sb-pub", state="stopped", stop_time=_iso_days_ago(5))]
+        )
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime([_FakeExecResult(), _FakeExecResult(stdout="sb-pub"), _FakeExecResult()])
+
+        await task.run_action(runtime)
+
+        archive_cmd = runtime.execute.await_args_list[2].args[0].command
+        assert "oss-cn-shanghai.aliyuncs.com" in archive_cmd
+
+    @pytest.mark.asyncio
+    async def test_skip_when_server_endpoint_set_but_bucket_empty(self, fake_table):
+        """Even with server_endpoint configured, skip if bucket is empty."""
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(
+            lambda: _fake_rock_config_with_server_endpoint(
+                bucket="",
+                server_endpoint="cn-shanghai.oss.aliyuncs.com",
+            )
+        )
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime([])
+        result = await task.run_action(runtime)
+
+        assert result["status"] == TaskStatusEnum.SUCCESS
+        assert "oss primary account not configured" in result["message"]

--- a/tests/unit/sdk/sandbox/test_oss_client.py
+++ b/tests/unit/sdk/sandbox/test_oss_client.py
@@ -538,3 +538,144 @@ def test_compute_object_name_empty_string_prefix_is_treated_as_empty():
         prefix="",
     )
     assert "/" not in name
+
+
+# ---------------------------------------------------------------------------
+# server_endpoint propagation
+# ---------------------------------------------------------------------------
+
+
+class TestServerEndpoint:
+    """Verify the new server_endpoint field is properly resolved and used."""
+
+    def test_resolve_config_picks_server_endpoint_from_response(self):
+        """When server response includes ServerEndpoint, it lands in config."""
+        cfg = OssClient._resolve_config(
+            {
+                "Endpoint": "oss-cn-shanghai.aliyuncs.com",
+                "ServerEndpoint": "cn-shanghai.oss.aliyuncs.com",
+                "Bucket": "my-bucket",
+                "Region": "cn-shanghai",
+            }
+        )
+        assert cfg.endpoint == "oss-cn-shanghai.aliyuncs.com"
+        assert cfg.server_endpoint == "cn-shanghai.oss.aliyuncs.com"
+
+    def test_resolve_config_server_endpoint_empty_when_absent(self):
+        """When server response lacks ServerEndpoint, field defaults to empty."""
+        cfg = OssClient._resolve_config(
+            {
+                "Endpoint": "oss-cn-shanghai.aliyuncs.com",
+                "Bucket": "my-bucket",
+                "Region": "cn-shanghai",
+            }
+        )
+        assert cfg.server_endpoint == ""
+
+    def test_resolve_config_server_endpoint_none_treated_as_empty(self):
+        """Explicit None for ServerEndpoint is normalized to empty string."""
+        cfg = OssClient._resolve_config(
+            {
+                "Endpoint": "pub.oss",
+                "ServerEndpoint": None,
+                "Bucket": "b",
+                "Region": "r",
+            }
+        )
+        assert cfg.server_endpoint == ""
+
+    async def test_download_via_oss_uses_server_endpoint_when_set(self, tmp_path):
+        """ossutil cp inside sandbox MUST use server_endpoint when configured."""
+        sandbox = _make_sandbox()
+        sandbox.sandbox_id = "sb-dl"
+        sandbox.execute = AsyncMock(return_value=MagicMock(exit_code=0))
+        sandbox.arun = AsyncMock(return_value=MagicMock(exit_code=0, output=""))
+
+        client = OssClient(sandbox)
+        client._bucket = MagicMock()
+        client._client_config = OssClientConfig(
+            endpoint="oss-cn-shanghai.aliyuncs.com",
+            bucket="my-bucket",
+            region="cn-shanghai",
+            server_endpoint="cn-shanghai.oss.aliyuncs.com",
+        )
+        # Force token not expired so it still calls _get_sts_credentials
+        client._token_expire_time = "2000-01-01T00:00:00Z"
+
+        with (
+            patch("rock.sdk.sandbox.oss_client.HttpUtils") as mock_http,
+            patch("rock.sdk.sandbox.oss_client.oss2") as mock_oss2,
+        ):
+            mock_http.get = AsyncMock(
+                return_value={
+                    "status": "Success",
+                    "result": {
+                        "AccessKeyId": "ak",
+                        "AccessKeySecret": "sk",
+                        "SecurityToken": "tok",
+                        "Expiration": "2099-01-01T00:00:00Z",
+                    },
+                }
+            )
+            mock_oss2.StsAuth = MagicMock()
+            mock_bucket = MagicMock()
+            mock_oss2.Bucket = MagicMock(return_value=mock_bucket)
+            # Make the local file exist after get_object_to_file
+            local_file = tmp_path / "out.txt"
+            mock_bucket.get_object_to_file = MagicMock(side_effect=lambda k, p: local_file.write_text("ok"))
+
+            response = await client.download_via_oss("/sandbox/file.txt", local_file)
+
+        assert response.success is True
+        # Verify the ossutil command used the INTERNAL server_endpoint
+        arun_cmd = sandbox.arun.await_args.kwargs.get("cmd") or sandbox.arun.await_args.args[0]
+        assert "cn-shanghai.oss.aliyuncs.com" in arun_cmd
+        assert "oss-cn-shanghai.aliyuncs.com" not in arun_cmd
+        # But the host-side oss2.Bucket uses the PUBLIC endpoint
+        oss2_bucket_call = mock_oss2.Bucket.call_args
+        assert oss2_bucket_call.args[1] == "oss-cn-shanghai.aliyuncs.com"
+
+    async def test_download_via_oss_falls_back_to_endpoint_when_server_endpoint_empty(self, tmp_path):
+        """When server_endpoint is empty, ossutil should fall back to endpoint."""
+        sandbox = _make_sandbox()
+        sandbox.sandbox_id = "sb-dl2"
+        sandbox.execute = AsyncMock(return_value=MagicMock(exit_code=0))
+        sandbox.arun = AsyncMock(return_value=MagicMock(exit_code=0, output=""))
+
+        client = OssClient(sandbox)
+        client._bucket = MagicMock()
+        client._client_config = OssClientConfig(
+            endpoint="oss-cn-shanghai.aliyuncs.com",
+            bucket="my-bucket",
+            region="cn-shanghai",
+            server_endpoint="",  # empty → fall back
+        )
+        client._token_expire_time = "2000-01-01T00:00:00Z"
+
+        with (
+            patch("rock.sdk.sandbox.oss_client.HttpUtils") as mock_http,
+            patch("rock.sdk.sandbox.oss_client.oss2") as mock_oss2,
+        ):
+            mock_http.get = AsyncMock(
+                return_value={
+                    "status": "Success",
+                    "result": {
+                        "AccessKeyId": "ak",
+                        "AccessKeySecret": "sk",
+                        "SecurityToken": "tok",
+                        "Expiration": "2099-01-01T00:00:00Z",
+                    },
+                }
+            )
+            mock_oss2.StsAuth = MagicMock()
+            mock_bucket = MagicMock()
+            mock_oss2.Bucket = MagicMock(return_value=mock_bucket)
+            local_file = tmp_path / "out2.txt"
+            mock_bucket.get_object_to_file = MagicMock(side_effect=lambda k, p: local_file.write_text("ok"))
+
+            response = await client.download_via_oss("/sandbox/file.txt", local_file)
+
+        assert response.success is True
+        arun_cmd = sandbox.arun.await_args.kwargs.get("cmd") or sandbox.arun.await_args.args[0]
+        # Falls back to the public endpoint
+        assert "oss-cn-shanghai.aliyuncs.com" in arun_cmd

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -130,6 +130,80 @@ def test_oss_config_primary_dict_coerced():
     assert cfg.bucket == ""
 
 
+def test_oss_account_config_server_endpoint_default_empty():
+    from rock.config import OssAccountConfig
+
+    cfg = OssAccountConfig()
+    assert cfg.server_endpoint == ""
+
+
+def test_oss_account_config_server_endpoint_from_dict():
+    from rock.config import OssConfig
+
+    cfg = OssConfig(
+        primary={
+            "endpoint": "oss-cn-shanghai.aliyuncs.com",
+            "server_endpoint": "cn-shanghai.oss.aliyuncs.com",
+            "bucket": "my-bucket",
+            "access_key_id": "a",
+            "access_key_secret": "s",
+            "role_arn": "r",
+            "region": "cn-shanghai",
+        }
+    )
+    assert cfg.primary.endpoint == "oss-cn-shanghai.aliyuncs.com"
+    assert cfg.primary.server_endpoint == "cn-shanghai.oss.aliyuncs.com"
+
+
+def test_oss_config_deep_merge_server_endpoint_inherited(tmp_path):
+    """_deep_merge correctly inherits server_endpoint from base to child."""
+    base = {
+        "oss": {
+            "primary": {
+                "endpoint": "oss-cn-shanghai.aliyuncs.com",
+                "server_endpoint": "cn-shanghai.oss.aliyuncs.com",
+                "bucket": "b",
+                "access_key_id": "a",
+                "access_key_secret": "s",
+                "role_arn": "r",
+                "region": "cn-shanghai",
+            }
+        }
+    }
+    # Child overrides only endpoint (non-VPC scenario) — server_endpoint inherited
+    override = {
+        "oss": {
+            "primary": {
+                "endpoint": "oss-cn-hangzhou.aliyuncs.com",
+            }
+        }
+    }
+    merged = RockConfig._deep_merge(base, override)
+    assert merged["oss"]["primary"]["server_endpoint"] == "cn-shanghai.oss.aliyuncs.com"
+
+
+def test_oss_config_deep_merge_server_endpoint_override_empty(tmp_path):
+    """Child can explicitly override server_endpoint to empty to disable it."""
+    base = {
+        "oss": {
+            "primary": {
+                "endpoint": "oss-cn-shanghai.aliyuncs.com",
+                "server_endpoint": "cn-shanghai.oss.aliyuncs.com",
+                "bucket": "b",
+            }
+        }
+    }
+    override = {
+        "oss": {
+            "primary": {
+                "server_endpoint": "",  # explicit clear
+            }
+        }
+    }
+    merged = RockConfig._deep_merge(base, override)
+    assert merged["oss"]["primary"]["server_endpoint"] == ""
+
+
 def test_sandbox_log_config_defaults():
     from rock.config import SandboxLogConfig
 


### PR DESCRIPTION
Closes #1184 

## Summary

Introduce a new optional field **`sandbox_endpoint`** on `OssAccountConfig` that fully decouples the "user-facing public endpoint" from the "worker / sandbox-side private endpoint":

- User-side SDK (`/get_token` → `oss2.Bucket`): keeps using `endpoint` (**public**).
- Worker-side `SandboxLogArchiveTask` uploading log archives: now uses `sandbox_endpoint` (**private**).
- In-sandbox `OssClient.download_via_oss` (`ossutil cp`): now uses `sandbox_endpoint` (**private**).

When `sandbox_endpoint` is empty, callers uniformly fall back to `endpoint`, so **existing YAMLs need zero migration**.

## Motivation

`OssAccountConfig` previously exposed only one `endpoint`, shared by three callers on different sides of the network:

| Caller | Runs on | Expected endpoint |
| --- | --- | --- |
| User SDK | Developer machine / public internet | Public |
| `SandboxLogArchiveTask` | Worker (inside VPC) | Private |
| In-sandbox `download_via_oss` | Sandbox container (inside VPC) | Private |

A single field can't satisfy all three semantics. This split lets user SDKs stay on the reliably-reachable public endpoint while workers / sandboxes save bandwidth and latency by going over the private one.

## Changes

### `rock/config.py`

- Added `sandbox_endpoint: str = ""` to `OssAccountConfig` with a full docstring covering usage scope and fallback behavior.

### `rock/admin/scheduler/tasks/sandbox_log_archive_task.py`

- The endpoint used when building the `ossutil cp` command is now `primary.sandbox_endpoint or primary.endpoint`.

### `rock/sdk/sandbox/oss_client.py`

- `OssClientConfig` dataclass gained `sandbox_endpoint: str = ""`.
- `_resolve_config`:
  - Layer 2 (server response) reads `sts_response.get("SandboxEndpoint")`.
  - Layer 1 (env vars) reads `env_vars.ROCK_OSS_SANDBOX_ENDPOINT`.
- `download_via_oss`:
  - The in-sandbox `ossutil cp --endpoint=…` uses `sandbox_endpoint or endpoint` (private).
  - The host-side `oss2.Bucket(…, endpoint)` still uses `endpoint` (public).

### `rock/sandbox/service/sandbox_proxy_service.py`

- `gen_oss_sts_token` response body now includes a `SandboxEndpoint` field:
  - `primary` account returns `primary.sandbox_endpoint or None`.
  - Legacy account returns `None` (no such semantics).

### Unit tests (12 new cases, all green)

- `tests/unit/test_config.py`: default empty, construction from dict, `_deep_merge` inheritance, explicit `""` override via `_deep_merge`.
- `tests/unit/admin/scheduler/test_sandbox_log_archive_task.py`: archive command uses the private endpoint (and never the public one) when `sandbox_endpoint` is set; falls back to `endpoint` when empty; still skips safely when `bucket` is empty.
- `tests/unit/sdk/sandbox/test_oss_client.py`: Layer 2 picks `SandboxEndpoint` from the response; missing / explicit `None` normalizes to empty; `download_via_oss` sends the private endpoint to `ossutil` while the host-side `oss2.Bucket` sees the public one; falls back to public when `sandbox_endpoint` is empty.

## Backward Compatibility

- **The new field defaults to `""`, so no existing YAML has to change.** When `sandbox_endpoint` is empty, `SandboxLogArchiveTask` and `download_via_oss` behave exactly like before.
- The `SandboxEndpoint` key in the SDK response is **additive** — older SDKs ignore it; newer SDKs still fall back correctly when the field is missing.
- `_deep_merge` allows a child YAML to explicitly set `sandbox_endpoint: ""` to clear a value inherited from a base.

## Test Plan

- [x] `uv run pytest tests/unit/test_config.py tests/unit/admin/scheduler/test_sandbox_log_archive_task.py tests/unit/sdk/sandbox/test_oss_client.py` → **125 passed**
- [x] Regression: with `sandbox_endpoint` unset, `SandboxLogArchiveTask` / `download_via_oss` behavior is unchanged
- [ ] Staging: configure `sandbox_endpoint` on a VPC cluster and confirm both the archive command and in-sandbox download command use the private domain
- [ ] Staging: verify user SDKs still receive the public domain from `/get_token` and can upload from developer machines

## Deployment Notes (internal deployment, separate PR — for reference)

The new field only takes effect on the admin-side YAML; SDKs pick it up automatically via `/get_token`. Recommended configuration (uniform across VPC / non-VPC clusters):

```yaml
oss:
  primary:
    # Public endpoint returned to SDK clients via /get_token
    endpoint: oss-cn-shanghai.aliyuncs.com
    # Private endpoint used by worker / in-sandbox code
    sandbox_endpoint: cn-shanghai.oss.aliyuncs.com
```

## Diff Summary

```
 rock/admin/scheduler/tasks/sandbox_log_archive_task.py      |   5 +-
 rock/config.py                                              |  14 ++
 rock/sandbox/service/sandbox_proxy_service.py               |   9 ++
 rock/sdk/sandbox/oss_client.py                              |  19 ++-
 tests/unit/admin/scheduler/test_sandbox_log_archive_task.py | 103 ++++++++
 tests/unit/sdk/sandbox/test_oss_client.py                   | 158 ++++++++++
 tests/unit/test_config.py                                   |  74 ++++++
 7 files changed, 380 insertions(+), 2 deletions(-)
```