### PR TITLE
perf(admin): adopt uvloop/httptools and simplify request metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ readme = "README.md"
 dependencies = [
     # Core dependencies needed by all modules
     "httpx",
-    "uuid",
     "anyio",
     "build",
     "opentelemetry-api",
@@ -38,7 +37,7 @@ admin = [
     # Admin specific dependencies
     "ray[default]==2.43.0",
     "nacos-sdk-python>=0.1.14",
-    "redis",
+    "redis==7.2.0",
     "apscheduler",
     "websockets>=15.0.1",
     "aiohttp>=3.12.15",
@@ -53,6 +52,8 @@ admin = [
     "fakeredis[json]",
     "kubernetes>=35.0.0",  # For K8S operator support
     "aiolimiter>=1.2.1",  # For rate limiting
+    "httptools",
+    "uvloop",
 ]
 
 rocklet = [

--- a/requirements_admin.txt
+++ b/requirements_admin.txt
@@ -92,7 +92,7 @@ annotated-doc==0.0.3
     # via fastapi
 annotated-types==0.7.0
     # via pydantic
-antlr4-python3-runtime==4.13.2
+antlr4-python3-runtime==4.13.2 ; sys_platform != 'win32'
     # via latex2sympy2-extended
 anyio==4.11.0
     # via
@@ -103,7 +103,7 @@ apscheduler==3.11.1
     # via
     #   alibabacloud-credentials
     #   rl-rock
-arckit==0.1.0
+arckit==0.1.0 ; sys_platform != 'win32'
     # via reasoning-gym
 async-timeout==5.0.1 ; python_full_version < '3.11.3'
     # via
@@ -118,11 +118,11 @@ attrs==25.4.0
     #   jsonschema
     #   referencing
     #   twisted
-automat==25.4.16
+automat==25.4.16 ; sys_platform != 'win32'
     # via twisted
-bashlex==0.18
+bashlex==0.18 ; sys_platform != 'win32'
     # via rl-rock
-bfi==1.0.4
+bfi==1.0.4 ; sys_platform != 'win32'
     # via reasoning-gym
 boto3==1.40.66
     # via rl-rock
@@ -134,7 +134,7 @@ build==1.3.0
     # via rl-rock
 cachetools==6.2.1
     # via google-auth
-cellpylib==2.4.0
+cellpylib==2.4.0 ; sys_platform != 'win32'
     # via reasoning-gym
 certifi==2025.10.5
     # via
@@ -159,11 +159,11 @@ colorama==0.4.6 ; os_name == 'nt' or sys_platform == 'win32'
     #   tqdm
 colorful==0.5.8
     # via ray
-constantly==23.10.4
+constantly==23.10.4 ; sys_platform != 'win32'
     # via twisted
-contourpy==1.3.2 ; python_full_version < '3.11'
+contourpy==1.3.2 ; python_full_version < '3.11' and sys_platform != 'win32'
     # via matplotlib
-contourpy==1.3.3 ; python_full_version >= '3.11'
+contourpy==1.3.3 ; python_full_version >= '3.11' and sys_platform != 'win32'
     # via matplotlib
 crcmod==1.7
     # via oss2
@@ -174,13 +174,13 @@ cryptography==39.0.1
     #   alibabacloud-tea-openapi
     #   aliyun-python-sdk-core
     #   rl-rock
-cycler==0.12.1
+cycler==0.12.1 ; sys_platform != 'win32'
     # via matplotlib
 darabonba-core==1.0.4
     # via alibabacloud-tea-openapi
 distlib==0.4.0
     # via virtualenv
-drawsvg==2.4.0
+drawsvg==2.4.0 ; sys_platform != 'win32'
     # via arckit
 durationpy==0.10
     # via kubernetes
@@ -194,14 +194,14 @@ filelock==3.20.0
     # via
     #   ray
     #   virtualenv
-fonttools==4.60.1
+fonttools==4.60.1 ; sys_platform != 'win32'
     # via matplotlib
 frozenlist==1.8.0
     # via
     #   aiohttp
     #   aiosignal
     #   ray
-gem-llm==0.1.0
+gem-llm==0.1.0 ; sys_platform != 'win32'
     # via rl-rock
 google-api-core==2.28.1
     # via opencensus
@@ -225,9 +225,11 @@ h11==0.16.0
     #   uvicorn
 httpcore==1.0.9
     # via httpx
+httptools==0.8.0
+    # via rl-rock
 httpx==0.28.1
     # via rl-rock
-hyperlink==21.0.0
+hyperlink==21.0.0 ; sys_platform != 'win32'
     # via twisted
 idna==3.11
     # via
@@ -240,7 +242,7 @@ importlib-metadata==8.7.0
     # via
     #   build
     #   opentelemetry-api
-incremental==24.7.2
+incremental==24.7.2 ; sys_platform != 'win32'
     # via twisted
 jinja2==3.1.6
     # via rl-rock
@@ -249,7 +251,7 @@ jmespath==0.10.0
     #   aliyun-python-sdk-core
     #   boto3
     #   botocore
-joblib==1.5.2
+joblib==1.5.2 ; sys_platform != 'win32'
     # via nltk
 jsonpath-ng==1.7.0
     # via fakeredis
@@ -257,29 +259,29 @@ jsonschema==4.25.1
     # via ray
 jsonschema-specifications==2025.9.1
     # via jsonschema
-kiwisolver==1.4.9
+kiwisolver==1.4.9 ; sys_platform != 'win32'
     # via matplotlib
 kubernetes==35.0.0
     # via rl-rock
-latex2sympy2-extended==1.10.2
+latex2sympy2-extended==1.10.2 ; sys_platform != 'win32'
     # via math-verify
-magiccube==0.3.0
+magiccube==0.3.0 ; sys_platform != 'win32'
     # via reasoning-gym
 markdown-it-py==4.0.0
     # via rich
 markupsafe==3.0.3
     # via jinja2
-math-verify==0.8.0
+math-verify==0.8.0 ; sys_platform != 'win32'
     # via gem-llm
-matplotlib==3.10.7
+matplotlib==3.10.7 ; sys_platform != 'win32'
     # via cellpylib
 mdurl==0.1.2
     # via markdown-it-py
-mpmath==1.3.0
+mpmath==1.3.0 ; sys_platform != 'win32'
     # via sympy
 msgpack==1.1.2
     # via ray
-msgspec==0.19.0
+msgspec==0.19.0 ; sys_platform != 'win32'
     # via gem-llm
 multidict==6.7.0
     # via
@@ -287,22 +289,16 @@ multidict==6.7.0
     #   yarl
 nacos-sdk-python==2.0.9
     # via rl-rock
-nltk==3.9.1
+nltk==3.9.1 ; sys_platform != 'win32'
     # via gem-llm
-numpy==2.2.6 ; python_full_version < '3.11'
+numpy==2.2.6
     # via
     #   arckit
     #   cellpylib
     #   contourpy
     #   magiccube
     #   matplotlib
-numpy==2.3.4 ; python_full_version >= '3.11'
-    # via
-    #   arckit
-    #   cellpylib
-    #   contourpy
-    #   magiccube
-    #   matplotlib
+    #   rl-rock
 oauthlib==3.3.1
     # via requests-oauthlib
 opencensus==0.11.4
@@ -349,9 +345,9 @@ packaging==25.0
     #   build
     #   matplotlib
     #   ray
-pexpect==4.9.0
+pexpect==4.9.0 ; sys_platform != 'win32'
     # via rl-rock
-pillow==12.0.0
+pillow==12.0.0 ; sys_platform != 'win32'
     # via matplotlib
 pip==25.3
     # via rl-rock
@@ -381,7 +377,7 @@ psutil==7.1.3
     # via
     #   nacos-sdk-python
     #   rl-rock
-ptyprocess==0.7.0
+ptyprocess==0.7.0 ; sys_platform != 'win32'
     # via pexpect
 py-spy==0.4.1
     # via ray
@@ -391,7 +387,7 @@ pyasn1==0.6.1
     #   rsa
 pyasn1-modules==0.4.2
     # via google-auth
-pycosat==0.6.6
+pycosat==0.6.6 ; sys_platform != 'win32'
     # via reasoning-gym
 pycparser==2.23 ; implementation_name != 'PyPy'
     # via cffi
@@ -408,11 +404,11 @@ pydantic==2.11.9
     #   sqlmodel
 pydantic-core==2.33.2
     # via pydantic
-pyfiglet==1.0.2
+pyfiglet==1.0.2 ; sys_platform != 'win32'
     # via reasoning-gym
 pygments==2.19.2
     # via rich
-pyparsing==3.2.5
+pyparsing==3.2.5 ; sys_platform != 'win32'
     # via matplotlib
 pyproject-hooks==1.2.0
     # via build
@@ -423,7 +419,9 @@ python-dateutil==2.9.0.post0
     #   matplotlib
 python-multipart==0.0.20
     # via rl-rock
-pytz==2025.2
+python-statemachine==3.1.2
+    # via rl-rock
+pytz==2025.2 ; sys_platform != 'win32'
     # via reasoning-gym
 pyyaml==6.0.3
     # via
@@ -433,9 +431,9 @@ pyyaml==6.0.3
     #   rl-rock
 ray==2.43.0
     # via rl-rock
-reasoning-gym==0.1.23
+reasoning-gym==0.1.23 ; sys_platform != 'win32'
     # via gem-llm
-redis==7.0.1
+redis==7.2.0
     # via
     #   fakeredis
     #   rl-rock
@@ -443,7 +441,7 @@ referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-regex==2025.11.3
+regex==2025.11.3 ; sys_platform != 'win32'
     # via nltk
 requests==2.32.5
     # via
@@ -470,7 +468,7 @@ rsa==4.9.1
     # via google-auth
 s3transfer==0.14.0
     # via boto3
-setuptools==80.9.0
+setuptools==80.9.0 ; sys_platform != 'win32'
     # via incremental
 six==1.17.0
     # via
@@ -491,19 +489,19 @@ sqlmodel==0.0.27
     # via rl-rock
 starlette==0.49.3
     # via fastapi
-sympy==1.14.0
+sympy==1.14.0 ; sys_platform != 'win32'
     # via
     #   latex2sympy2-extended
     #   reasoning-gym
-tabulate==0.9.0
+tabulate==0.9.0 ; sys_platform != 'win32'
     # via reasoning-gym
 tomli==2.3.0 ; python_full_version < '3.11'
     # via
     #   build
     #   incremental
-tqdm==4.67.1
+tqdm==4.67.1 ; sys_platform != 'win32'
     # via nltk
-twisted==25.5.0
+twisted==25.5.0 ; sys_platform != 'win32'
     # via rl-rock
 typing-extensions==4.15.0
     # via
@@ -542,9 +540,9 @@ urllib3==2.5.0
     #   botocore
     #   kubernetes
     #   requests
-uuid==1.30
-    # via rl-rock
 uvicorn==0.38.0
+    # via rl-rock
+uvloop==0.22.1
     # via rl-rock
 virtualenv==20.35.4
     # via ray
@@ -558,7 +556,7 @@ yarl==1.22.0
     # via aiohttp
 zipp==3.23.0
     # via importlib-metadata
-zope-interface==8.0.1
+zope-interface==8.0.1 ; sys_platform != 'win32'
     # via twisted
-zss==1.2.0
+zss==1.2.0 ; sys_platform != 'win32'
     # via reasoning-gym

--- a/requirements_sandbox_actor.txt
+++ b/requirements_sandbox_actor.txt
@@ -166,6 +166,8 @@ importlib-metadata==8.7.0
     # via
     #   build
     #   opentelemetry-api
+jinja2==3.1.6
+    # via rl-rock
 jmespath==0.10.0
     # via aliyun-python-sdk-core
 joblib==1.5.2
@@ -178,6 +180,8 @@ magiccube==0.3.0
     # via reasoning-gym
 markdown-it-py==4.0.0
     # via rich
+markupsafe==3.0.3
+    # via jinja2
 math-verify==0.8.0
     # via gem-llm
 matplotlib==3.10.7
@@ -196,14 +200,7 @@ nacos-sdk-python==2.0.9
     # via rl-rock
 nltk==3.9.1
     # via gem-llm
-numpy==2.2.6 ; python_full_version < '3.11'
-    # via
-    #   arckit
-    #   cellpylib
-    #   contourpy
-    #   magiccube
-    #   matplotlib
-numpy==2.3.4 ; python_full_version >= '3.11'
+numpy==2.2.6
     # via
     #   arckit
     #   cellpylib
@@ -291,6 +288,8 @@ python-dateutil==2.9.0.post0
     # via matplotlib
 python-multipart==0.0.20
     # via rl-rock
+python-statemachine==3.1.2
+    # via rl-rock
 pytz==2025.2
     # via reasoning-gym
 pyyaml==6.0.3
@@ -299,7 +298,7 @@ pyyaml==6.0.3
     #   rl-rock
 reasoning-gym==0.1.23
     # via gem-llm
-redis==7.0.1
+redis==7.2.0
     # via rl-rock
 regex==2025.11.3
     # via nltk
@@ -361,8 +360,6 @@ tzlocal==5.3.1
     # via apscheduler
 urllib3==2.5.0
     # via requests
-uuid==1.30
-    # via rl-rock
 yarl==1.22.0
     # via aiohttp
 zipp==3.23.0

--- a/rock/admin/main.py
+++ b/rock/admin/main.py
@@ -331,6 +331,8 @@ def main():
         host="0.0.0.0",
         port=args.port,
         workers=workers,
+        loop="uvloop",
+        http="httptools",
         ws_ping_interval=None,
         ws_ping_timeout=None,
         timeout_keep_alive=30,

--- a/rock/admin/main.py
+++ b/rock/admin/main.py
@@ -3,6 +3,7 @@ import asyncio
 import json
 import logging
 import os
+import sys
 import time
 import traceback
 import uuid
@@ -306,6 +307,12 @@ def create_app() -> FastAPI:
 
 
 def main():
+    # Set uvloop as global event loop policy (covers Redis, SchedulerThread, etc.)
+    if sys.platform != "win32":
+        import uvloop
+
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
     args = _parse_args()
     os.environ["ROCK_ADMIN_ENV"] = args.env
     os.environ["ROCK_ADMIN_ROLE"] = args.role

--- a/uv.lock
+++ b/uv.lock
@@ -1814,6 +1814,56 @@ wheels = [
 ]
 
 [[package]]
+name = "httptools"
+version = "0.8.0"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/43/e5/d471fcb0e14523fe1c3f4ba58ca52480e7bd70ad7109a3846bc75892f7fb/httptools-0.8.0.tar.gz", hash = "sha256:6b2a32f18d97e16e90827d7a819ffa8dbd8cc245fc4e1fa9d1095b54ef4bd999" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/40/b9/be66eb0decd730d89b9c94f930e4b8d87787b05724bb84af98bfd825f72c/httptools-0.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bf3b6f807c8541503cecfbb8a8dffb385640d0d96102f3d112aa8740f9b7c826" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/9d/f7/b4d41eaae2869d31356bc4bbf546f44fae83ff298af0a043ca0625b06773/httptools-0.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da684f2e1aa2ee9bdcb083f3f3a68c5956750b375bc5df864d3a5f0c42a40b77" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/e6/e4/77487e14fc7be47180fd0eb4267c7486d0cc59b74031839a3daf8650136b/httptools-0.8.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6f21e2a3b0067bbe7f67e34cfd16276af556e5e52f4c7503be0cb5f90e905e4" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/da/72/5a8f787e323f56fbd86c32a4be92a86776e4cfe8b4317db999f452028362/httptools-0.8.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea897f0c729581ebf72131a438a7932d9b14efef72d75ada966700cac3caaeb" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/ed/41/b44a25560955197674b6744cb903664300e239235a5eaa69df0890d87054/httptools-0.8.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c0d726cc107fceb7d45f978483b4b70dd8caa836f5914d3434bb18628eb73813" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/74/b0/054aac84c03d7e097bf4c605fb7e74eec3d65c0276adf64ee97f3a103ff5/httptools-0.8.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9878eb2785ba5eb70631ad269b37976f73d647955e26c91d490eb8a4edfda4ba" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/bb/e8/86b85bbc0ac7892232f1a99ab96a9aa71936984fa06adfc0afc83ca7789e/httptools-0.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:b205e5f5523fa039679da0dfe5a10132b2a4abeae6a86fdd1ddc035f7f836557" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/f8/d2/c3eedaef57de65c3cc5f8dc244cf12d09c84ad258a479055aad6db23206c/httptools-0.8.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ed377e64805bdba4943c82717333f8f8603a13b09aff9cead2717c6c817fb168" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/f1/94/dfe435d90d0ef61ec0f2cc3d480eef78c59727c6c2ce039f433882f6131a/httptools-0.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9518c406d7b310f05adb1a37f80acabac40504a575d7c0da6d3e365c695ac20d" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/cc/d4/13025f1a56e615dcb331e0bbe2d9a1143212b58c263385fc5d2e558f5bac/httptools-0.8.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:57278e6fa0424c42a8a3e454828ab4f0aff27b40cddf9679579b98c6dce6a376" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/bf/95/4c1c26c0b985f8a3331682d802598f14e32dc41bf7509266eb2c04ad4801/httptools-0.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbb8caadb2b742d293169d2b458b5c001ef70e3158704aa3d3ef9597624c5d1d" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/a2/82/6735be2b0ca527718c431cdb8e5f70c3862c0844a687df0f572c51e11497/httptools-0.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:52dd695b865fe96d9d2b16b64a895f3f57bf3cb064e8383cd3b5713a069e8085" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/b5/f9/5811c74f37a758c8a4aa3dc430375119d335947e883efc4664d8f3559a41/httptools-0.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:20b4aac66ff65f7db06a375808b78f42a94970aa22e826b3cb2b43eb09174124" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/cc/94/97b75870dea07b71e3ec535cebe525b08d723152e4c7d13fa887e51f4de2/httptools-0.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:a1b4c8e7a489a0d750d91894e9a8cdc295838f1924c0ca903ae993456fddec07" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/14/88/1d21a36da8f5cb0fa49eafd4b169eba5608d57e75bbcf61845cbc6243216/httptools-0.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:880490234c10f70a9830743097e8958d6e4b9f5a0ffc24515023afeef984054d" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/a5/42/cc4feea2945cb3051038f090c9b36bd5b8a9d7f5a894a506a8983e33fd1c/httptools-0.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5931891fb7b441b8a3853cf1b85c82c903defce084dd5f6771ca46e31bf862c5" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/e3/a6/febbb8b8db0f58b38e44ad6cb946e6a255ae49b55f2e8543408fb7501ccd/httptools-0.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b15fc622b0f869d19207c4089a501d9bcc63ca5e071ffdd2f03f922df882dcb2" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/b7/e4/f90a0df0b83beff265b7e3b65f2a4cefd95792d4be0ac3e16049f2acd3c2/httptools-0.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:425f83884fd6343828d8c565f046cb72b6d19063f6924093e11bcd8e1548cd09" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/9e/2d/0c9ac76dd2c893841fbf6498d6acec4f2442e1b7067f6e3e316a80e494e8/httptools-0.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ef7c3c97f4311c7be57e2986629df89d49cb434dbff78eafcd48c2bff986b15a" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/ca/42/906adc91ae3a5fa9c59c0a2f21c139725bd7e5b41ae6acd485cd14123ebf/httptools-0.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a1afd7c9fbff0d9f5d489c4ce2768bd09c84a46ddefc7161e6aa82ae35c85745" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/05/0b/4240efeb672751ee5b9b380cb0e3fdc050bc05f68adc7a8aefc4fcd9a69a/httptools-0.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:cd96f29b4bab1d42fa6e3d008711c75e0f79e94e06827330160e3a304227f150" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/5e/e5/8cfcabc5546e8022f168be28bcdaa128a240a0befdd03b59d558b4f18bd6/httptools-0.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:614ceea8ea606848bece2338ac03b3ce5324bcb4be8dc7d377ed708012fa4db8" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/2a/0e/0fb14848c19a686c8062ff9067c1a48793e3224b47bc5b201535b6036fce/httptools-0.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2d689918c15a013c65ef52d9fd495d766893ab831a2c8d89f2ac5940a5df847c" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/2e/1b/46f1cecf06b9bbde8e4b8c88034ac7908989e5ff7a3a388ef38392949c1f/httptools-0.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:eb3028cca2fc0a6d720e52ef61d8ebb62fcbfeb1de56874546d858d3f25a26b7" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/77/00/258bfc0837221f81d9725c45f9b948a6a6b2994a147a4fb66e85100c668f/httptools-0.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88bdd940f2b5d487b4d032c6afa5489a7dc4694410d43de3c38c4fb3af0dc45d" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/04/ab/d1cef3b5523f4d272a70f42a776c3169a2dddfe3a54de4b2ce4a36341528/httptools-0.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6a43c9dd399758ccc0531acb0a3c4a6c299ee893ee9400e9c893b7bdcfae0681" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/ce/48/5d1d072442277bb2b3434e0e60690b8e8c23840ef7de8b6ea54040a536d3/httptools-0.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0770728beb05094c809b98e814edff5fef69d26ad7d21185f2f6d5884a0ba683" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/0d/66/b96623b27e51a68199ef4efdda0613cced9233fe3062ac74e50749c5ad37/httptools-0.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:7685df791fad561384bfb139e77fde27a1ffd93134e016f95a0db424ffbf77b1" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/1a/12/fa3fbf5f9517b273edea2dc982aa82a8c634091e67c590792b729017bc6f/httptools-0.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:de242a49b5d18e0a8776e654e9f6bf6d89f3875a5c35b425a0e7ce940feb3fd6" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/30/fc/5e7c4cb443370f2090a3aba0453a07384d29ff66b7435bb90e77e1037599/httptools-0.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:159e9ab5f701ccd42e555a12f1ad8ff69702910fc1c996cf2bb66e5fcb7a231b" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/ba/53/771bd891eb0f236f32145d6a1775777ec85745f3cc983a1f23d1a3b8ddfe/httptools-0.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c4a9f1707e4823d54dfec6c33fa3697d302aed536ed352a7ebb5a061ddb869d0" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/62/42/94e15bc68ce3d423243c45d7f1b0c7561f13844f97dc52ae23182fb65628/httptools-0.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d76ad7b951387e3632c8716a9bb03ac5b45c5f16119aa409db0459520887944e" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/1c/7c/fe2980fc03723272e30f135b62360b075f513dfe7cc73aef36c7f04012bd/httptools-0.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a3b7387147361c3fd47a0bde763c5c91b5b4cd4dc9989b8ece84ff436c99843b" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/15/1b/47fc5fff68acd1bfa20b4734059c9a06cadb88119dcd5258b5b0d21d91c8/httptools-0.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f256d6ce930c52ca1cb2a960b7da03548c454e7d28b06059ad41bfe789036ce0" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/60/bd/07b13c93ffd9bec9546e0d43f8e19378dd696dbd278511406bc07371ef1f/httptools-0.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:19d1ee275bb59ba2643ba9a3a1e51cc0c788caf2b8df506368e03f56fdd08527" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/fd/c4/121648f68ce066d7bd762d6b6d97e620847642d38d54f3d90ff11d947629/httptools-0.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:de1ed58a974e75d56560acc7e7fed01a454994429456f65209789992e41f2568" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/b9/b0/312a062ae741ae3e8baa8c8bf20be81b2e67337b259ab4349bebc7b6142e/httptools-0.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e93c227b595c6926c1acee96891dd9da4be338cfbe82e5cd3bb9d8dd7dc4ac0b" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/fc/37/fccd705f795386bb05bf413012fecff2a33e5aa8c2f069096de3e9fd8702/httptools-0.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2a021c3a8e65cc125390d72f59b968afca3bdcaff25bd67965e0a055a14946ca" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/bd/39/f172e8003576de35f5ba77ff417cf0e34429d35dc014deef15afa337a72c/httptools-0.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48774d39cbb70e2b1f71f88852a3087ae1d3a1eb80482bb48c13067ab080c14f" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/3e/b9/f5564760af99f3dbbf3f9104dc00e5da27e96cf433c6bdcf77617f70bf3f/httptools-0.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:88eead8ec8680a9f146c655bc88445a325bd7921cfd8194c7337e9467282427d" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/99/67/8d9f2c313618e161b82f3873188e7196126da1d6e29688df40eb3997c77a/httptools-0.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2c032fa028f46871ec7e1fc59fc15e8023eab3e6bbe6ece786a1611719a5d081" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/48/63/b906c01e53f50d432c0defe43ce52764a111dc1bdd028bafbeb54dcfd008/httptools-0.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:384c17174464c8e873398b7af24f0b1f44d992c820328413951a625323155d77" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
@@ -4106,14 +4156,14 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "7.0.1"
+version = "7.2.0"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
 dependencies = [
     { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
 ]
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/57/8f/f125feec0b958e8d22c8f0b492b30b1991d9499a4315dfde466cf4289edc/redis-7.0.1.tar.gz", hash = "sha256:c949df947dca995dc68fdf5a7863950bf6df24f8d6022394585acc98e81624f1" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/9f/32/6fac13a11e73e1bc67a2ae821a72bfe4c2d8c4c48f0267e4a952be0f1bae/redis-7.2.0.tar.gz", hash = "sha256:4dd5bf4bd4ae80510267f14185a15cba2a38666b941aff68cccf0256b51c1f26" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/e9/97/9f22a33c475cda519f20aba6babb340fb2f2254a02fb947816960d1e669a/redis-7.0.1-py3-none-any.whl", hash = "sha256:4977af3c7d67f8f0eb8b6fec0dafc9605db9343142f634041fb0235f67c0588a" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/86/cf/f6180b67f99688d83e15c84c5beda831d1d341e95872d224f87ccafafe61/redis-7.2.0-py3-none-any.whl", hash = "sha256:01f591f8598e483f1842d429e8ae3a820804566f1c73dca1b80e23af9fba0497" },
 ]
 
 [[package]]
@@ -4299,7 +4349,6 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "tzdata" },
-    { name = "uuid" },
 ]
 
 [package.optional-dependencies]
