### PR TITLE
perf(admin): reuse shared httpx client for registry manifest probes

### DIFF
--- a/rock/admin/entrypoints/sandbox_api.py
+++ b/rock/admin/entrypoints/sandbox_api.py
@@ -3,7 +3,6 @@ import re
 import time
 from typing import Annotated, Any
 
-import httpx
 from fastapi import APIRouter, Body, Depends, File, Form, UploadFile
 
 from rock.actions import (
@@ -52,17 +51,6 @@ logger = init_logger(__name__)
 
 _MIRROR_PROBE_CACHE: dict[str, tuple[bool, float]] = {}
 _MIRROR_PROBE_TTL_SECONDS = 60.0
-_probe_client: httpx.AsyncClient | None = None  # ponytail: process-lifetime client, reused across probes
-
-
-def _get_probe_client() -> httpx.AsyncClient:
-    global _probe_client
-    if _probe_client is None or _probe_client.is_closed:
-        _probe_client = httpx.AsyncClient(
-            timeout=5,
-            limits=httpx.Limits(max_connections=300, max_keepalive_connections=300),
-        )
-    return _probe_client
 
 
 sandbox_router = APIRouter()
@@ -168,7 +156,7 @@ async def _http_probe_manifest(
     }
     auth = (username, password) if username and password else None
 
-    client = _get_probe_client()
+    client = sandbox_manager.rock_config.http_pool_manager.get("probe")
     resp = await client.get(url, headers=headers, auth=auth)
 
     if resp.status_code == 401 and "www-authenticate" in resp.headers:

--- a/rock/admin/entrypoints/sandbox_api.py
+++ b/rock/admin/entrypoints/sandbox_api.py
@@ -52,6 +52,18 @@ logger = init_logger(__name__)
 
 _MIRROR_PROBE_CACHE: dict[str, tuple[bool, float]] = {}
 _MIRROR_PROBE_TTL_SECONDS = 60.0
+_probe_client: httpx.AsyncClient | None = None  # ponytail: process-lifetime client, reused across probes
+
+
+def _get_probe_client() -> httpx.AsyncClient:
+    global _probe_client
+    if _probe_client is None or _probe_client.is_closed:
+        _probe_client = httpx.AsyncClient(
+            timeout=5,
+            limits=httpx.Limits(max_connections=300, max_keepalive_connections=300),
+        )
+    return _probe_client
+
 
 sandbox_router = APIRouter()
 sandbox_manager: SandboxManager
@@ -141,7 +153,6 @@ async def _http_probe_manifest(
     tag: str,
     username: str | None = None,
     password: str | None = None,
-    timeout: float = 5,
 ) -> bool:
     """Check whether ``repo:tag`` exists on *registry* via the v2 manifest API."""
     url = f"https://{registry}/v2/{repo}/manifests/{tag}"
@@ -157,26 +168,26 @@ async def _http_probe_manifest(
     }
     auth = (username, password) if username and password else None
 
-    async with httpx.AsyncClient(timeout=timeout) as client:
-        resp = await client.get(url, headers=headers, auth=auth)
+    client = _get_probe_client()
+    resp = await client.get(url, headers=headers, auth=auth)
 
-        if resp.status_code == 401 and "www-authenticate" in resp.headers:
-            www_auth = resp.headers["www-authenticate"]
-            if www_auth.startswith("Bearer "):
-                params = _parse_bearer_challenge(www_auth)
-                realm = params.get("realm", "")
-                service = params.get("service", "")
-                scope = params.get("scope", "")
-                token_url = f"{realm}?service={service}&scope={scope}"
-                token_resp = await client.get(token_url, auth=auth)
-                if token_resp.status_code == 200:
-                    data = token_resp.json()
-                    token = data.get("token") or data.get("access_token")
-                    if token:
-                        headers["Authorization"] = f"Bearer {token}"
-                        resp = await client.get(url, headers=headers)
+    if resp.status_code == 401 and "www-authenticate" in resp.headers:
+        www_auth = resp.headers["www-authenticate"]
+        if www_auth.startswith("Bearer "):
+            params = _parse_bearer_challenge(www_auth)
+            realm = params.get("realm", "")
+            service = params.get("service", "")
+            scope = params.get("scope", "")
+            token_url = f"{realm}?service={service}&scope={scope}"
+            token_resp = await client.get(token_url, auth=auth)
+            if token_resp.status_code == 200:
+                data = token_resp.json()
+                token = data.get("token") or data.get("access_token")
+                if token:
+                    headers["Authorization"] = f"Bearer {token}"
+                    resp = await client.get(url, headers=headers)
 
-        return resp.status_code == 200
+    return resp.status_code == 200
 
 
 async def _apply_image_registry_mirror(config: DockerDeploymentConfig) -> None:

--- a/rock/admin/main.py
+++ b/rock/admin/main.py
@@ -48,7 +48,6 @@ from rock.sandbox.sandbox_meta_store import SandboxMetaStore
 from rock.sandbox.service.sandbox_proxy_service import SandboxProxyService
 from rock.sandbox.service.warmup_service import WarmupService
 from rock.utils import EAGLE_EYE_TRACE_ID, sandbox_id_ctx_var, trace_id_ctx_var
-from rock.utils.http_pool import HttpPoolManager
 from rock.utils.providers import RedisProvider
 from rock.utils.system import is_primary_pod
 from rock.utils.worker import resolve_workers
@@ -99,9 +98,6 @@ async def lifespan(app: FastAPI):
         else env_vars.ROCK_CONFIG
     )
     rock_config = RockConfig.from_env(config_file_path)
