### PR TITLE
feat(logger): multi-worker safe log append with deploy-time reset (#1192)

### DIFF
--- a/rock/admin/main.py
+++ b/rock/admin/main.py
@@ -40,7 +40,7 @@ from rock.admin.scheduler.tasks.sandbox_log_archive_task import (
 from rock.admin.service.ops_service import OpsService
 from rock.common.exception import request_validation_exception_handler
 from rock.config import DatabaseConfig, RockConfig, SchedulerConfig
-from rock.logger import init_logger
+from rock.logger import init_logger, reset_log_file
 from rock.sandbox.gem_manager import GemManager
 from rock.sandbox.operator.factory import OperatorContext, OperatorFactory
 from rock.sandbox.sandbox_meta_store import SandboxMetaStore
@@ -303,6 +303,11 @@ def main():
     args = _parse_args()
     os.environ["ROCK_ADMIN_ENV"] = args.env
     os.environ["ROCK_ADMIN_ROLE"] = args.role
+
+    # Clear the log file once at deploy (master), then make every worker append
+    # to the shared file. Must run before workers spawn so only the master clears.
+    reset_log_file()
+    os.environ["ROCK_LOGGING_APPEND"] = "true"
 
     workers = resolve_workers(
         role=args.role,

--- a/rock/env_vars.py
+++ b/rock/env_vars.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     ROCK_LOGGING_PATH: str | None = None
     ROCK_LOGGING_FILE_NAME: str | None = None
     ROCK_LOGGING_LEVEL: str | None = None
+    ROCK_LOGGING_APPEND: bool = False
     ROCK_SERVICE_STATUS_DIR: str | None = None
     ROCK_SCHEDULER_STATUS_DIR: str | None = None
     ROCK_CONFIG: str | None = None
@@ -78,6 +79,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "ROCK_LOGGING_PATH": lambda: os.getenv("ROCK_LOGGING_PATH"),
     "ROCK_LOGGING_FILE_NAME": lambda: os.getenv("ROCK_LOGGING_FILE_NAME", "rocklet.log"),
     "ROCK_LOGGING_LEVEL": lambda: os.getenv("ROCK_LOGGING_LEVEL", "INFO"),
+    "ROCK_LOGGING_APPEND": lambda: os.getenv("ROCK_LOGGING_APPEND", "false").lower() == "true",
     "ROCK_SERVICE_STATUS_DIR": lambda: os.getenv("ROCK_SERVICE_STATUS_DIR", "/tmp"),
     "ROCK_SCHEDULER_STATUS_DIR": lambda: os.getenv("ROCK_SCHEDULER_STATUS_DIR", "/data/scheduler_status"),
     "ROCK_CONFIG": lambda: os.getenv("ROCK_CONFIG"),

--- a/rock/logger.py
+++ b/rock/logger.py
@@ -73,10 +73,34 @@ def init_file_handler(log_name: str):
         # Ensure directory exists
         os.makedirs(os.path.dirname(log_file_path), exist_ok=True)
 
-        handler = logging.FileHandler(log_file_path, mode="w+", encoding="utf-8")
+        # Multi-worker safe: when ROCK_LOGGING_APPEND is set, every worker opens
+        # the shared file in append mode (no per-process truncate race). The
+        # one-time clear-on-deploy is done by the entrypoint via reset_log_file().
+        # Default stays "w+" so single-process services (rocklet, cli) keep their
+        # truncate-on-start behavior.
+        mode = "a" if env_vars.ROCK_LOGGING_APPEND else "w+"
+        handler = logging.FileHandler(log_file_path, mode=mode, encoding="utf-8")
         handler.setFormatter(TimezoneFormatter(log_color_enable=False, tz_string=env_vars.ROCK_TIME_ZONE))
         return handler
     return None
+
+
+def reset_log_file(file_name: str | None = None) -> None:
+    """Truncate the configured log file once (e.g. at deploy / master startup).
+
+    Under multi-worker, all workers open the same file in append mode, so the
+    one-time clear must happen here in the master BEFORE workers spawn — doing
+    it in the FileHandler would make each worker truncate and race. No-op when
+    file logging is disabled (stdout mode).
+    """
+    if not env_vars.ROCK_LOGGING_PATH:
+        return
+    file_name = file_name or env_vars.ROCK_LOGGING_FILE_NAME
+    if not file_name:
+        return
+    log_file_path = os.path.join(env_vars.ROCK_LOGGING_PATH, file_name)
+    os.makedirs(os.path.dirname(log_file_path), exist_ok=True)
+    open(log_file_path, "w").close()
 
 
 def init_logger(name: str | None = None, file_name: str | None = None):

--- a/tests/unit/test_logger_multiprocess.py
+++ b/tests/unit/test_logger_multiprocess.py
@@ -1,0 +1,54 @@
+"""Multi-worker logging: handler append mode + one-time deploy truncation."""
+
+import importlib
+
+import pytest
+
+import rock.logger as rock_logger
+from rock import env_vars
+
+
+@pytest.fixture(autouse=True)
+def _clear_handler_cache():
+    rock_logger.init_file_handler.cache_clear()
+    yield
+    rock_logger.init_file_handler.cache_clear()
+
+
+def test_rock_logging_append_defaults_false(monkeypatch):
+    monkeypatch.delenv("ROCK_LOGGING_APPEND", raising=False)
+    import rock.env_vars as ev
+
+    importlib.reload(ev)
+    assert ev.ROCK_LOGGING_APPEND is False
+
+
+def test_file_handler_defaults_to_truncate_mode(tmp_path, monkeypatch):
+    monkeypatch.setattr(env_vars, "ROCK_LOGGING_PATH", str(tmp_path), raising=False)
+    monkeypatch.setattr(env_vars, "ROCK_LOGGING_APPEND", False, raising=False)
+    handler = rock_logger.init_file_handler("trunc_default.log")
+    assert handler is not None
+    assert handler.mode == "w+"
+
+
+def test_file_handler_append_when_env_set(tmp_path, monkeypatch):
+    monkeypatch.setattr(env_vars, "ROCK_LOGGING_PATH", str(tmp_path), raising=False)
+    monkeypatch.setattr(env_vars, "ROCK_LOGGING_APPEND", True, raising=False)
+    handler = rock_logger.init_file_handler("append_mode.log")
+    assert handler is not None
+    assert handler.mode == "a"
+
+
+def test_reset_log_file_truncates_existing(tmp_path, monkeypatch):
+    monkeypatch.setattr(env_vars, "ROCK_LOGGING_PATH", str(tmp_path), raising=False)
+    monkeypatch.setattr(env_vars, "ROCK_LOGGING_FILE_NAME", "deploy.log", raising=False)
+    p = tmp_path / "deploy.log"
+    p.write_text("stale lines from previous deploy\n")
+    rock_logger.reset_log_file()
+    assert p.read_text() == ""
+
+
+def test_reset_log_file_noop_without_path(monkeypatch):
+    monkeypatch.setattr(env_vars, "ROCK_LOGGING_PATH", None, raising=False)
+    # must not raise when file logging is disabled (stdout mode)
+    rock_logger.reset_log_file()


### PR DESCRIPTION
closes #1192

**Stack 2/3** — depends on #1194 (multi-worker). Merge after it. Until #1194 merges, this PR's diff also shows the multi-worker commit; GitHub auto-recomputes it down to just the logging changes once #1194 lands.

Split from the original combined proxy multi-core PR (#1147). This PR only adds multi-worker-safe logging:
- `ROCK_LOGGING_APPEND` → file handlers open in append mode (no per-worker truncate race).
- `reset_log_file()` truncates the shared file once in the master at deploy, before workers spawn; `main()` calls it then sets append for the workers.
- Single-process services (rocklet, cli) keep truncate-on-start.

Tests: `tests/unit/test_logger_multiprocess.py`.