@@ -4316,6 +4365,7 @@ admin = [
     { name = "fakeredis", extra = ["json"] },
     { name = "fastapi" },
     { name = "gem-llm", marker = "sys_platform != 'win32'" },
+    { name = "httptools" },
     { name = "kubernetes" },
     { name = "nacos-sdk-python" },
     { name = "numpy" },
@@ -4327,6 +4377,7 @@ admin = [
     { name = "sqlmodel" },
     { name = "twisted", marker = "sys_platform != 'win32'" },
     { name = "uvicorn" },
+    { name = "uvloop" },
     { name = "websockets" },
 ]
 all = [
@@ -4343,6 +4394,7 @@ all = [
     { name = "fakeredis", extra = ["json"] },
     { name = "fastapi" },
     { name = "gem-llm" },
+    { name = "httptools" },
     { name = "kubernetes" },
     { name = "nacos-sdk-python" },
     { name = "numpy" },
@@ -4355,6 +4407,7 @@ all = [
     { name = "swebench" },
     { name = "twisted", marker = "sys_platform != 'win32'" },
     { name = "uvicorn" },
+    { name = "uvloop" },
     { name = "websockets" },
 ]
 builder = [
@@ -4428,6 +4481,7 @@ requires-dist = [
     { name = "gem-llm", marker = "sys_platform != 'win32' and extra == 'rocklet'", specifier = ">=0.1.0" },
     { name = "gem-llm", marker = "extra == 'builder'", specifier = ">=0.1.0" },
     { name = "gem-llm", marker = "extra == 'sandbox-actor'", specifier = ">=0.1.0" },
+    { name = "httptools", marker = "extra == 'admin'" },
     { name = "httpx" },
     { name = "httpx", marker = "extra == 'model-service'" },
     { name = "jinja2" },
@@ -4450,7 +4504,7 @@ requires-dist = [
     { name = "python-statemachine", specifier = ">=3.1.1" },
     { name = "pyyaml" },
     { name = "ray", extras = ["default"], marker = "extra == 'admin'", specifier = "==2.43.0" },
-    { name = "redis", marker = "extra == 'admin'" },
+    { name = "redis", marker = "extra == 'admin'", specifier = "==7.2.0" },
     { name = "redis", marker = "extra == 'sandbox-actor'" },
     { name = "requests" },
     { name = "rich" },
@@ -4464,9 +4518,9 @@ requires-dist = [
     { name = "swebench", marker = "extra == 'model-service'" },
     { name = "twisted", marker = "sys_platform != 'win32' and extra == 'rocklet'" },
     { name = "tzdata" },
-    { name = "uuid" },
     { name = "uvicorn", marker = "extra == 'model-service'" },
     { name = "uvicorn", marker = "extra == 'rocklet'" },
+    { name = "uvloop", marker = "extra == 'admin'" },
     { name = "websockets", marker = "extra == 'admin'", specifier = ">=15.0.1" },
 ]
 provides-extras = ["admin", "rocklet", "sandbox-actor", "builder", "model-service", "all"]
@@ -5118,12 +5172,6 @@ wheels = [
 ]
 
 [[package]]
-name = "uuid"
-version = "1.30"
-source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/ce/63/f42f5aa951ebf2c8dac81f77a8edcc1c218640a2a35a03b9ff2d4aa64c3d/uuid-1.30.tar.gz", hash = "sha256:1f87cc004ac5120466f36c5beae48b4c48cc411968eed0eaecd3da82aa96193f" }
-
-[[package]]
 name = "uvicorn"
 version = "0.38.0"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
@@ -5135,6 +5183,50 @@ dependencies = [
 sdist = { url = "https://mirrors.aliyun.com/pypi/packages/cb/ce/f06b84e2697fef4688ca63bdb2fdf113ca0a3be33f94488f2cadb690b0cf/uvicorn-0.38.0.tar.gz", hash = "sha256:fd97093bdd120a2609fc0d3afe931d4d4ad688b6e75f0f929fde1bc36fe0e91d" }
 wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/ee/d9/d88e73ca598f4f6ff671fb5fde8a32925c2e08a637303a1d12883c7305fa/uvicorn-0.38.0-py3-none-any.whl", hash = "sha256:48c0afd214ceb59340075b4a052ea1ee91c16fbc2a9b1469cca0e54566977b02" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/eb/14/ecceb239b65adaaf7fde510aa8bd534075695d1e5f8dadfa32b5723d9cfb/uvloop-0.22.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ef6f0d4cc8a9fa1f6a910230cd53545d9a14479311e87e3cb225495952eb672c" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/ba/ae/6f6f9af7f590b319c94532b9567409ba11f4fa71af1148cab1bf48a07048/uvloop-0.22.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7cd375a12b71d33d46af85a3343b35d98e8116134ba404bd657b3b1d15988792" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/09/bd/3667151ad0702282a1f4d5d29288fce8a13c8b6858bf0978c219cd52b231/uvloop-0.22.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac33ed96229b7790eb729702751c0e93ac5bc3bcf52ae9eccbff30da09194b86" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/b3/f6/21657bb3beb5f8c57ce8be3b83f653dd7933c2fd00545ed1b092d464799a/uvloop-0.22.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:481c990a7abe2c6f4fc3d98781cc9426ebd7f03a9aaa7eb03d3bfc68ac2a46bd" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/09/e0/604f61d004ded805f24974c87ddd8374ef675644f476f01f1df90e4cdf72/uvloop-0.22.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a592b043a47ad17911add5fbd087c76716d7c9ccc1d64ec9249ceafd735f03c2" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/bb/ce/8491fd370b0230deb5eac69c7aae35b3be527e25a911c0acdffb922dc1cd/uvloop-0.22.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1489cf791aa7b6e8c8be1c5a080bae3a672791fcb4e9e12249b05862a2ca9cec" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/c7/d5/69900f7883235562f1f50d8184bb7dd84a2fb61e9ec63f3782546fdbd057/uvloop-0.22.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c60ebcd36f7b240b30788554b6f0782454826a0ed765d8430652621b5de674b9" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/a8/73/c4e271b3bce59724e291465cc936c37758886a4868787da0278b3b56b905/uvloop-0.22.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b7f102bf3cb1995cfeaee9321105e8f5da76fdb104cdad8986f85461a1b7b77" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/86/94/9fb7fad2f824d25f8ecac0d70b94d0d48107ad5ece03769a9c543444f78a/uvloop-0.22.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53c85520781d84a4b8b230e24a5af5b0778efdb39142b424990ff1ef7c48ba21" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/74/4f/256aca690709e9b008b7108bc85fba619a2bc37c6d80743d18abad16ee09/uvloop-0.22.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56a2d1fae65fd82197cb8c53c367310b3eabe1bbb9fb5a04d28e3e3520e4f702" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/7f/74/03c05ae4737e871923d21a76fe28b6aad57f5c03b6e6bfcfa5ad616013e4/uvloop-0.22.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:40631b049d5972c6755b06d0bfe8233b1bd9a8a6392d9d1c45c10b6f9e9b2733" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/75/be/f8e590fe61d18b4a92070905497aec4c0e64ae1761498cad09023f3f4b3e/uvloop-0.22.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:535cc37b3a04f6cd2c1ef65fa1d370c9a35b6695df735fcff5427323f2cd5473" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e" },
 ]
 
 [[package]]


### PR DESCRIPTION
closes #1200

## Summary
Run the admin service on uvloop + httptools for faster async I/O (Redis, scheduler, request handling), and simplify request failure metrics into a single bucket.

## Key changes
- Set uvloop as the global event loop policy and start uvicorn with `loop="uvloop"` / `http="httptools"` (non-Windows only).
- Add `uvloop` and `httptools` to admin dependencies; pin `redis==7.2.0`; remove the redundant `uuid` PyPI backport.
- Collapse the `request.client_error` metric bucket into `request.failure`; drop the unused constant, counter registration, and update tests.
- Regenerate lockfile / requirements with `sys_platform != 'win32'` markers for non-Windows-only deps.