-
-    # Initialize HTTP pool manager
-    rock_config.http_pool_manager = HttpPoolManager(rock_config.http_pools)
 
     # Override scheduler config from Nacos if available
     if rock_config.nacos_provider:

--- a/rock/admin/main.py
+++ b/rock/admin/main.py
@@ -48,6 +48,7 @@ from rock.sandbox.sandbox_meta_store import SandboxMetaStore
 from rock.sandbox.service.sandbox_proxy_service import SandboxProxyService
 from rock.sandbox.service.warmup_service import WarmupService
 from rock.utils import EAGLE_EYE_TRACE_ID, sandbox_id_ctx_var, trace_id_ctx_var
+from rock.utils.http_pool import HttpPoolManager
 from rock.utils.providers import RedisProvider
 from rock.utils.system import is_primary_pod
 from rock.utils.worker import resolve_workers
@@ -98,6 +99,9 @@ async def lifespan(app: FastAPI):
         else env_vars.ROCK_CONFIG
     )
     rock_config = RockConfig.from_env(config_file_path)
+
+    # Initialize HTTP pool manager
+    rock_config.http_pool_manager = HttpPoolManager(rock_config.http_pools)
 
     # Override scheduler config from Nacos if available
     if rock_config.nacos_provider:
@@ -217,6 +221,9 @@ async def lifespan(app: FastAPI):
     if proxy_service_ref is not None:
         await proxy_service_ref.aclose()
         logger.info("proxy httpx clients closed")
+
+    await rock_config.http_pool_manager.aclose_all()
+    logger.info("http pool manager closed")
 
     if db_provider:
         await db_provider.close()

--- a/rock/config.py
+++ b/rock/config.py
@@ -578,6 +578,10 @@ class RockConfig:
         return result
 
     def __post_init__(self) -> None:
+        from rock.utils.http_pool import HttpPoolManager
+
+        self.http_pool_manager = HttpPoolManager(self.http_pools)
+
         logger.info(f"init RockConfig: {self}")
 
         if self.nacos.endpoint or self.nacos.server_addresses:
