### PR TITLE
feat(proxy): reuse shared httpx clients instead of per-request clients (#1193)

### DIFF
--- a/rock/admin/main.py
+++ b/rock/admin/main.py
@@ -146,6 +146,7 @@ async def lifespan(app: FastAPI):
     scheduler_thread = None
 
     # init sandbox service
+    proxy_service_ref = None
     if env_vars.ROCK_ADMIN_ROLE == "admin":
         # init ray service
         ray_service = RayService(rock_config.ray)
@@ -201,6 +202,7 @@ async def lifespan(app: FastAPI):
     else:
         sandbox_manager = SandboxProxyService(rock_config=rock_config, meta_store=meta_store)
         set_sandbox_proxy_service(sandbox_manager)
+        proxy_service_ref = sandbox_manager
 
     logger.info("rock-admin start")
 
@@ -210,6 +212,10 @@ async def lifespan(app: FastAPI):
     if scheduler_thread:
         scheduler_thread.stop()
         logger.info("Scheduler thread stopped")
+
+    if proxy_service_ref is not None:
+        await proxy_service_ref.aclose()
+        logger.info("proxy httpx clients closed")
 
     if db_provider:
         await db_provider.close()

--- a/rock/sandbox/service/sandbox_proxy_service.py
+++ b/rock/sandbox/service/sandbox_proxy_service.py
@@ -1,5 +1,6 @@
 import asyncio  # noqa: I001
 import json
+import os
 from fastapi.responses import JSONResponse, StreamingResponse
 from starlette.datastructures import Headers
 
@@ -49,22 +50,33 @@ logger = init_logger(__name__)
 
 
 class SandboxProxyService:
-    _httpx_client = None
-
     def __init__(self, rock_config: RockConfig, meta_store: SandboxMetaStore):
         self._rock_config = rock_config
         self._meta_store = meta_store
         self.metrics_monitor = MetricsMonitor.create(
             export_interval_millis=20_000,
             metrics_endpoint=rock_config.runtime.metrics_endpoint,
-            user_defined_tags=rock_config.runtime.user_defined_tags,
+            user_defined_tags={
+                **(rock_config.runtime.user_defined_tags or {}),
+                "worker_pid": str(os.getpid()),
+            },
         )
         self.oss_config: OssConfig = rock_config.oss
         self.proxy_config: ProxyServiceConfig = rock_config.proxy_service
         logger.info(f"proxy config: {self.proxy_config}")
-        # Initialize httpx client with configuration
-        self._httpx_client = httpx.AsyncClient(
+        # Control-plane RPC client: short JSON calls to rocklet.
+        self._rpc_client = httpx.AsyncClient(
             timeout=self.proxy_config.timeout,
+            limits=httpx.Limits(
+                max_connections=self.proxy_config.max_connections,
+                max_keepalive_connections=self.proxy_config.max_keepalive_connections,
+            ),
+        )
+        # Data-plane proxy client: streaming/SSE/large bodies. No total timeout;
+        # per-request timeout is set via build_request(timeout=...). NEVER closed
+        # per-request — lives for the process lifetime, closed in aclose().
+        self._proxy_client = httpx.AsyncClient(
+            timeout=httpx.Timeout(None),
             limits=httpx.Limits(
                 max_connections=self.proxy_config.max_connections,
                 max_keepalive_connections=self.proxy_config.max_keepalive_connections,
@@ -93,6 +105,11 @@ class SandboxProxyService:
 
         self._batch_get_status_max_count = rock_config.proxy_service.batch_get_status_max_count
         self._validate_oss_config_or_warn()
+
+    async def aclose(self) -> None:
+        """Close both shared httpx clients. Called on proxy shutdown."""
+        await self._rpc_client.aclose()
+        await self._proxy_client.aclose()
 
     def _validate_oss_config_or_warn(self) -> None:
         # Same resolution order as gen_oss_sts_token: env > YAML
@@ -656,7 +673,7 @@ class SandboxProxyService:
 
         # Make request
         try:
-            response = await self._httpx_client.request(
+            response = await self._rpc_client.request(
                 method=method,
                 url=full_request_url,
                 headers=headers,
@@ -870,33 +887,33 @@ class SandboxProxyService:
         request_headers = filter_headers(headers)
         payload = body or {}
 
-        async with httpx.AsyncClient(timeout=httpx.Timeout(90)) as http_client:
-            try:
-                resp = await http_client.post(
-                    url=target_url,
-                    json=payload,
-                    headers=request_headers,
-                )
-            except httpx.RequestError as exc:
-                logger.error(f"Error forwarding request to {target_url}: {exc}", exc_info=True)
-                raise Exception(f"Service unavailable: Rocklet at {host_ip}:{Port.PROXY.value} is not reachable.")
+        try:
+            resp = await self._proxy_client.post(
+                url=target_url,
+                json=payload,
+                headers=request_headers,
+                timeout=90,
+            )
+        except httpx.RequestError as exc:
+            logger.error(f"Error forwarding request to {target_url}: {exc}", exc_info=True)
+            raise Exception(f"Service unavailable: Rocklet at {host_ip}:{Port.PROXY.value} is not reachable.")
 
-            content_type = resp.headers.get("content-type", "")
-            response_headers = filter_headers(resp.headers)
+        content_type = resp.headers.get("content-type", "")
+        response_headers = filter_headers(resp.headers)
 
-            if "application/json" in content_type:
-                return JSONResponse(
-                    status_code=resp.status_code,
-                    content=resp.json(),
-                    headers=response_headers,
-                )
-
-            return Response(
+        if "application/json" in content_type:
+            return JSONResponse(
                 status_code=resp.status_code,
-                content=resp.content,
-                media_type=content_type or "application/octet-stream",
+                content=resp.json(),
                 headers=response_headers,
             )
+
+        return Response(
+            status_code=resp.status_code,
+            content=resp.content,
+            media_type=content_type or "application/octet-stream",
+            headers=response_headers,
+        )
 
     async def http_proxy(
         self,
@@ -948,22 +965,16 @@ class SandboxProxyService:
         request_headers = filter_headers(headers)
         request_kwargs: dict = {"content": body} if body else {}
 
-        client = httpx.AsyncClient(timeout=httpx.Timeout(None))
-
-        try:
-            resp = await client.send(
-                client.build_request(
-                    method=method,
-                    url=target_url,
-                    headers=request_headers,
-                    timeout=120,
-                    **request_kwargs,
-                ),
-                stream=True,
-            )
-        except Exception:
-            await client.aclose()
-            raise
+        resp = await self._proxy_client.send(
+            self._proxy_client.build_request(
+                method=method,
+                url=target_url,
+                headers=request_headers,
+                timeout=120,
+                **request_kwargs,
+            ),
+            stream=True,
+        )
 
         content_type = resp.headers.get("content-type", "")
         is_sse = "text/event-stream" in content_type
@@ -989,7 +1000,6 @@ class SandboxProxyService:
                             yield chunk
                 finally:
                     await resp.aclose()
-                    await client.aclose()
 
             return StreamingResponse(
                 event_stream(),
@@ -1016,4 +1026,3 @@ class SandboxProxyService:
             )
         finally:
             await resp.aclose()
-            await client.aclose()

--- a/tests/unit/sandbox/test_proxy_enhancements.py
+++ b/tests/unit/sandbox/test_proxy_enhancements.py
@@ -4,6 +4,7 @@
 3. batch_get_sandbox_status legacy-states filtering
 """
 
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -334,7 +335,8 @@ class TestHttpProxyServiceMethod:
 
         with patch("rock.sandbox.service.sandbox_proxy_service.ServiceStatus") as MockSS:
             MockSS.from_dict.return_value = mock_status
-            with patch("rock.sandbox.service.sandbox_proxy_service.httpx.AsyncClient", return_value=FakeClient()):
+            service._proxy_client = FakeClient()
+            with contextlib.nullcontext():
                 await SandboxProxyService.http_proxy(
                     service,
                     sandbox_id="sb1",
@@ -386,7 +388,8 @@ class TestHttpProxyServiceMethod:
 
         with patch("rock.sandbox.service.sandbox_proxy_service.ServiceStatus") as MockSS:
             MockSS.from_dict.return_value = mock_status
-            with patch("rock.sandbox.service.sandbox_proxy_service.httpx.AsyncClient", return_value=FakeClient()):
+            service._proxy_client = FakeClient()
+            with contextlib.nullcontext():
                 await SandboxProxyService.http_proxy(
                     service,
                     sandbox_id="sb1",
@@ -437,7 +440,8 @@ class TestHttpProxyServiceMethod:
 
         with patch("rock.sandbox.service.sandbox_proxy_service.ServiceStatus") as MockSS:
             MockSS.from_dict.return_value = mock_status
-            with patch("rock.sandbox.service.sandbox_proxy_service.httpx.AsyncClient", return_value=FakeClient()):
+            service._proxy_client = FakeClient()
+            with contextlib.nullcontext():
                 await SandboxProxyService.http_proxy(
                     service,
                     sandbox_id="sb1",
@@ -492,7 +496,8 @@ class TestHttpProxyServiceMethod:
 
         with patch("rock.sandbox.service.sandbox_proxy_service.ServiceStatus") as MockSS:
             MockSS.from_dict.return_value = mock_status
-            with patch("rock.sandbox.service.sandbox_proxy_service.httpx.AsyncClient", return_value=FakeClient()):
+            service._proxy_client = FakeClient()
+            with contextlib.nullcontext():
                 await SandboxProxyService.http_proxy(
                     service,
                     sandbox_id="sb1",
@@ -550,7 +555,8 @@ class TestHttpProxyLocationRewrite:
 
         with patch("rock.sandbox.service.sandbox_proxy_service.ServiceStatus") as MockSS:
             MockSS.from_dict.return_value = mock_status
-            with patch("rock.sandbox.service.sandbox_proxy_service.httpx.AsyncClient", return_value=FakeClient()):
+            service._proxy_client = FakeClient()
+            with contextlib.nullcontext():
                 resp = await SandboxProxyService.http_proxy(
                     service,
                     sandbox_id="sb1",
@@ -573,7 +579,8 @@ class TestHttpProxyLocationRewrite:
 
         with patch("rock.sandbox.service.sandbox_proxy_service.ServiceStatus") as MockSS:
             MockSS.from_dict.return_value = mock_status
-            with patch("rock.sandbox.service.sandbox_proxy_service.httpx.AsyncClient", return_value=FakeClient()):
+            service._proxy_client = FakeClient()
+            with contextlib.nullcontext():
                 resp = await SandboxProxyService.http_proxy(
                     service,
                     sandbox_id="sb1",
@@ -619,7 +626,8 @@ class TestHttpProxyLocationRewrite:
 
         with patch("rock.sandbox.service.sandbox_proxy_service.ServiceStatus") as MockSS:
             MockSS.from_dict.return_value = mock_status
-            with patch("rock.sandbox.service.sandbox_proxy_service.httpx.AsyncClient", return_value=FakeClient()):
+            service._proxy_client = FakeClient()
+            with contextlib.nullcontext():
                 resp = await SandboxProxyService.http_proxy(
                     service,
                     sandbox_id="sb1",
@@ -642,7 +650,8 @@ class TestHttpProxyLocationRewrite:
 
         with patch("rock.sandbox.service.sandbox_proxy_service.ServiceStatus") as MockSS:
             MockSS.from_dict.return_value = mock_status
-            with patch("rock.sandbox.service.sandbox_proxy_service.httpx.AsyncClient", return_value=FakeClient()):
+            service._proxy_client = FakeClient()
+            with contextlib.nullcontext():
                 resp = await SandboxProxyService.http_proxy(
                     service,
                     sandbox_id="sb1",
@@ -704,7 +713,8 @@ class TestHttpProxyContentEncodingStripped:
 
         with patch("rock.sandbox.service.sandbox_proxy_service.ServiceStatus") as MockSS:
             MockSS.from_dict.return_value = mock_status
-            with patch("rock.sandbox.service.sandbox_proxy_service.httpx.AsyncClient", return_value=FakeClient()):
+            service._proxy_client = FakeClient()
+            with contextlib.nullcontext():
                 resp = await SandboxProxyService.http_proxy(
                     service,
                     sandbox_id="sb1",
@@ -759,7 +769,8 @@ class TestHttpProxyQueryStringForwarding:
 
         with patch("rock.sandbox.service.sandbox_proxy_service.ServiceStatus") as MockSS:
             MockSS.from_dict.return_value = mock_status
-            with patch("rock.sandbox.service.sandbox_proxy_service.httpx.AsyncClient", return_value=FakeClient()):
+            service._proxy_client = FakeClient()
+            with contextlib.nullcontext():
                 from starlette.datastructures import Headers
 
                 await SandboxProxyService.http_proxy(
@@ -813,7 +824,8 @@ class TestHttpProxyQueryStringForwarding:
 
         with patch("rock.sandbox.service.sandbox_proxy_service.ServiceStatus") as MockSS:
             MockSS.from_dict.return_value = mock_status
-            with patch("rock.sandbox.service.sandbox_proxy_service.httpx.AsyncClient", return_value=FakeClient()):
+            service._proxy_client = FakeClient()
+            with contextlib.nullcontext():
                 from starlette.datastructures import Headers
 
                 await SandboxProxyService.http_proxy(

--- a/tests/unit/sandbox/test_proxy_httpx_reuse.py
+++ b/tests/unit/sandbox/test_proxy_httpx_reuse.py
@@ -1,0 +1,78 @@
+import os
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from starlette.datastructures import Headers
+
+from rock.deployments.constants import Port
+
+
+@pytest.mark.asyncio
+async def test_service_has_two_distinct_httpx_clients(sandbox_proxy_service):
+    svc = sandbox_proxy_service
+    assert isinstance(svc._rpc_client, httpx.AsyncClient)
+    assert isinstance(svc._proxy_client, httpx.AsyncClient)
+    assert svc._rpc_client is not svc._proxy_client
+
+
+@pytest.mark.asyncio
+async def test_metrics_monitor_has_worker_pid_tag(sandbox_proxy_service):
+    tags = sandbox_proxy_service.metrics_monitor.user_defined_tags
+    assert tags.get("worker_pid") == str(os.getpid())
+
+
+@pytest.mark.asyncio
+async def test_aclose_closes_both_clients(sandbox_proxy_service):
+    svc = sandbox_proxy_service
+    await svc.aclose()
+    assert svc._rpc_client.is_closed
+    assert svc._proxy_client.is_closed
+
+
+def _fake_status():
+    return {"host_ip": "1.2.3.4", "port_mapping": {Port.SERVER.value: 18080}}
+
+
+@pytest.mark.asyncio
+async def test_http_proxy_reuses_proxy_client_without_closing(sandbox_proxy_service, monkeypatch):
+    svc = sandbox_proxy_service
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"ok": True})
+
+    svc._proxy_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(svc, "_update_expire_time", AsyncMock())
+    monkeypatch.setattr(svc, "get_service_status", AsyncMock(return_value=[_fake_status()]))
+
+    resp = await svc.http_proxy(
+        sandbox_id="sb1",
+        target_path="hello",
+        body=None,
+        headers=Headers({}),
+        method="GET",
+    )
+
+    assert resp.status_code == 200
+    # shared client must remain open for reuse
+    assert not svc._proxy_client.is_closed
+
+
+@pytest.mark.asyncio
+async def test_host_proxy_reuses_proxy_client_without_closing(sandbox_proxy_service):
+    svc = sandbox_proxy_service
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"pong": True})
+
+    svc._proxy_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    resp = await svc.host_proxy(
+        host_ip="10.0.0.1",
+        target_path="ping",
+        body={"a": 1},
+        headers=Headers({}),
+    )
+
+    assert resp.status_code == 200
+    assert not svc._proxy_client.is_closed


### PR DESCRIPTION
closes #1193

**Stack 3/3** — depends on #1194 (multi-worker) and #1192's PR #1195. Merge last. Its diff auto-cleans once the parent PRs merge.

Split from the original combined proxy multi-core PR (#1147). This PR only reuses httpx clients:
- Split the proxy into two long-lived clients: RPC (short JSON control calls) + proxy (streaming/SSE/large bodies).
- `host_proxy`/`http_proxy` reuse the shared proxy client instead of opening/closing one per request.
- Both closed once via `aclose()`, wired from the admin lifespan on shutdown.
- Metrics tagged with `worker_pid` so per-worker series stay distinct.

Tests: `tests/unit/sandbox/test_proxy_httpx_reuse.py`, updated `tests/unit/sandbox/test_proxy_enhancements.py`.