### PR TITLE
fix(rocklet): skip bash installation when already present in musl containers

### DIFF
--- a/rock/rocklet/local_files/docker_run.sh
+++ b/rock/rocklet/local_files/docker_run.sh
@@ -77,7 +77,7 @@ if [ "$(is_musl)" = "true" ]; then
     fi
 
     sed -i "s|https://.*alpinelinux.org|https://mirrors.aliyun.com|g" /etc/apk/repositories
-    apk add bash
+    command -v bash >/dev/null 2>&1 || apk add bash
     apk add --allow-untrusted --force-overwrite /tmp/local_files/alpine_glibc/*.apk
     mkdir -p /lib64
     ln -sf /usr/glibc-compat/lib/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2


### PR DESCRIPTION
close #1206 

On customized Alpine images with a corrupted APK database, `apk add bash` returns a non-zero exit code even though bash is already installed. Combined with `set -o errexit`, this causes docker_run.sh to exit before installing the glibc compatibility layer or starting rocklet.