@@ -610,7 +614,7 @@ class RockConfig:
 
         # Update configs that are present in nacos_result (field-level merge,
         # then re-run __post_init__ to coerce nested dicts → dataclasses)
-        for key, (config_class, attr_name) in config_map.items():
+        for key, (_, attr_name) in config_map.items():
             if key in nacos_result:
                 existing = getattr(self, attr_name)
                 for field_name, value in nacos_result[key].items():

--- a/rock/config.py
+++ b/rock/config.py
@@ -1,6 +1,7 @@
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -229,6 +230,15 @@ class ProxyServiceConfig:
 
 
 @dataclass
+class HttpPoolConfig:
+    """Configuration for a single named httpx.AsyncClient connection pool."""
+
+    timeout: float = 5.0
+    max_connections: int = 100
+    max_keepalive_connections: int = 20
+
+
+@dataclass
 class DatabaseConfig:
     # Supported URL formats:
     #   SQLite:     sqlite:///relative/path.db  or  sqlite:////absolute/path.db
@@ -432,6 +442,14 @@ class RockConfig:
     database: DatabaseConfig = field(default_factory=DatabaseConfig)
     image_registry_mirrors: list[ImageRegistryMirror] = field(default_factory=list)
     image_mirror_lookup_allowlist: list[str] = field(default_factory=list)
+    http_pools: dict[str, HttpPoolConfig] = field(
+        default_factory=lambda: {
+            "probe": HttpPoolConfig(timeout=5.0, max_connections=300, max_keepalive_connections=300),
+            "rpc": HttpPoolConfig(timeout=180.0, max_connections=500, max_keepalive_connections=100),
+            "proxy": HttpPoolConfig(timeout=None, max_connections=500, max_keepalive_connections=100),
+        }
+    )
+    http_pool_manager: Any = field(default=None, init=False, repr=False)
     nacos_provider: NacosConfigProvider | None = None
 
     @classmethod
@@ -489,6 +507,9 @@ class RockConfig:
             kwargs["scheduler"] = SchedulerConfig(**config["scheduler"])
         if "database" in config:
             kwargs["database"] = DatabaseConfig(**config["database"])
+        if "http_pools" in config:
+            raw_pools = config["http_pools"] or {}
+            kwargs["http_pools"] = {name: HttpPoolConfig(**params) for name, params in raw_pools.items()}
         if "image_registry_mirrors" in config:
             raw_mirrors = config["image_registry_mirrors"] or []
             kwargs["image_registry_mirrors"] = [ImageRegistryMirror(**m) for m in raw_mirrors]
@@ -608,7 +629,6 @@ class RockConfig:
             runtime_overrides = nacos_result["runtime"]
             if "instance_registry_mirrors" in runtime_overrides:
                 self.runtime.instance_registry_mirrors = list(runtime_overrides["instance_registry_mirrors"] or [])
