### PR TITLE
feat(oss): route sandbox log archive over in-VPC endpoint with fallback

### DIFF
--- a/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
+++ b/rock/admin/scheduler/tasks/sandbox_log_archive_task.py
@@ -140,6 +140,9 @@ class SandboxLogArchiveTask(BaseTask):
         primary = rock_config.oss.primary
         bucket = primary.bucket
         endpoint = primary.endpoint
+        # In-VPC endpoint tried first to keep archive traffic on the internal
+        # network. Optional: legacy YAMLs may only configure `endpoint`.
+        server_endpoint = primary.server_endpoint
         access_key_id = primary.access_key_id
         access_key_secret = primary.access_key_secret
         if not (bucket and endpoint and access_key_id and access_key_secret):
@@ -201,6 +204,7 @@ class SandboxLogArchiveTask(BaseTask):
                     archive_prefix,
                     bucket,
                     endpoint,
+                    server_endpoint,
                     access_key_id,
                     access_key_secret,
                 )
@@ -272,6 +276,7 @@ class SandboxLogArchiveTask(BaseTask):
         archive_prefix: str,
         bucket: str,
         endpoint: str,
+        server_endpoint: str,
         access_key_id: str,
         access_key_secret: str,
     ) -> None:
@@ -281,21 +286,53 @@ class SandboxLogArchiveTask(BaseTask):
         ``ps`` output. The command itself is built by the pure-function
         ``build_archive_command`` (PR #957) — single source of truth for
         archive key naming.
+
+        Endpoint strategy: try ``server_endpoint`` first (in-VPC, saves
+        public-egress bandwidth); on failure, fall back to ``endpoint``
+        (public). When ``server_endpoint`` is empty or equals ``endpoint``,
+        the loop degenerates to a single attempt.
         """
         log_dir = f"{self.log_root}/{sandbox_id}"
         oss_key = ArchiveCommand.build_key(sandbox_id, archive_prefix)
-        cmd = ArchiveCommand.build_command(log_dir, oss_key, bucket, endpoint)
-        await runtime.execute(
-            Command(
-                command=cmd,
-                shell=True,
-                check=True,
-                timeout=3600,
-                env={
-                    "OSS_ACCESS_KEY_ID": access_key_id,
-                    "OSS_ACCESS_KEY_SECRET": access_key_secret,
-                },
-                sandbox_id=sandbox_id,
-            )
+
+        # Dedupe + drop empties, preserving order: internal-first, public-fallback.
+        candidates = [ep for ep in (server_endpoint, endpoint) if ep]
+        candidates = list(dict.fromkeys(candidates))
+        last_error: Exception | None = None
+        for i, ep in enumerate(candidates):
+            cmd = ArchiveCommand.build_command(log_dir, oss_key, bucket, ep)
+            try:
+                await runtime.execute(
+                    Command(
+                        command=cmd,
+                        shell=True,
+                        check=True,
+                        timeout=3600,
+                        env={
+                            "OSS_ACCESS_KEY_ID": access_key_id,
+                            "OSS_ACCESS_KEY_SECRET": access_key_secret,
+                        },
+                        sandbox_id=sandbox_id,
+                    )
+                )
+                logger.info(
+                    f"[{self.type}] archived {sandbox_id} -> oss://{bucket}/{oss_key} (endpoint={ep})"
+                )
+                return
+            except Exception as e:
+                last_error = e
+                is_last = i == len(candidates) - 1
+                if is_last:
+                    raise
+                logger.warning(
+                    f"[{self.type}] archive {sandbox_id} via endpoint={ep} failed: {e}; "
+                    f"retrying with next endpoint"
+                )
+        # Unreachable: last iteration either returns or raises. Guard against
+        # an empty `candidates` list (should be impossible since caller gates
+        # on non-empty `endpoint`).
+        if last_error is not None:
+            raise last_error
+        raise RuntimeError(
+            f"[{self.type}] archive {sandbox_id}: no endpoints configured"
         )
-        logger.info(f"[{self.type}] archived {sandbox_id} -> oss://{bucket}/{oss_key}")

--- a/rock/config.py
+++ b/rock/config.py
@@ -120,6 +120,21 @@ class SandboxConfig:
 @dataclass
 class OssAccountConfig:
     endpoint: str = ""
+    server_endpoint: str = ""
+    """In-VPC OSS endpoint used by ROCK server-side code paths ONLY —
+    currently `SandboxLogArchiveTask` running on workers. When set,
+    that task uses this endpoint to keep archive uploads on the VPC
+    network (avoids public-egress bandwidth cost and reduces latency).
+
+    Deliberately NOT exposed to the SDK: the STS response returned by
+    `/get_token` only ever carries the public `endpoint`, so SDK code
+    (running on the developer's machine) never sees this value. If a
+    server-side caller needs a fallback, it may fall back to `endpoint`
+    on its own — the choice is a server-side decision.
+
+    Empty string = no separate in-VPC endpoint configured. Server-side
+    callers that want to be robust should treat empty as "no override"
+    and fall back to `endpoint`."""
     bucket: str = ""
     access_key_id: str = ""
     access_key_secret: str = ""

--- a/tests/unit/admin/scheduler/test_sandbox_log_archive_task.py
+++ b/tests/unit/admin/scheduler/test_sandbox_log_archive_task.py
@@ -48,6 +48,7 @@ def _iso_days_ago(days, tz=timezone.utc) -> str:
 def _fake_rock_config(
     bucket="b",
     endpoint="oss-cn-hangzhou.aliyuncs.com",
+    server_endpoint="",
     access_key_id="AKID",
     access_key_secret="AKSEC",
     keep_days=3,
@@ -58,6 +59,7 @@ def _fake_rock_config(
             primary=SimpleNamespace(
                 bucket=bucket,
                 endpoint=endpoint,
+                server_endpoint=server_endpoint,
                 access_key_id=access_key_id,
                 access_key_secret=access_key_secret,
             )
@@ -426,3 +428,179 @@ class TestArchiveCommand:
 
         assert result["archived"] == 1
         assert result["failed"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Endpoint fallback (server_endpoint → endpoint)
+# ---------------------------------------------------------------------------
+
+
+class TestEndpointFallback:
+    @pytest.mark.asyncio
+    async def test_only_public_endpoint_single_attempt(self, fake_table):
+        """When server_endpoint is empty, only the public endpoint is tried."""
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(
+            lambda: _fake_rock_config(
+                endpoint="oss-cn-shanghai.aliyuncs.com",
+                server_endpoint="",
+                keep_days=3,
+            )
+        )
+        fake_table.list_by_in = AsyncMock(
+            return_value=[_row("sb-1", state="stopped", stop_time=_iso_days_ago(5))]
+        )
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime(
+            [
+                _FakeExecResult(),  # cleanup stale archives
+                _FakeExecResult(stdout="sb-1"),  # discover
+                _FakeExecResult(),  # archive (public)
+            ]
+        )
+
+        result = await task.run_action(runtime)
+
+        assert result["archived"] == 1
+        assert result["failed"] == 0
+        assert runtime.execute.await_count == 3
+        archive_cmd = runtime.execute.await_args_list[2].args[0].command
+        assert "oss-cn-shanghai.aliyuncs.com" in archive_cmd
+
+    @pytest.mark.asyncio
+    async def test_server_endpoint_first_success(self, fake_table):
+        """When server_endpoint succeeds, public endpoint is not tried."""
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(
+            lambda: _fake_rock_config(
+                endpoint="oss-cn-shanghai.aliyuncs.com",
+                server_endpoint="cn-shanghai.oss.aliyuncs.com",
+                keep_days=3,
+            )
+        )
+        fake_table.list_by_in = AsyncMock(
+            return_value=[_row("sb-1", state="stopped", stop_time=_iso_days_ago(5))]
+        )
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime(
+            [
+                _FakeExecResult(),  # cleanup stale archives
+                _FakeExecResult(stdout="sb-1"),  # discover
+                _FakeExecResult(),  # archive (server_endpoint) → success
+            ]
+        )
+
+        result = await task.run_action(runtime)
+
+        assert result["archived"] == 1
+        assert result["failed"] == 0
+        assert runtime.execute.await_count == 3
+        archive_cmd = runtime.execute.await_args_list[2].args[0].command
+        assert "cn-shanghai.oss.aliyuncs.com" in archive_cmd
+        # Public endpoint must NOT be used
+        assert "oss-cn-shanghai.aliyuncs.com" not in archive_cmd
+
+    @pytest.mark.asyncio
+    async def test_server_endpoint_fail_public_fallback_success(self, fake_table):
+        """server_endpoint failure → falls back to public endpoint and succeeds."""
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(
+            lambda: _fake_rock_config(
+                endpoint="oss-cn-shanghai.aliyuncs.com",
+                server_endpoint="cn-shanghai.oss.aliyuncs.com",
+                keep_days=3,
+            )
+        )
+        fake_table.list_by_in = AsyncMock(
+            return_value=[_row("sb-1", state="stopped", stop_time=_iso_days_ago(5))]
+        )
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime(
+            [
+                _FakeExecResult(),  # cleanup stale archives
+                _FakeExecResult(stdout="sb-1"),  # discover
+                RuntimeError("in-vpc endpoint blackholed"),  # archive attempt 1
+                _FakeExecResult(),  # archive attempt 2 (public) succeeds
+            ]
+        )
+
+        result = await task.run_action(runtime)
+
+        assert result["archived"] == 1
+        assert result["failed"] == 0
+        assert runtime.execute.await_count == 4
+        # 1st archive attempt: server_endpoint
+        assert (
+            "cn-shanghai.oss.aliyuncs.com"
+            in runtime.execute.await_args_list[2].args[0].command
+        )
+        # 2nd archive attempt: public endpoint
+        assert (
+            "oss-cn-shanghai.aliyuncs.com"
+            in runtime.execute.await_args_list[3].args[0].command
+        )
+
+    @pytest.mark.asyncio
+    async def test_both_endpoints_fail_records_failure(self, fake_table):
+        """When both endpoints fail, the sandbox is counted as failed."""
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(
+            lambda: _fake_rock_config(
+                endpoint="oss-cn-shanghai.aliyuncs.com",
+                server_endpoint="cn-shanghai.oss.aliyuncs.com",
+                keep_days=3,
+            )
+        )
+        fake_table.list_by_in = AsyncMock(
+            return_value=[_row("sb-1", state="stopped", stop_time=_iso_days_ago(5))]
+        )
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime(
+            [
+                _FakeExecResult(),  # cleanup stale archives
+                _FakeExecResult(stdout="sb-1"),  # discover
+                RuntimeError("in-vpc endpoint blackholed"),  # attempt 1
+                RuntimeError("public endpoint also down"),  # attempt 2
+            ]
+        )
+
+        result = await task.run_action(runtime)
+
+        assert result["archived"] == 0
+        assert result["failed"] == 1
+        assert runtime.execute.await_count == 4
+
+    @pytest.mark.asyncio
+    async def test_duplicate_endpoints_deduped(self, fake_table):
+        """If server_endpoint == endpoint, we only attempt once (dedupe)."""
+        set_sandbox_table_provider(lambda: fake_table)
+        set_rock_config_provider(
+            lambda: _fake_rock_config(
+                endpoint="oss-cn-shanghai.aliyuncs.com",
+                server_endpoint="oss-cn-shanghai.aliyuncs.com",
+                keep_days=3,
+            )
+        )
+        fake_table.list_by_in = AsyncMock(
+            return_value=[_row("sb-1", state="stopped", stop_time=_iso_days_ago(5))]
+        )
+
+        task = SandboxLogArchiveTask(log_root="/data/logs")
+        runtime = _runtime(
+            [
+                _FakeExecResult(),  # cleanup stale archives
+                _FakeExecResult(stdout="sb-1"),  # discover
+                RuntimeError("primary endpoint down"),  # attempt 1 — no fallback
+            ]
+        )
+
+        result = await task.run_action(runtime)
+
+        assert result["archived"] == 0
+        assert result["failed"] == 1
+        # Only one archive attempt after cleanup + discover
+        assert runtime.execute.await_count == 3

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -130,6 +130,64 @@ def test_oss_config_primary_dict_coerced():
     assert cfg.bucket == ""
 
 
+def test_oss_primary_server_endpoint_default_empty():
+    """`server_endpoint` defaults to empty string; server-side callers must
+    then fall back to `endpoint` themselves."""
+    from rock.config import OssAccountConfig
+
+    acc = OssAccountConfig()
+    assert acc.server_endpoint == ""
+
+
+def test_oss_primary_server_endpoint_from_dict():
+    """YAML-supplied `server_endpoint` is preserved on the dataclass after
+    dict coercion in `OssConfig.__post_init__`."""
+    from rock.config import OssConfig
+
+    cfg = OssConfig(
+        primary={
+            "endpoint": "oss-cn-shanghai.aliyuncs.com",
+            "server_endpoint": "cn-shanghai.oss.aliyuncs.com",
+            "bucket": "chatos-rock",
+        }
+    )
+    assert cfg.primary.endpoint == "oss-cn-shanghai.aliyuncs.com"
+    assert cfg.primary.server_endpoint == "cn-shanghai.oss.aliyuncs.com"
+
+
+def test_oss_primary_endpoint_and_server_endpoint_are_independent():
+    """Setting `server_endpoint` alone must not clobber `endpoint`, and vice
+    versa — they occupy separate slots on the dataclass."""
+    from rock.config import OssAccountConfig
+
+    only_server = OssAccountConfig(server_endpoint="cn-shanghai.oss.aliyuncs.com")
+    assert only_server.endpoint == ""
+    assert only_server.server_endpoint == "cn-shanghai.oss.aliyuncs.com"
+
+    only_public = OssAccountConfig(endpoint="oss-cn-shanghai.aliyuncs.com")
+    assert only_public.endpoint == "oss-cn-shanghai.aliyuncs.com"
+    assert only_public.server_endpoint == ""
+
+
+def test_oss_primary_legacy_dict_without_server_endpoint():
+    """YAML written before `server_endpoint` was added still coerces cleanly:
+    the new field defaults to empty string, no KeyError, no TypeError."""
+    from rock.config import OssConfig
+
+    cfg = OssConfig(
+        primary={
+            "endpoint": "oss-cn-shanghai.aliyuncs.com",
+            "bucket": "chatos-rock",
+            "access_key_id": "a",
+            "access_key_secret": "s",
+            "role_arn": "r",
+            "region": "cn-shanghai",
+        }
+    )
+    assert cfg.primary.endpoint == "oss-cn-shanghai.aliyuncs.com"
+    assert cfg.primary.server_endpoint == ""
+
+
 def test_sandbox_log_config_defaults():
     from rock.config import SandboxLogConfig
 


### PR DESCRIPTION
## Summary

- Adds `OssAccountConfig.server_endpoint`, a server-side-only in-VPC
  OSS endpoint. Deliberately not exposed via the STS response, so the
  SDK boundary is unchanged.
- `SandboxLogArchiveTask._archive_one` now tries `server_endpoint`
  first and falls back to `endpoint` on failure. Empty and equal
  entries are deduplicated via `dict.fromkeys`, so a legacy YAML that
  only sets `endpoint` still makes exactly one attempt. Two failures
  propagate — the sandbox is counted as failed and the outer loop
  moves on.

## Why the SDK does not see `server_endpoint`

The STS response body is the physical boundary between the two
processes. `gen_oss_sts_token` still returns only `endpoint` (public),
so the SDK cannot depend on the in-VPC endpoint even accidentally.
All three OSS flows separate cleanly by which process reads config:

| Flow                    | Runs in   | Reads config directly? | Endpoint used                  |
| ----------------------- | --------- | ---------------------- | ------------------------------ |
| SDK upload / download   | User host | No (HTTP `/get_token`) | `endpoint` (public)            |
| `SandboxLogArchiveTask` | Worker    | Yes                    | `server_endpoint` → `endpoint` |

Archive uses failure-driven fallback because it is an async background
job — one retry is cheap. This is behind server-side config and can
be revisited without touching the SDK.

## Test plan

- [x] `tests/unit/test_config.py`: `server_endpoint` defaults to
      empty, dict-coerces from YAML, is independent of `endpoint`,
      and legacy YAMLs (without the field) still parse.
- [x] `tests/unit/admin/scheduler/test_sandbox_log_archive_task.py`:
      new `TestEndpointFallback` covers (a) only public endpoint →
      single attempt, (b) both configured with internal success → one
      attempt using internal, (c) internal fails → falls back to
      public and succeeds (4 execs total: cleanup + discover + 2
      archive attempts), (d) both fail → sandbox counted as failed,
      (e) `server_endpoint == endpoint` deduped to a single attempt.
- [x] Full `tests/unit/{sandbox,admin,test_config.py}` sweep passes.

## Rollout

`server_endpoint` defaults to `""`. Every existing YAML keeps working
unchanged. To enable the in-VPC endpoint on a cluster, set:

```yaml
oss:
  primary:
    endpoint: oss-cn-shanghai.aliyuncs.com
    server_endpoint: cn-shanghai.oss.aliyuncs.com
    
Closes #1187 