### PR TITLE
feat(admin): run proxy as multi-worker uvicorn via app factory (#1191)

### DIFF
--- a/rock/admin/main.py
+++ b/rock/admin/main.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import json
 import logging
+import os
 import time
 import traceback
 import uuid
@@ -48,13 +49,17 @@ from rock.sandbox.service.warmup_service import WarmupService
 from rock.utils import EAGLE_EYE_TRACE_ID, sandbox_id_ctx_var, trace_id_ctx_var
 from rock.utils.providers import RedisProvider
 from rock.utils.system import is_primary_pod
+from rock.utils.worker import resolve_workers
 
-parser = argparse.ArgumentParser()
-parser.add_argument("--env", type=str, default="local")
-parser.add_argument("--role", type=str, default="admin", choices=["admin", "proxy"])
-parser.add_argument("--port", type=int, default=8080)
 
-args = parser.parse_args()
+def _parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--env", type=str, default="local")
+    parser.add_argument("--role", type=str, default="admin", choices=["admin", "proxy"])
+    parser.add_argument("--port", type=int, default=8080)
+    parser.add_argument("--workers", type=int, default=None)
+    return parser.parse_args()
+
 
 logger = init_logger("admin")
 logging.getLogger("urllib3").setLevel(logging.WARNING)
@@ -87,7 +92,7 @@ def _init_ops_service(
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     config_file_path = (
-        Path(__file__).resolve().parents[2] / env_vars.ROCK_CONFIG_DIR_NAME / f"rock-{args.env}.yml"
+        Path(__file__).resolve().parents[2] / env_vars.ROCK_CONFIG_DIR_NAME / f"rock-{env_vars.ROCK_ADMIN_ENV}.yml"
         if not env_vars.ROCK_CONFIG
         else env_vars.ROCK_CONFIG
     )
@@ -100,11 +105,8 @@ async def lifespan(app: FastAPI):
             rock_config.scheduler = SchedulerConfig(**nacos_config["scheduler"])
             logger.info(f"Overrode scheduler config from Nacos with {len(rock_config.scheduler.tasks)} tasks")
 
-    env_vars.ROCK_ADMIN_ENV = args.env
-    env_vars.ROCK_ADMIN_ROLE = args.role
-
     # init redis provider (fallback to fakeredis if no host configured)
-    if args.env in ["local", "test", "dev"] or not rock_config.redis.host:
+    if env_vars.ROCK_ADMIN_ENV in ["local", "test", "dev"] or not rock_config.redis.host:
         from fakeredis import aioredis
 
         if not rock_config.redis.host:
@@ -144,7 +146,7 @@ async def lifespan(app: FastAPI):
     scheduler_thread = None
 
     # init sandbox service
-    if args.role == "admin":
+    if env_vars.ROCK_ADMIN_ROLE == "admin":
         # init ray service
         ray_service = RayService(rock_config.ray)
         ray_service.init()
@@ -218,43 +220,16 @@ async def lifespan(app: FastAPI):
     logger.info("rock-admin exit")
 
 
-app = FastAPI(lifespan=lifespan)
-
-# --- CORS configuration start ---
-# Allowed origins list
-origins = [
-    "*",  # Your frontend origin
-]
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=origins,  # Set allowed origins
-    allow_credentials=True,  # Whether to support cookie cross-origin
-    allow_methods=["*"],  # Allow all methods
-    allow_headers=["*"],  # Allow all headers
-)
-# --- CORS configuration end ---
-
-
-# Pydantic validation errors are matched by FastAPI before the catch-all Exception
-# handler below — register an explicit override so they come out as RockResponse
-# envelopes instead of the default 422 ``{"detail": [...]}``.
-app.add_exception_handler(RequestValidationError, request_validation_exception_handler)
-
-
-@app.exception_handler(Exception)
 async def base_exception_handler(request: Request, exc: Exception):
     exc_content = {"detail": str(exc), "traceback": traceback.format_exc().split("\n")}
     logger.error(f"[app error] request:[{request}], exc:[{exc_content}]")
     return JSONResponse(status_code=500, content=exc_content)
 
 
-@app.get("/")
 async def root():
     return {"message": "hello, ROCK!"}
 
 
-@app.middleware("http")
 async def log_requests_and_responses(request: Request, call_next):
     req_logger = init_logger("accessLog")
 
@@ -297,9 +272,8 @@ async def log_requests_and_responses(request: Request, call_next):
     return response
 
 
-def main():
-    # config router
-    if args.role == "admin":
+def _include_routers(app: FastAPI, role: str) -> None:
+    if role == "admin":
         app.include_router(sandbox_router, prefix="/apis/envs/sandbox/v1", tags=["sandbox"])
         app.include_router(admin_ops_router, prefix="/apis/envs/sandbox/v1/ops", tags=["admin-ops"])
     else:
@@ -307,7 +281,49 @@ def main():
     app.include_router(warmup_router, prefix="/apis/envs/sandbox/v1", tags=["warmup"])
     app.include_router(gem_router, prefix="/apis/v1/envs/gem", tags=["gem"])
 
-    uvicorn.run(app, host="0.0.0.0", port=args.port, ws_ping_interval=None, ws_ping_timeout=None, timeout_keep_alive=30)
+
+def create_app() -> FastAPI:
+    app = FastAPI(lifespan=lifespan)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.add_exception_handler(RequestValidationError, request_validation_exception_handler)
+    app.add_exception_handler(Exception, base_exception_handler)
+    app.middleware("http")(log_requests_and_responses)
+    app.add_api_route("/", root, methods=["GET"])
+    _include_routers(app, role=env_vars.ROCK_ADMIN_ROLE)
+    return app
+
+
+def main():
+    args = _parse_args()
+    os.environ["ROCK_ADMIN_ENV"] = args.env
+    os.environ["ROCK_ADMIN_ROLE"] = args.role
+
+    workers = resolve_workers(
+        role=args.role,
+        override=args.workers,
+        env_workers=int(os.getenv("ROCK_PROXY_WORKERS", "0")),
+        env=args.env,
+    )
+    # write resolved count back so each worker's lifespan sizes pools deterministically
+    os.environ["ROCK_PROXY_WORKERS"] = str(workers)
+    logger.info(f"starting role={args.role} port={args.port} workers={workers}")
+
+    uvicorn.run(
+        "rock.admin.main:create_app",
+        factory=True,
+        host="0.0.0.0",
+        port=args.port,
+        workers=workers,
+        ws_ping_interval=None,
+        ws_ping_timeout=None,
+        timeout_keep_alive=30,
+    )
 
 
 if __name__ == "__main__":

--- a/rock/env_vars.py
+++ b/rock/env_vars.py
@@ -108,6 +108,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ROCK_PYTHON_ENV_PATH": lambda: os.getenv("ROCK_PYTHON_ENV_PATH", sys.base_prefix),
     "ROCK_ADMIN_ENV": lambda: os.getenv("ROCK_ADMIN_ENV", "dev"),
     "ROCK_ADMIN_ROLE": lambda: os.getenv("ROCK_ADMIN_ROLE", "write"),
+    "ROCK_PROXY_WORKERS": lambda: int(os.getenv("ROCK_PROXY_WORKERS", "0")),
     "ROCK_FORCE_PRIMARY_POD": lambda: os.getenv("ROCK_FORCE_PRIMARY_POD", "false").lower() == "true",
     "ROCK_CLI_LOAD_PATHS": lambda: os.getenv("ROCK_CLI_LOAD_PATHS", str(Path(__file__).parent / "cli" / "command")),
     "ROCK_CLI_DEFAULT_CONFIG_PATH": lambda: os.getenv(

--- a/rock/utils/worker.py
+++ b/rock/utils/worker.py
@@ -1,0 +1,29 @@
+"""Pure helpers for multi-worker proxy sizing. No I/O, fully unit-testable."""
+
+from __future__ import annotations
+
+MIN_POOL_SIZE = 2
+
+# Envs that fall back to fakeredis / in-memory sqlite (per-process state).
+# Multi-worker there would unshare sandbox state across workers, so force 1.
+SINGLE_WORKER_ENVS = frozenset({"local", "test", "dev"})
+
+
+def resolve_workers(role: str, override: int | None, env_workers: int, env: str | None = None) -> int:
+    """Resolve uvicorn worker count.
+
+    admin role is always single-process (owns scheduler/Ray singletons).
+    local/test/dev are always single-process (fakeredis/in-memory state is
+    per-process; multi-worker would unshare it) — this overrides override/env.
+    proxy role otherwise: explicit override > env > 1. Worker count must be set
+    explicitly (via --workers or ROCK_PROXY_WORKERS); no cpu_count auto-detect.
+    """
+    if role != "proxy":
+        return 1
+    if env in SINGLE_WORKER_ENVS:
+        return 1
+    if override and override > 0:
+        return override
+    if env_workers and env_workers > 0:
+        return env_workers
+    return 1

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,7 +1,6 @@
 import os
 import socket
 import subprocess
-import sys
 import tempfile
 import threading
 import time
@@ -101,21 +100,25 @@ def admin_client_fixture():
     local rocklet process (like admin_remote_server) so those calls reach a live
     rocklet instead of failing with ConnectError.
     """
-    # Save original sys.argv
-    original_argv = sys.argv.copy()
-    # Modify sys.argv
-    sys.argv = ["main.py", "--env", "local", "--role", "admin"]
+    # create_app()/lifespan read env+role from env vars (not argv). Use env=local
+    # (ray operator) + role=admin so the gem service gets wired up.
+    overrides = {"ROCK_ADMIN_ENV": "local", "ROCK_ADMIN_ROLE": "admin"}
+    saved = {k: os.environ.get(k) for k in overrides}
+    os.environ.update(overrides)
     try:
         with start_rocklet_process():
-            from rock.admin.main import app, gem_router
+            from rock.admin.main import create_app
 
-            # Register env router
-            app.include_router(gem_router, prefix="/apis/v1/envs/gem", tags=["gem"])
+            # create_app() already wires up gem_router (see _include_routers)
+            app = create_app()
             with TestClient(app) as client:
                 yield client
     finally:
-        # Restore original sys.argv
-        sys.argv = original_argv
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/admin/test_create_app_routes.py
+++ b/tests/unit/admin/test_create_app_routes.py
@@ -1,0 +1,28 @@
+from fastapi import FastAPI
+
+from rock.admin.main import _include_routers
+
+
+def _paths(app: FastAPI) -> set[str]:
+    return {getattr(r, "path", "") for r in app.routes}
+
+
+def test_proxy_role_mounts_proxy_router():
+    app = FastAPI()
+    _include_routers(app, role="proxy")
+    paths = _paths(app)
+    assert any(p.endswith("/get_token") for p in paths)
+
+
+def test_proxy_role_excludes_admin_router():
+    app = FastAPI()
+    _include_routers(app, role="proxy")
+    paths = _paths(app)
+    assert not any("/ops" in p for p in paths)
+
+
+def test_admin_role_mounts_admin_routers():
+    app = FastAPI()
+    _include_routers(app, role="admin")
+    paths = _paths(app)
+    assert any("/ops" in p for p in paths)

--- a/tests/unit/utils/test_worker.py
+++ b/tests/unit/utils/test_worker.py
@@ -1,0 +1,46 @@
+import importlib
+
+from rock.utils.worker import resolve_workers
+
+
+def test_rock_proxy_workers_defaults_to_zero(monkeypatch):
+    monkeypatch.delenv("ROCK_PROXY_WORKERS", raising=False)
+    import rock.env_vars as env_vars
+
+    importlib.reload(env_vars)
+    assert env_vars.ROCK_PROXY_WORKERS == 0
+
+
+def test_rock_proxy_workers_reads_env(monkeypatch):
+    monkeypatch.setenv("ROCK_PROXY_WORKERS", "6")
+    import rock.env_vars as env_vars
+
+    importlib.reload(env_vars)
+    assert env_vars.ROCK_PROXY_WORKERS == 6
+
+
+def test_resolve_workers_admin_always_one():
+    assert resolve_workers("admin", override=None, env_workers=8, env="prod") == 1
+    assert resolve_workers("admin", override=10, env_workers=8, env="prod") == 1
+
+
+def test_resolve_workers_proxy_override_wins():
+    assert resolve_workers("proxy", override=4, env_workers=8, env="prod") == 4
+
+
+def test_resolve_workers_proxy_env_when_no_override():
+    assert resolve_workers("proxy", override=None, env_workers=8, env="prod") == 8
+
+
+def test_resolve_workers_proxy_defaults_to_one_when_unset():
+    assert resolve_workers("proxy", override=None, env_workers=0, env="prod") == 1
+
+
+def test_resolve_workers_local_envs_force_one_over_override():
+    for env in ("local", "test", "dev"):
+        assert resolve_workers("proxy", override=8, env_workers=8, env=env) == 1
+
+
+def test_resolve_workers_unknown_env_defaults_param_none():
+    # env defaults to None (treated as non-local) — preserves explicit override
+    assert resolve_workers("proxy", override=4, env_workers=0) == 4


### PR DESCRIPTION
closes #1191

**Stack 1/3** — base for the log-append and httpx-reuse PRs. Merge this first.

Split from the original combined proxy multi-core PR (#1147). This PR only introduces multi-worker support:
- `create_app()` app factory + `_include_routers()`, so uvicorn can build one app per worker via `factory=True`.
- `_parse_args()` / `main()` refactor: env + role set as env vars before workers spawn (lifespan/`create_app` read them instead of argv).
- `resolve_workers()` pure helper (`rock/utils/worker.py`): admin/local/test/dev → 1; proxy → `--workers` > `ROCK_PROXY_WORKERS` > 1.
- `ROCK_PROXY_WORKERS` env var; `uvicorn.run(..., workers=workers)`.
- Integration conftest switches admin_client from argv to env vars to match `create_app()`.

Tests: `tests/unit/utils/test_worker.py`, `tests/unit/admin/test_create_app_routes.py`.