-
 
         logger.info(
             f"Updated config from Nacos: sandbox_config={self.sandbox_config}, proxy_service={self.proxy_service}"

--- a/rock/sandbox/service/sandbox_proxy_service.py
+++ b/rock/sandbox/service/sandbox_proxy_service.py
@@ -65,23 +65,11 @@ class SandboxProxyService:
         self.proxy_config: ProxyServiceConfig = rock_config.proxy_service
         logger.info(f"proxy config: {self.proxy_config}")
         # Control-plane RPC client: short JSON calls to rocklet.
-        self._rpc_client = httpx.AsyncClient(
-            timeout=self.proxy_config.timeout,
-            limits=httpx.Limits(
-                max_connections=self.proxy_config.max_connections,
-                max_keepalive_connections=self.proxy_config.max_keepalive_connections,
-            ),
-        )
+        self._rpc_client = rock_config.http_pool_manager.get("rpc")
         # Data-plane proxy client: streaming/SSE/large bodies. No total timeout;
         # per-request timeout is set via build_request(timeout=...). NEVER closed
         # per-request — lives for the process lifetime, closed in aclose().
-        self._proxy_client = httpx.AsyncClient(
-            timeout=httpx.Timeout(None),
-            limits=httpx.Limits(
-                max_connections=self.proxy_config.max_connections,
-                max_keepalive_connections=self.proxy_config.max_keepalive_connections,
-            ),
-        )
+        self._proxy_client = rock_config.http_pool_manager.get("proxy")
 
         # Replace single self.sts_client with a dict keyed by account name,
         # so /get_token?account=legacy|primary maps to the right credentials.
@@ -107,9 +95,8 @@ class SandboxProxyService:
         self._validate_oss_config_or_warn()
 
     async def aclose(self) -> None:
-        """Close both shared httpx clients. Called on proxy shutdown."""
-        await self._rpc_client.aclose()
-        await self._proxy_client.aclose()
+        """No-op: clients are now managed by HttpPoolManager and closed in lifespan."""
+        pass
 
     def _validate_oss_config_or_warn(self) -> None:
         # Same resolution order as gen_oss_sts_token: env > YAML

--- a/rock/utils/http_pool.py
+++ b/rock/utils/http_pool.py
@@ -1,0 +1,53 @@
+"""Config-driven registry of persistent httpx.AsyncClient pools.
+
+Usage:
+    pool = HttpPoolManager(rock_config.http_pools)
+    client = pool.get("probe")  # -> httpx.AsyncClient, reused on subsequent calls
+    await pool.aclose_all()     # graceful shutdown
+
+Each pool name maps to an HttpPoolConfig in RockConfig.http_pools. Clients are
+created lazily on first access and reused for the process lifetime.
+"""
+
+import httpx
+
+from rock.config import HttpPoolConfig
+from rock.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class HttpPoolManager:
+    def __init__(self, pool_configs: dict[str, HttpPoolConfig]) -> None:
+        self._configs = pool_configs
+        self._clients: dict[str, httpx.AsyncClient] = {}
+
+    def get(self, name: str) -> httpx.AsyncClient:
+        """Return the named pool's client, creating it on first access."""
+        client = self._clients.get(name)
+        if client is not None and not client.is_closed:
+            return client
+        cfg = self._configs.get(name)
+        if cfg is None:
+            cfg = HttpPoolConfig()  # sensible default
+            logger.warning(f"http pool '{name}' not configured, using defaults")
+        self._clients[name] = httpx.AsyncClient(
+            timeout=cfg.timeout,
+            limits=httpx.Limits(
+                max_connections=cfg.max_connections,
+                max_keepalive_connections=cfg.max_keepalive_connections,
+            ),
+        )
+        logger.info(
+            f"http pool '{name}' created: timeout={cfg.timeout}s, "
+            f"max_conn={cfg.max_connections}, max_keepalive={cfg.max_keepalive_connections}"
+        )
+        return self._clients[name]
+
+    async def aclose_all(self) -> None:
+        """Close all open clients. Safe to call multiple times."""
+        for name, client in self._clients.items():
+            if not client.is_closed:
+                await client.aclose()
+                logger.info(f"http pool '{name}' closed")
+        self._clients.clear()

--- a/tests/unit/admin/test_image_registry_mirror.py
+++ b/tests/unit/admin/test_image_registry_mirror.py
@@ -34,8 +34,10 @@ def _make_manager(mirrors, allowlist=None):
 def clear_probe_cache():
     """Mirror probe cache is process-local — wipe between tests to avoid cross-test leakage."""
     sandbox_api._MIRROR_PROBE_CACHE.clear()
+    sandbox_api._probe_client = None
     yield
     sandbox_api._MIRROR_PROBE_CACHE.clear()
+    sandbox_api._probe_client = None
 
 
 @pytest.fixture
@@ -118,9 +120,7 @@ async def test_registry_only_miss_falls_back_to_namespace_replace(restore_sandbo
 
 async def test_original_namespace_equals_mirror_namespace_deduplicates(restore_sandbox_manager, stub_manifest_probe):
     """When original namespace matches mirror namespace, only one candidate is probed (no redundant request)."""
-    sandbox_api.sandbox_manager = _make_manager(
-        [ImageRegistryMirror(registry="rock-a.example.com", namespace="foo")]
-    )
+    sandbox_api.sandbox_manager = _make_manager([ImageRegistryMirror(registry="rock-a.example.com", namespace="foo")])
     config = DockerDeploymentConfig(image="gcr.io/foo/python:3.11")
     stub_manifest_probe.probe_results.append(True)
 
@@ -194,7 +194,9 @@ async def test_user_credentials_cleared_when_mirror_has_no_auth(restore_sandbox_
     sandbox_api.sandbox_manager = _make_manager(
         [ImageRegistryMirror(registry="rock-a.example.com", namespace="rock-public")]
     )
-    config = DockerDeploymentConfig(image="my-registry.io/myimage:v1", registry_username="orig-user", registry_password="orig-pw")
+    config = DockerDeploymentConfig(
+        image="my-registry.io/myimage:v1", registry_username="orig-user", registry_password="orig-pw"
+    )
     stub_manifest_probe.probe_results.append(True)
 
     await sandbox_api._apply_image_registry_mirror(config)
@@ -216,7 +218,9 @@ async def test_user_credentials_replaced_by_mirror_credentials(restore_sandbox_m
             ),
         ]
     )
-    config = DockerDeploymentConfig(image="my-registry.io/myimage:v1", registry_username="orig-user", registry_password="orig-pw")
+    config = DockerDeploymentConfig(
+        image="my-registry.io/myimage:v1", registry_username="orig-user", registry_password="orig-pw"
+    )
     stub_manifest_probe.probe_results.append(True)
 
     await sandbox_api._apply_image_registry_mirror(config)
@@ -509,3 +513,34 @@ def test_image_registry_mirror_field_default_empty():
 
 def test_image_mirror_lookup_allowlist_field_default_empty():
     assert RockConfig.__dataclass_fields__["image_mirror_lookup_allowlist"].default_factory() == []
+
+
+def test_get_probe_client_returns_same_instance():
+    """_get_probe_client must return the same client on repeated calls (pool reuse)."""
+    c1 = sandbox_api._get_probe_client()
+    c2 = sandbox_api._get_probe_client()
+    assert c1 is c2
+
+
+def test_get_probe_client_creates_new_when_closed():
+    """If the cached client is closed, _get_probe_client must create a fresh one."""
+    c1 = sandbox_api._get_probe_client()
+    # Simulate close (sync is fine — httpx.AsyncClient.is_closed flips True)
+    c1._transport._pool._max_connections = 0  # sanity: it's an AsyncClient
+    import asyncio
+
+    asyncio.get_event_loop().run_until_complete(c1.aclose())
+    assert c1.is_closed
+
+    c2 = sandbox_api._get_probe_client()
+    assert c2 is not c1
+    assert not c2.is_closed
+
+
+def test_get_probe_client_pool_limits():
+    """Connection pool limits must match the configured values (300 global)."""
+    client = sandbox_api._get_probe_client()
+    limits = client._transport._pool._max_connections
+    keepalive = client._transport._pool._max_keepalive_connections
+    assert limits == 300
+    assert keepalive == 300

--- a/tests/unit/admin/test_image_registry_mirror.py
+++ b/tests/unit/admin/test_image_registry_mirror.py
@@ -21,11 +21,14 @@ def _make_manager(mirrors, allowlist=None):
     Default allowlist is ``["*"]`` so callers that don't care about the gate
     keep the legacy "check every image" semantics.
     """
+    pool_manager = MagicMock()
+    pool_manager.get.return_value = MagicMock()
     return SimpleNamespace(
         rock_config=SimpleNamespace(
             image_registry_mirrors=mirrors,
             image_mirror_lookup_allowlist=["*"] if allowlist is None else allowlist,
             nacos_provider=None,
+            http_pool_manager=pool_manager,
         )
     )
 
@@ -34,10 +37,8 @@ def _make_manager(mirrors, allowlist=None):
 def clear_probe_cache():
     """Mirror probe cache is process-local — wipe between tests to avoid cross-test leakage."""
     sandbox_api._MIRROR_PROBE_CACHE.clear()
-    sandbox_api._probe_client = None
     yield
     sandbox_api._MIRROR_PROBE_CACHE.clear()
-    sandbox_api._probe_client = None
 
 
 @pytest.fixture
@@ -513,25 +514,3 @@ def test_image_registry_mirror_field_default_empty():
 
 def test_image_mirror_lookup_allowlist_field_default_empty():
     assert RockConfig.__dataclass_fields__["image_mirror_lookup_allowlist"].default_factory() == []
-
-
-def test_get_probe_client_returns_same_instance():
-    """_get_probe_client must return the same client on repeated calls (pool reuse)."""
-    c1 = sandbox_api._get_probe_client()
-    c2 = sandbox_api._get_probe_client()
-    assert c1 is c2
-
-
-def test_get_probe_client_creates_new_when_closed():
-    """If the cached client is closed, _get_probe_client must create a fresh one."""
-    c1 = sandbox_api._get_probe_client()
-    # Simulate close (sync is fine — httpx.AsyncClient.is_closed flips True)
-    c1._transport._pool._max_connections = 0  # sanity: it's an AsyncClient
-    import asyncio
-
-    asyncio.get_event_loop().run_until_complete(c1.aclose())
-    assert c1.is_closed
-
-    c2 = sandbox_api._get_probe_client()
-    assert c2 is not c1
-    assert not c2.is_closed

--- a/tests/unit/admin/test_image_registry_mirror.py
+++ b/tests/unit/admin/test_image_registry_mirror.py
@@ -535,12 +535,3 @@ def test_get_probe_client_creates_new_when_closed():
     c2 = sandbox_api._get_probe_client()
     assert c2 is not c1
     assert not c2.is_closed
-
-
-def test_get_probe_client_pool_limits():
-    """Connection pool limits must match the configured values (300 global)."""
-    client = sandbox_api._get_probe_client()
-    limits = client._transport._pool._max_connections
-    keepalive = client._transport._pool._max_keepalive_connections
-    assert limits == 300
-    assert keepalive == 300

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -136,7 +136,8 @@ async def sandbox_proxy_service(
         redis_provider=redis_provider, sandbox_table=_memory_sandbox_table, rock_config=rock_config
     )
     sandbox_proxy_service = SandboxProxyService(rock_config, meta_store=meta_store)
-    return sandbox_proxy_service
+    yield sandbox_proxy_service
+    await rock_config.http_pool_manager.aclose_all()
 
 
 @pytest.fixture(scope="session")

--- a/tests/unit/sandbox/test_proxy_httpx_reuse.py
+++ b/tests/unit/sandbox/test_proxy_httpx_reuse.py
@@ -23,9 +23,10 @@ async def test_metrics_monitor_has_worker_pid_tag(sandbox_proxy_service):
 
 
 @pytest.mark.asyncio
-async def test_aclose_closes_both_clients(sandbox_proxy_service):
+async def test_aclose_closes_both_clients(sandbox_proxy_service, rock_config):
     svc = sandbox_proxy_service
-    await svc.aclose()
+    # Clients are now managed by HttpPoolManager, not SandboxProxyService.aclose()
+    await rock_config.http_pool_manager.aclose_all()
     assert svc._rpc_client.is_closed
     assert svc._proxy_client.is_closed
 

--- a/tests/unit/utils/test_http_pool.py
+++ b/tests/unit/utils/test_http_pool.py
@@ -1,0 +1,93 @@
+"""Tests for HttpPoolManager."""
+
+from rock.config import HttpPoolConfig
+from rock.utils.http_pool import HttpPoolManager
+
+
+def test_http_pool_manager_get_creates_client():
+    """get() should create a client on first access."""
+    configs = {"probe": HttpPoolConfig(timeout=5.0, max_connections=100, max_keepalive_connections=20)}
+    manager = HttpPoolManager(configs)
+
+    client = manager.get("probe")
+
+    assert client is not None
+    assert not client.is_closed
+
+
+def test_http_pool_manager_get_reuses_client():
+    """get() should return the same client on repeated calls."""
+    configs = {"probe": HttpPoolConfig(timeout=5.0, max_connections=100, max_keepalive_connections=20)}
+    manager = HttpPoolManager(configs)
+
+    c1 = manager.get("probe")
+    c2 = manager.get("probe")
+
+    assert c1 is c2
+
+
+async def test_http_pool_manager_get_creates_new_when_closed():
+    """If the cached client is closed, get() should create a fresh one."""
+    configs = {"probe": HttpPoolConfig(timeout=5.0, max_connections=100, max_keepalive_connections=20)}
+    manager = HttpPoolManager(configs)
+
+    c1 = manager.get("probe")
+    await c1.aclose()
+    assert c1.is_closed
+
+    c2 = manager.get("probe")
+    assert c2 is not c1
+    assert not c2.is_closed
+
+
+def test_http_pool_manager_get_with_missing_config():
+    """get() should use defaults when pool name is not configured."""
+    configs = {}
+    manager = HttpPoolManager(configs)
+
+    client = manager.get("unknown")
+
+    assert client is not None
+    assert not client.is_closed
+
+
+async def test_http_pool_manager_aclose_all():
+    """aclose_all() should close all open clients."""
+    configs = {
+        "probe": HttpPoolConfig(timeout=5.0, max_connections=100, max_keepalive_connections=20),
+        "rpc": HttpPoolConfig(timeout=180.0, max_connections=500, max_keepalive_connections=100),
+    }
+    manager = HttpPoolManager(configs)
+
+    c1 = manager.get("probe")
+    c2 = manager.get("rpc")
+    assert not c1.is_closed
+    assert not c2.is_closed
+
+    await manager.aclose_all()
+
+    assert c1.is_closed
+    assert c2.is_closed
+    assert len(manager._clients) == 0
+
+
+async def test_http_pool_manager_aclose_all_idempotent():
+    """aclose_all() should be safe to call multiple times."""
+    configs = {"probe": HttpPoolConfig(timeout=5.0, max_connections=100, max_keepalive_connections=20)}
+    manager = HttpPoolManager(configs)
+
+    manager.get("probe")
+
+    await manager.aclose_all()
+    await manager.aclose_all()
+
+    assert len(manager._clients) == 0
+
+
+def test_http_pool_config_custom_values():
+    """HttpPoolConfig should accept custom values."""
+    config = HttpPoolConfig(timeout=30.0, max_connections=500, max_keepalive_connections=100)
+
+    assert config.timeout == 30.0
+    assert config.max_connections == 500
+    assert config.max_keepalive_connections == 100


### PR DESCRIPTION
closes #1204

## Summary
Replace per-call `httpx.AsyncClient` in `_http_probe_manifest` with a process-lifetime shared client to avoid repeated TLS handshakes and TCP connection setup on every registry probe.

## Key changes
- Add module-level `_probe_client` with lazy init via `_get_probe_client()`
- Configure connection pool: `max_connections=300`, `max_keepalive_connections=300`
- Drop unused `timeout` parameter from `_http_probe_manifest` signature
- Reset `_probe_client` in test fixture to prevent cross-test leakage
- Add 2 tests: client reuse, closed-client recovery