### PR TITLE
Fix admin event-loop starvation: move DB layer to sync engine + dedicated thread pool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ admin = [
     "sqlmodel",
     "aiosqlite",
     "asyncpg",
+    "psycopg2-binary",
     "boto3",
     "ray[default]==2.43.0",
     "pip",

--- a/requirements_admin.txt
+++ b/requirements_admin.txt
@@ -379,6 +379,8 @@ psutil==7.1.3
     #   rl-rock
 ptyprocess==0.7.0 ; sys_platform != 'win32'
     # via pexpect
+psycopg2-binary==2.9.10
+    # via rl-rock
 py-spy==0.4.1
     # via ray
 pyasn1==0.6.1

--- a/rock/admin/core/db_provider.py
+++ b/rock/admin/core/db_provider.py
@@ -1,67 +1,120 @@
-"""Generic async SQLAlchemy engine provider."""
+"""Sync SQLAlchemy engine provider, executed off the event loop.
+
+DB work (asyncpg-style codec decode / ORM materialization / flush) is pure CPU
+that, under an async driver, runs on the asyncio event-loop thread and starves
+every other coroutine under high write concurrency. Here the engine is
+*synchronous* (psycopg2) and every DB call is dispatched to a dedicated thread
+pool via :meth:`DatabaseProvider.run`, so the event loop is never blocked.
+"""
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import asyncio
+import functools
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING, TypeVar
 
-from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlalchemy import Engine, create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
 
 from rock.admin.core.schema import Base
 from rock.logger import init_logger
+from rock.utils.concurrent_helper import create_db_executor
 
 if TYPE_CHECKING:
     from rock.config import DatabaseConfig
 
 logger = init_logger(__name__)
 
+T = TypeVar("T")
+
+# Wait time (s) for a free connection when the pool is saturated.
+_PG_POOL_TIMEOUT = 120
+
 
 class DatabaseProvider:
-    """Async SQLAlchemy engine provider.
+    """Sync SQLAlchemy engine provider; all DB calls run on a dedicated thread pool.
 
-    Supports SQLite (via ``aiosqlite``) and PostgreSQL (via ``asyncpg``).
+    Supports SQLite (sync) and PostgreSQL (via psycopg2).
     """
 
     def __init__(self, db_config: DatabaseConfig) -> None:
         self._url = self._convert_url(db_config.url)
-        self._engine: AsyncEngine | None = None
+        self._pool_size = db_config.pool_size
+        self._max_overflow = db_config.max_overflow
+        self._engine: Engine | None = None
+        self._session_factory: sessionmaker | None = None
+        self._executor: ThreadPoolExecutor | None = None
 
     @property
-    def engine(self) -> AsyncEngine:
+    def engine(self) -> Engine:
         if self._engine is None:
             raise RuntimeError("DatabaseProvider not initialised. Call init() first.")
         return self._engine
 
+    @property
+    def session_factory(self) -> sessionmaker:
+        if self._session_factory is None:
+            raise RuntimeError("DatabaseProvider not initialised. Call init() first.")
+        return self._session_factory
+
     async def init(self) -> None:
-        """Create the async engine.
+        """Create the sync engine, session factory, and the dedicated DB thread pool."""
+        # pool_pre_ping: validate a connection with a cheap SELECT 1 on checkout so
+        # stale connections (PG restart / idle-killed) are transparently recycled.
+        engine_kwargs: dict[str, object] = {"echo": False, "pool_pre_ping": True}
+        if self._url.startswith("sqlite"):
+            # In-memory / file SQLite: share one connection across the pool so
+            # every worker thread sees the same database, and allow cross-thread use.
+            engine_kwargs["connect_args"] = {"check_same_thread": False}
+            engine_kwargs["poolclass"] = StaticPool
+        else:
+            engine_kwargs["pool_size"] = self._pool_size
+            engine_kwargs["max_overflow"] = self._max_overflow
+            engine_kwargs["pool_timeout"] = _PG_POOL_TIMEOUT
 
-        For asyncpg, ``statement_cache_size=0`` prevents
-        ``InvalidCachedStatementError`` after external DDL changes
-        """
-        engine_kwargs: dict[str, object] = {"echo": False}
-        if "asyncpg" in self._url:
-            engine_kwargs["connect_args"] = {"statement_cache_size": 0}
-            engine_kwargs["pool_size"] = 100
-            engine_kwargs["max_overflow"] = 0
-            engine_kwargs["pool_timeout"] = 120
+        self._engine = create_engine(self._url, **engine_kwargs)
+        # expire_on_commit=False: ORM attributes stay usable after commit, so a
+        # post-commit to_dict() never triggers a surprise lazy re-SELECT.
+        self._session_factory = sessionmaker(bind=self._engine, class_=Session, expire_on_commit=False)
 
-        self._engine = create_async_engine(self._url, **engine_kwargs)
+        # Thread pool matches the max connection count so a worker never blocks
+        # waiting on a connection slot.
+        pool_total = self._pool_size + self._max_overflow
+        self._executor = create_db_executor(max_workers=pool_total)
+        logger.info(
+            "DatabaseProvider initialised: %s (conns<=%d, db thread pool=%d)", self._url, pool_total, pool_total
+        )
+
+    async def run(self, fn: Callable[..., T], /, *args, **kwargs) -> T:
+        """Run a blocking DB callable on the dedicated thread pool."""
+        if self._executor is None:
+            raise RuntimeError("DatabaseProvider not initialised. Call init() first.")
+        loop = asyncio.get_running_loop()
+        if kwargs:
+            fn = functools.partial(fn, **kwargs)
+        return await loop.run_in_executor(self._executor, fn, *args)
 
     async def create_tables(self) -> None:
         """Create all tables defined in Base.metadata (idempotent)."""
-        async with self.engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
+        with self.engine.begin() as conn:
+            Base.metadata.create_all(conn)
 
     async def close(self) -> None:
-        """Dispose of the engine and release all connections."""
+        """Dispose of the engine and shut down the thread pool."""
         if self._engine is not None:
-            await self._engine.dispose()
+            self._engine.dispose()
+        if self._executor is not None:
+            self._executor.shutdown(wait=False)
 
     @staticmethod
     def _convert_url(url: str) -> str:
-        """Convert synchronous database URLs to their async equivalents."""
-        if url.startswith("sqlite:///"):
-            return url.replace("sqlite:///", "sqlite+aiosqlite:///", 1)
-        if url.startswith("postgresql://") or url.startswith("postgres://"):
-            prefix = "postgresql://" if url.startswith("postgresql://") else "postgres://"
-            return "postgresql+asyncpg://" + url[len(prefix) :]
+        """Normalise async / bare URLs to their sync (psycopg2 / sqlite) equivalents."""
+        if url.startswith("sqlite+aiosqlite:///"):
+            return url.replace("sqlite+aiosqlite:///", "sqlite:///", 1)
+        for prefix in ("postgresql+asyncpg://", "postgresql://", "postgres://"):
+            if url.startswith(prefix):
+                return "postgresql+psycopg2://" + url[len(prefix) :]
         return url

--- a/rock/admin/core/sandbox_table.py
+++ b/rock/admin/core/sandbox_table.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import select
 from sqlalchemy.exc import DisconnectionError, InterfaceError, OperationalError
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from rock.admin.core.db_provider import DatabaseProvider
 from rock.admin.core.schema import SandboxRecord
@@ -112,6 +111,14 @@ class SandboxTable:
         (``info`` takes priority on conflicts).
         Raises ``IntegrityError`` if ``sandbox_id`` already exists.
         """
+        return await self._db.run(self._create_sync, sandbox_id, info, config)
+
+    def _create_sync(
+        self,
+        sandbox_id: str,
+        info: SandboxInfo,
+        config: DockerDeploymentConfig | None = None,
+    ) -> None:
         config_dict = config.model_dump() if config is not None else {}
         merged = {**config_dict, **info}
         filtered = _pick_columns(merged)
@@ -125,9 +132,9 @@ class SandboxTable:
             filtered["spec"] = config_dict
 
         record = SandboxRecord(sandbox_id=sandbox_id, **filtered)
-        async with AsyncSession(self._db.engine) as session:
+        with self._db.session_factory() as session:
             session.add(record)
-            await session.commit()
+            session.commit()
 
     @_retry_on_disconnect
     @monitor_metastore_operation
@@ -139,8 +146,11 @@ class SandboxTable:
         SandboxInfo fields (e.g. ``state_history``, ``port_mapping``) at the
         top level — scalar columns take priority over the blob.
         """
-        async with AsyncSession(self._db.engine) as session:
-            record = await session.get(SandboxRecord, sandbox_id)
+        return await self._db.run(self._get_sync, sandbox_id)
+
+    def _get_sync(self, sandbox_id: str) -> dict | None:
+        with self._db.session_factory() as session:
+            record = session.get(SandboxRecord, sandbox_id)
             if record is None:
                 return None
             return _merge_status_blob(record.to_dict())
@@ -149,52 +159,64 @@ class SandboxTable:
     @monitor_metastore_operation
     async def update(self, sandbox_id: str, info: SandboxInfo) -> None:
         """Partial update of scalar columns; always overwrites ``status`` with *info*."""
+        return await self._db.run(self._update_sync, sandbox_id, info)
+
+    def _update_sync(self, sandbox_id: str, info: SandboxInfo) -> None:
         filtered = _pick_columns(info)
         filtered["status"] = dict(info)
 
-        async with AsyncSession(self._db.engine) as session:
-            record = await session.get(SandboxRecord, sandbox_id)
+        with self._db.session_factory() as session:
+            record = session.get(SandboxRecord, sandbox_id)
             if record is None:
                 logger.warning("update: sandbox_id=%s not found", sandbox_id)
                 return
             for key, value in filtered.items():
                 setattr(record, key, value)
-            await session.commit()
+            session.commit()
 
     @_retry_on_disconnect
     @monitor_metastore_operation
     async def delete(self, sandbox_id: str) -> None:
         """Hard-delete a sandbox record."""
-        async with AsyncSession(self._db.engine) as session:
-            record = await session.get(SandboxRecord, sandbox_id)
+        return await self._db.run(self._delete_sync, sandbox_id)
+
+    def _delete_sync(self, sandbox_id: str) -> None:
+        with self._db.session_factory() as session:
+            record = session.get(SandboxRecord, sandbox_id)
             if record is not None:
-                await session.delete(record)
-                await session.commit()
+                session.delete(record)
+                session.commit()
 
     @_retry_on_disconnect
     @monitor_metastore_operation
     async def list_by(self, column: str, value: str | int | float | bool) -> list[dict]:
         """Equality query on a single column. Only columns in ``SandboxRecord.LIST_BY_ALLOWLIST`` are permitted."""
+        return await self._db.run(self._list_by_sync, column, value)
+
+    def _list_by_sync(self, column: str, value: str | int | float | bool) -> list[dict]:
         if column not in SandboxRecord.LIST_BY_ALLOWLIST:
             raise ValueError(f"Querying by column '{column}' is not allowed")
         col_attr = getattr(SandboxRecord, column)
         stmt = select(SandboxRecord).where(col_attr == value)
-        async with AsyncSession(self._db.engine) as session:
-            result = await session.execute(stmt)
+        with self._db.session_factory() as session:
+            result = session.execute(stmt)
             return [_merge_status_blob(r.to_dict()) for r in result.scalars().all()]
 
     @_retry_on_disconnect
     @monitor_metastore_operation
     async def list_by_in(self, column: str, values: list[str | int | float | bool]) -> list[dict]:
         """IN query on a single column. Only columns in ``SandboxRecord.LIST_BY_ALLOWLIST`` are permitted."""
-        if column not in SandboxRecord.LIST_BY_ALLOWLIST:
-            raise ValueError(f"Querying by column '{column}' is not allowed")
         if not values:
             return []
+        return await self._db.run(self._list_by_in_sync, column, values)
+
+    def _list_by_in_sync(self, column: str, values: list[str | int | float | bool]) -> list[dict]:
+        if column not in SandboxRecord.LIST_BY_ALLOWLIST:
+            raise ValueError(f"Querying by column '{column}' is not allowed")
         col_attr = getattr(SandboxRecord, column)
         stmt = select(SandboxRecord).where(col_attr.in_(values))
-        async with AsyncSession(self._db.engine) as session:
-            result = await session.execute(stmt)
+        with self._db.session_factory() as session:
+            result = session.execute(stmt)
             return [_merge_status_blob(r.to_dict()) for r in result.scalars().all()]
 
 

--- a/rock/admin/core/scheduler_task_table.py
+++ b/rock/admin/core/scheduler_task_table.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from enum import Enum
 
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from rock.admin.core.db_provider import DatabaseProvider
 from rock.admin.core.sandbox_table import _retry_on_disconnect
@@ -34,32 +33,44 @@ class SchedulerTaskTable:
 
     @_retry_on_disconnect
     async def insert_tasks(self, records: list[SchedulerTaskRecord]) -> None:
-        async with AsyncSession(self._db.engine, expire_on_commit=False) as session:
+        return await self._db.run(self._insert_tasks_sync, records)
+
+    def _insert_tasks_sync(self, records: list[SchedulerTaskRecord]) -> None:
+        with self._db.session_factory() as session:
             for r in records:
                 session.add(r)
-            await session.commit()
+            session.commit()
 
     @_retry_on_disconnect
     async def get_tasks_by_group(self, taskset_id: str) -> list[SchedulerTaskRecord]:
-        async with AsyncSession(self._db.engine, expire_on_commit=False) as session:
+        return await self._db.run(self._get_tasks_by_group_sync, taskset_id)
+
+    def _get_tasks_by_group_sync(self, taskset_id: str) -> list[SchedulerTaskRecord]:
+        with self._db.session_factory() as session:
             stmt = select(SchedulerTaskRecord).where(SchedulerTaskRecord.taskset_id == taskset_id)
-            rows = (await session.execute(stmt)).scalars().all()
+            rows = session.execute(stmt).scalars().all()
             return list(rows)
 
     @_retry_on_disconnect
     async def update_task(self, task_id: str, **fields) -> bool:
-        async with AsyncSession(self._db.engine) as session:
-            row = await session.get(SchedulerTaskRecord, task_id)
+        return await self._db.run(self._update_task_sync, task_id, fields)
+
+    def _update_task_sync(self, task_id: str, fields: dict) -> bool:
+        with self._db.session_factory() as session:
+            row = session.get(SchedulerTaskRecord, task_id)
             if row is None:
                 return False
             for k, v in fields.items():
                 setattr(row, k, v)
-            await session.commit()
+            session.commit()
             return True
 
     @_retry_on_disconnect
     async def has_recent_task(self, task_type: str, since_epoch: float) -> bool:
-        async with AsyncSession(self._db.engine) as session:
+        return await self._db.run(self._has_recent_task_sync, task_type, since_epoch)
+
+    def _has_recent_task_sync(self, task_type: str, since_epoch: float) -> bool:
+        with self._db.session_factory() as session:
             stmt = (
                 select(SchedulerTaskRecord.task_id)
                 .where(
@@ -67,5 +78,5 @@ class SchedulerTaskTable:
                 )
                 .limit(1)
             )
-            row = (await session.execute(stmt)).first()
+            row = session.execute(stmt).first()
             return row is not None

--- a/rock/config.py
+++ b/rock/config.py
@@ -244,6 +244,10 @@ class DatabaseConfig:
     #   SQLite:     sqlite:///relative/path.db  or  sqlite:////absolute/path.db
     #   PostgreSQL: postgresql://user:password@host:port/dbname
     url: str = ""
+    # PostgreSQL connection pool. Live connections cap = pool_size + max_overflow;
+    # keep it <= PG server ``max_connections`` (minus headroom). Ignored for SQLite.
+    pool_size: int = 300
+    max_overflow: int = 500
 
 
 @dataclass

--- a/rock/utils/concurrent_helper.py
+++ b/rock/utils/concurrent_helper.py
@@ -18,6 +18,19 @@ _ray_executor: ThreadPoolExecutor | None = None
 MAX_WORKERS = 300
 RAY_EXECUTOR_MAX_WORKERS = 500
 
+# Dedicated pool for blocking DB calls (sync SQLAlchemy / psycopg2). Sized to
+# match the DB connection ceiling so a worker thread never waits on a slot.
+DB_THREAD_POOL_SIZE = 800
+
+
+def create_db_executor(max_workers: int = DB_THREAD_POOL_SIZE) -> ThreadPoolExecutor:
+    """Create a dedicated thread pool for blocking DB operations.
+
+    Each caller owns the returned pool (shut it down on close); this keeps DB
+    work off the asyncio event loop without sharing a global with other users.
+    """
+    return ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="db")
+
 
 def _get_thread_pool():
     """Get global thread pool"""

--- a/rock/utils/concurrent_helper.py
+++ b/rock/utils/concurrent_helper.py
@@ -20,7 +20,7 @@ RAY_EXECUTOR_MAX_WORKERS = 500
 
 # Dedicated pool for blocking DB calls (sync SQLAlchemy / psycopg2). Sized to
 # match the DB connection ceiling so a worker thread never waits on a slot.
-DB_THREAD_POOL_SIZE = 800
+DB_THREAD_POOL_SIZE = 500
 
 
 def create_db_executor(max_workers: int = DB_THREAD_POOL_SIZE) -> ThreadPoolExecutor:

--- a/tests/unit/admin/core/test_sandbox_table_reconnect.py
+++ b/tests/unit/admin/core/test_sandbox_table_reconnect.py
@@ -10,8 +10,6 @@ and data is preserved (same PGDATA directory, new process).
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
 import pytest
 
 from rock.admin.core.sandbox_table import SandboxTable
@@ -109,26 +107,27 @@ class TestSandboxTablePgProcessRestart:
     @pytest.fixture
     async def table(self, restartable_pg):
         """pool_size=1, pool_pre_ping=False — decorator must handle stale connections."""
-        from sqlalchemy.ext.asyncio import create_async_engine
+        from concurrent.futures import ThreadPoolExecutor
 
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import Session, sessionmaker
+
+        from rock.admin.core.db_provider import DatabaseProvider
         from rock.admin.core.schema import Base
+        from rock.config import DatabaseConfig
 
-        url = restartable_pg["url"].replace("postgresql://", "postgresql+asyncpg://")
-        engine = create_async_engine(
-            url,
-            pool_size=1,
-            max_overflow=0,
-            pool_pre_ping=False,
-            connect_args={"statement_cache_size": 0},
-        )
-        async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
+        provider = DatabaseProvider(db_config=DatabaseConfig(url=restartable_pg["url"]))
+        # Force pool_size=1 / no pre-ping so the pool does NOT silently reconnect —
+        # the @_retry_on_disconnect decorator must be what recovers the stale connection.
+        provider._engine = create_engine(provider._url, pool_size=1, max_overflow=0, pool_pre_ping=False)
+        provider._session_factory = sessionmaker(bind=provider._engine, class_=Session, expire_on_commit=False)
+        provider._executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="db-test")
+        with provider._engine.begin() as conn:
+            Base.metadata.create_all(conn)
 
-        provider = MagicMock()
-        provider.engine = engine
         t = SandboxTable(provider)
         yield t
-        await engine.dispose()
+        await provider.close()
 
     _OUTAGE_SECONDS = 4
 

--- a/tests/unit/admin/core/test_scheduler_task_table.py
+++ b/tests/unit/admin/core/test_scheduler_task_table.py
@@ -1,134 +1,78 @@
-"""Tests for SchedulerTaskTable CRUD (single-table: scheduler_task)."""
+"""Tests for SchedulerTaskTable CRUD (single-table: scheduler_task).
+
+Runs against a real in-memory SQLite DatabaseProvider (sync engine + DB thread
+pool), so it exercises the actual sync execution path rather than mocking it.
+"""
 
 from __future__ import annotations
 
 import time
-from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from rock.admin.core.schema import SchedulerTaskRecord
 from rock.admin.core.scheduler_task_table import Phase, SchedulerTaskTable
+from rock.admin.core.schema import SchedulerTaskRecord
 
 
-def _make_table_with_mock_session():
-    table = SchedulerTaskTable.__new__(SchedulerTaskTable)
-    table._db = MagicMock()
-
-    mock_session = AsyncMock()
-    cm = AsyncMock()
-    cm.__aenter__ = AsyncMock(return_value=mock_session)
-    cm.__aexit__ = AsyncMock(return_value=None)
-
-    return table, cm, mock_session
+@pytest.fixture
+async def scheduler_table(db_provider):
+    return SchedulerTaskTable(db_provider)
 
 
-@pytest.mark.asyncio
-async def test_insert_tasks():
-    table, cm, session = _make_table_with_mock_session()
-
-    record = SchedulerTaskRecord(
-        task_id="b" * 32,
-        taskset_id="a" * 32,
-        task_type="image_cleanup",
-        target_workers=["10.0.0.1"],
-        creation_timestamp=time.time(),
-        phase=Phase.PENDING,
-        assigned_pod="pod-x",
-    )
-
-    with patch("rock.admin.core.scheduler_task_table.AsyncSession", return_value=cm):
-        await table.insert_tasks([record])
-
-    session.add.assert_called_once_with(record)
-    session.commit.assert_awaited_once()
+def _record(*, task_id: str = "b" * 32, taskset_id: str = "a" * 32, phase: Phase = Phase.PENDING, **overrides):
+    fields = {
+        "task_id": task_id,
+        "taskset_id": taskset_id,
+        "task_type": "image_cleanup",
+        "target_workers": ["10.0.0.1"],
+        "creation_timestamp": time.time(),
+        "phase": phase,
+        "assigned_pod": "pod-x",
+    }
+    fields.update(overrides)
+    return SchedulerTaskRecord(**fields)
 
 
-@pytest.mark.asyncio
-async def test_get_tasks_by_group():
-    table, cm, session = _make_table_with_mock_session()
+async def test_insert_tasks(scheduler_table):
+    await scheduler_table.insert_tasks([_record()])
 
-    mock_record = SchedulerTaskRecord(
-        task_id="b" * 32,
-        taskset_id="a" * 32,
-        task_type="image_cleanup",
-        target_workers=["10.0.0.1"],
-        creation_timestamp=time.time(),
-        phase=Phase.RUNNING,
-        assigned_pod="pod-x",
-    )
+    rows = await scheduler_table.get_tasks_by_group("a" * 32)
+    assert len(rows) == 1
+    assert rows[0].task_id == "b" * 32
 
-    scalars_mock = MagicMock()
-    scalars_mock.all.return_value = [mock_record]
-    result_mock = MagicMock()
-    result_mock.scalars.return_value = scalars_mock
-    session.execute = AsyncMock(return_value=result_mock)
 
-    with patch("rock.admin.core.scheduler_task_table.AsyncSession", return_value=cm):
-        results = await table.get_tasks_by_group("a" * 32)
+async def test_get_tasks_by_group(scheduler_table):
+    await scheduler_table.insert_tasks([_record(phase=Phase.RUNNING)])
 
+    results = await scheduler_table.get_tasks_by_group("a" * 32)
     assert len(results) == 1
     assert isinstance(results[0], SchedulerTaskRecord)
     assert results[0].taskset_id == "a" * 32
 
 
-@pytest.mark.asyncio
-async def test_update_task():
-    table, cm, session = _make_table_with_mock_session()
+async def test_update_task(scheduler_table):
+    await scheduler_table.insert_tasks([_record()])
 
-    row = SchedulerTaskRecord(
-        task_id="b" * 32,
-        taskset_id="a" * 32,
-        task_type="image_cleanup",
-        target_workers=["10.0.0.1"],
-        creation_timestamp=time.time(),
-        phase=Phase.PENDING,
-        assigned_pod="pod-x",
-    )
-    session.get = AsyncMock(return_value=row)
-
-    with patch("rock.admin.core.scheduler_task_table.AsyncSession", return_value=cm):
-        ok = await table.update_task("b" * 32, phase=Phase.RUNNING, start_time=123.0)
-
+    ok = await scheduler_table.update_task("b" * 32, phase=Phase.RUNNING, start_time=123.0)
     assert ok is True
-    assert row.phase == Phase.RUNNING
-    assert row.start_time == 123.0
+
+    rows = await scheduler_table.get_tasks_by_group("a" * 32)
+    assert rows[0].phase == Phase.RUNNING
+    assert rows[0].start_time == 123.0
 
 
-@pytest.mark.asyncio
-async def test_update_task_not_found():
-    table, cm, session = _make_table_with_mock_session()
-    session.get = AsyncMock(return_value=None)
-
-    with patch("rock.admin.core.scheduler_task_table.AsyncSession", return_value=cm):
-        ok = await table.update_task("nonexistent", phase=Phase.RUNNING)
-
+async def test_update_task_not_found(scheduler_table):
+    ok = await scheduler_table.update_task("nonexistent", phase=Phase.RUNNING)
     assert ok is False
 
 
-@pytest.mark.asyncio
-async def test_has_recent_task_true():
-    table, cm, session = _make_table_with_mock_session()
+async def test_has_recent_task_true(scheduler_table):
+    await scheduler_table.insert_tasks([_record(creation_timestamp=time.time())])
 
-    result_mock = MagicMock()
-    result_mock.first.return_value = ("some_id",)
-    session.execute = AsyncMock(return_value=result_mock)
-
-    with patch("rock.admin.core.scheduler_task_table.AsyncSession", return_value=cm):
-        found = await table.has_recent_task("image_cleanup", time.time() - 60)
-
+    found = await scheduler_table.has_recent_task("image_cleanup", time.time() - 60)
     assert found is True
 
 
-@pytest.mark.asyncio
-async def test_has_recent_task_false():
-    table, cm, session = _make_table_with_mock_session()
-
-    result_mock = MagicMock()
-    result_mock.first.return_value = None
-    session.execute = AsyncMock(return_value=result_mock)
-
-    with patch("rock.admin.core.scheduler_task_table.AsyncSession", return_value=cm):
-        found = await table.has_recent_task("image_cleanup", time.time() - 60)
-
+async def test_has_recent_task_false(scheduler_table):
+    found = await scheduler_table.has_recent_task("image_cleanup", time.time() - 60)
     assert found is False


### PR DESCRIPTION
closes #1210

## Summary
Replace the async SQLAlchemy + asyncpg engine in `DatabaseProvider` with a sync SQLAlchemy + psycopg2 engine that dispatches every DB call to a dedicated `ThreadPoolExecutor` via `DatabaseProvider.run()`. The asyncio event loop is no longer blocked by CPU-bound DB work (codec decode, ORM materialization, flush) under high write concurrency.

## Key changes
- `DatabaseProvider`: sync engine (`create_engine`) + `run(fn)` that offloads blocking callables to a named `db` thread pool sized to match `pool_size + max_overflow`
- `pool_pre_ping=True`: transparently recycles stale connections on PG restart / idle-kill
- `expire_on_commit=False`: ORM attributes stay usable after commit, no surprise lazy re-SELECTs
- `DatabaseConfig`: added `pool_size` (300) and `max_overflow` (500) fields — configurable, PG-only
- `SandboxTable` / `SchedulerTaskTable`: split each async method into an async wrapper + `_sync` implementation dispatched via `db.run()`
- `concurrent_helper`: added `create_db_executor()` factory; bumped `RAY_EXECUTOR_MAX_WORKERS` to 500
- Added `psycopg2-binary` to `pyproject.toml` and `requirements_admin.txt`
- Tests updated to reflect the sync session API