### PR TITLE
Proxy get_status endpoint and lazy state machine init in SandboxManager

### DIFF
--- a/rock/actions/sandbox/response.py
+++ b/rock/actions/sandbox/response.py
@@ -43,8 +43,8 @@ class IsAliveResponse(BaseModel):
 
 class SandboxStatusResponse(BaseModel):
     sandbox_id: str = None
-    status: dict = None
-    port_mapping: dict = None
+    status: dict | None = None
+    port_mapping: dict | None = None
     host_name: str | None = None
     host_ip: str | None = None
     is_alive: bool = True

--- a/rock/admin/entrypoints/sandbox_proxy_api.py
+++ b/rock/admin/entrypoints/sandbox_proxy_api.py
@@ -25,7 +25,7 @@ from rock.admin.proto.request import (
     SandboxReadFileRequest,
     SandboxWriteFileRequest,
 )
-from rock.admin.proto.response import BatchSandboxStatusResponse, SandboxListResponse
+from rock.admin.proto.response import BatchSandboxStatusResponse, SandboxListResponse, SandboxStatusResponse
 from rock.common.exception import handle_exceptions
 from rock.common.port_validation import validate_port_forward_port
 from rock.common.validation import NonBlankStr
@@ -150,6 +150,12 @@ async def close_session(request: SandboxCloseBashSessionRequest) -> RockResponse
 @handle_exceptions(error_message="get sandbox is alive failed")
 async def is_alive(sandbox_id: NonBlankStr):
     return RockResponse(result=await sandbox_proxy_service.is_alive(sandbox_id))
+
+
+@sandbox_proxy_router.get("/get_status")
+@handle_exceptions(error_message="get sandbox status failed")
+async def get_status(sandbox_id: NonBlankStr, include_all_states: bool = False) -> RockResponse[SandboxStatusResponse]:
+    return RockResponse(result=await sandbox_proxy_service.get_status(sandbox_id, include_all_states))
 
 
 @sandbox_proxy_router.post("/read_file")

--- a/rock/config.py
+++ b/rock/config.py
@@ -188,6 +188,7 @@ class ArchiveAcrConfig:
 
 @dataclass
 class ArchiveConfig:
+    enabled: bool = False
     dir_storage: ArchiveDirStorageConfig = field(default_factory=ArchiveDirStorageConfig)
     acr: ArchiveAcrConfig = field(default_factory=ArchiveAcrConfig)
     scan_interval_sec: int = 30

--- a/rock/config.py
+++ b/rock/config.py
@@ -450,7 +450,7 @@ class RockConfig:
         default_factory=lambda: {
             "probe": HttpPoolConfig(timeout=5.0, max_connections=300, max_keepalive_connections=300),
             "rpc": HttpPoolConfig(timeout=180.0, max_connections=500, max_keepalive_connections=100),
-            "proxy": HttpPoolConfig(timeout=None, max_connections=500, max_keepalive_connections=100),
+            "proxy": HttpPoolConfig(timeout=None, max_connections=100, max_keepalive_connections=50),
         }
     )
     http_pool_manager: Any = field(default=None, init=False, repr=False)

--- a/rock/config.py
+++ b/rock/config.py
@@ -188,7 +188,6 @@ class ArchiveAcrConfig:
 
 @dataclass
 class ArchiveConfig:
-    enabled: bool = False
     dir_storage: ArchiveDirStorageConfig = field(default_factory=ArchiveDirStorageConfig)
     acr: ArchiveAcrConfig = field(default_factory=ArchiveAcrConfig)
     scan_interval_sec: int = 30

--- a/rock/sandbox/operator/ray.py
+++ b/rock/sandbox/operator/ray.py
@@ -2,23 +2,20 @@ import json
 
 import ray
 
-from rock import env_vars
-from rock.actions.sandbox.response import IsAliveResponse, State
+from rock.actions.sandbox.response import State
 from rock.actions.sandbox.sandbox_info import SandboxInfo
 from rock.admin.core.ray_service import RayService
 from rock.common.constants import StopReason
 from rock.config import RuntimeConfig
 from rock.deployments.config import DockerDeploymentConfig
-from rock.deployments.constants import Port
 from rock.deployments.docker import DockerDeployment
-from rock.deployments.status import PersistedServiceStatus, ServiceStatus
+from rock.deployments.status import ServiceStatus
 from rock.logger import init_logger
 from rock.sandbox.operator.abstract import AbstractOperator
 from rock.sandbox.sandbox_actor import SandboxActor
+from rock.sandbox.utils.rocklet_probe import check_alive_status, get_remote_status
 from rock.sdk.common.exceptions import BadRequestRockError
-from rock.utils import EAGLE_EYE_TRACE_ID, trace_id_ctx_var
 from rock.utils.format import parse_size_to_bytes
-from rock.utils.http import HttpUtils
 from rock.utils.service import build_sandbox_from_redis
 
 logger = init_logger(__name__)
@@ -164,42 +161,7 @@ class RayOperator(AbstractOperator):
 
     async def _check_alive_status(self, sandbox_id: str, host_ip: str, remote_status: ServiceStatus) -> bool:
         """Check if sandbox is alive"""
-        try:
-            alive_resp = await HttpUtils.get(
-                url=f"http://{host_ip}:{remote_status.get_mapped_port(Port.PROXY)}/is_alive",
-                headers={
-                    "sandbox_id": sandbox_id,
-                    EAGLE_EYE_TRACE_ID: trace_id_ctx_var.get(),
-                },
-            )
-            return IsAliveResponse(**alive_resp).is_alive
-        except Exception:
-            return False
+        return await check_alive_status(sandbox_id, host_ip, remote_status)
 
     async def get_remote_status(self, sandbox_id: str, host_ip: str) -> ServiceStatus:
-        service_status_path = PersistedServiceStatus.gen_service_status_path(sandbox_id)
-        worker_rocklet_port = env_vars.ROCK_WORKER_ROCKLET_PORT if env_vars.ROCK_WORKER_ROCKLET_PORT else Port.PROXY
-        execute_url = f"http://{host_ip}:{worker_rocklet_port}/execute"
-        read_file_url = f"http://{host_ip}:{worker_rocklet_port}/read_file"
-        headers = {"sandbox_id": sandbox_id, EAGLE_EYE_TRACE_ID: trace_id_ctx_var.get()}
-        find_file_rsp = await HttpUtils.post(
-            url=execute_url,
-            headers=headers,
-            data={"command": ["ls", service_status_path], "sandbox_id": sandbox_id},
-            read_timeout=60,
-        )
-
-        # When the file does not exist, exit_code = 2
-        if find_file_rsp.get("exit_code") and find_file_rsp.get("exit_code") == 2:
-            return ServiceStatus()
-
-        response: dict = await HttpUtils.post(
-            url=read_file_url,
-            headers=headers,
-            data={"path": service_status_path, "sandbox_id": sandbox_id},
-            read_timeout=60,
-        )
-        if response.get("content"):
-            return ServiceStatus.from_content(response.get("content"))
-        logger.warning(f"{service_status_path} exists, but content is empty")
-        return ServiceStatus()
+        return await get_remote_status(sandbox_id, host_ip)

--- a/rock/sandbox/operator/ray.py
+++ b/rock/sandbox/operator/ray.py
@@ -9,7 +9,6 @@ from rock.common.constants import StopReason
 from rock.config import RuntimeConfig
 from rock.deployments.config import DockerDeploymentConfig
 from rock.deployments.docker import DockerDeployment
-from rock.deployments.status import ServiceStatus
 from rock.logger import init_logger
 from rock.sandbox.operator.abstract import AbstractOperator
 from rock.sandbox.sandbox_actor import SandboxActor
@@ -90,8 +89,8 @@ class RayOperator(AbstractOperator):
         if sandbox_info is None:
             return None
         host_ip = sandbox_info.get("host_ip")
-        remote_status = await self.get_remote_status(sandbox_id, host_ip)
-        is_alive = await self._check_alive_status(sandbox_id, host_ip, remote_status)
+        remote_status = await get_remote_status(sandbox_id, host_ip)
+        is_alive = await check_alive_status(sandbox_id, host_ip, remote_status)
         # TODO: sink update state according to is_alive logic into SandboxInfo
         if is_alive:
             sandbox_info["state"] = State.RUNNING
@@ -158,10 +157,3 @@ class RayOperator(AbstractOperator):
             sandbox_info["state"] = State.PENDING
             logger.info(f"sandbox {sandbox_id} restarted")
             return sandbox_info
-
-    async def _check_alive_status(self, sandbox_id: str, host_ip: str, remote_status: ServiceStatus) -> bool:
-        """Check if sandbox is alive"""
-        return await check_alive_status(sandbox_id, host_ip, remote_status)
-
-    async def get_remote_status(self, sandbox_id: str, host_ip: str) -> ServiceStatus:
-        return await get_remote_status(sandbox_id, host_ip)

--- a/rock/sandbox/sandbox_manager.py
+++ b/rock/sandbox/sandbox_manager.py
@@ -273,8 +273,8 @@ class SandboxManager(BaseManager):
     @monitor_sandbox_operation()
     async def get_status(self, sandbox_id, include_all_states: bool = False) -> SandboxStatusResponse:
         # get status from meta_store
-        sm = await self._get_current_statemachine(sandbox_id)
-        if sm is None:
+        sandbox_info = await self._meta_store.get(sandbox_id, check_db=True)
+        if sandbox_info is None:
             raise BadRequestRockError(f"Sandbox {sandbox_id} not found")
 
         # update status from operator
@@ -282,22 +282,25 @@ class SandboxManager(BaseManager):
         operator_sandbox_info: SandboxInfo | None = await self._operator.get_status(sandbox_id=sandbox_id)
         if operator_sandbox_info is not None:
             is_alive = operator_sandbox_info.get("state") == State.RUNNING
-            if sm.current_state.value == State.PENDING and is_alive:
+
+            # Optimization: only init state machine when PENDING→RUNNING transition needed
+            # If operator already says RUNNING, skip state machine overhead
+            if is_alive and sandbox_info.get("state") == State.PENDING:
+                sm = await self._get_current_statemachine(sandbox_id)
                 await sm.send(
                     "alive", sandbox_id=sandbox_id, meta_store=self._meta_store, sandbox_info=operator_sandbox_info
                 )
+
             if operator_sandbox_info.get("state") in (State.PENDING, State.RUNNING):
                 await self._refresh_timeout(sandbox_id)
 
         # compat with legacy get_status behavior by default (include_all_states == False),
         # raise 'not found' if not on pending or running status.
-        if not include_all_states and sm.current_state.value not in (State.PENDING, State.RUNNING):
+        if not include_all_states and sandbox_info.get("state") not in (State.PENDING, State.RUNNING):
             raise BadRequestRockError(f"Sandbox {sandbox_id} not found")
 
         if operator_sandbox_info is not None:
             sandbox_info = operator_sandbox_info
-        else:
-            sandbox_info = sm.sandbox_info
 
         return SandboxStatusResponse(
             sandbox_id=sandbox_id,
@@ -320,7 +323,7 @@ class SandboxManager(BaseManager):
             start_time=sandbox_info.get("start_time"),
             stop_time=sandbox_info.get("stop_time"),
             create_time=sandbox_info.get("create_time"),
-            state_history=sm.sandbox_info.get("state_history", []) if sm.sandbox_info else [],
+            state_history=sandbox_info.get("state_history", []),
         )
 
     async def build_sandbox_info_from_redis(self, sandbox_id: str, deployment_info: SandboxInfo) -> SandboxInfo | None:

--- a/rock/sandbox/service/sandbox_proxy_service.py
+++ b/rock/sandbox/service/sandbox_proxy_service.py
@@ -37,13 +37,16 @@ from rock.admin.proto.request import SandboxWriteFileRequest as WriteFileRequest
 from rock.admin.proto.response import SandboxListResponse, SandboxListStatusResponse, SandboxStatusResponse
 from rock.config import OssConfig, ProxyServiceConfig, RockConfig
 from rock.deployments.constants import Port
-from rock.deployments.status import ServiceStatus
+from rock.deployments.status import PersistedServiceStatus, ServiceStatus
 from rock.common.port_validation import validate_port_forward_port
 from rock.logger import init_logger
 from rock.sandbox.sandbox_meta_store import SandboxMetaStore
 from rock.sandbox.utils.proxy import build_upstream_ws_headers
 from rock.sandbox.utils.timeout import SandboxTimeoutHelper
 from rock.sdk.common.exceptions import BadRequestRockError
+from rock.rocklet import __version__ as swe_version
+from rock.sandbox import __version__ as gateway_version
+from rock.sandbox.sandbox_statemachine import SandboxStateMachine
 from rock.utils import EAGLE_EYE_TRACE_ID, trace_id_ctx_var
 
 logger = init_logger(__name__)
@@ -1013,3 +1016,133 @@ class SandboxProxyService:
             )
         finally:
             await resp.aclose()
+
+    async def _get_current_statemachine(self, sandbox_id: str) -> SandboxStateMachine | None:
+        """Fetch current state from meta store and return a restored SandboxStateMachine, or None.
+
+        Same pattern as SandboxManager._get_current_statemachine.
+        """
+        info = await self._meta_store.get(sandbox_id, check_db=True)
+        if info is None:
+            return None
+        return await SandboxStateMachine.from_state_value(info.get("state"), sandbox_info=info)
+
+    @monitor_sandbox_operation()
+    async def get_status(self, sandbox_id: str, include_all_states: bool = False) -> SandboxStatusResponse:
+        """Get sandbox status via meta_store + rocklet RPC (reuses _rpc_client pool).
+
+        Mirrors SandboxManager.get_status structure but uses rocklet RPCs instead of
+        Ray operator for live status probing. is_alive reflects rocklet responsiveness
+        (can I send traffic?) rather than container-process existence.
+        PENDING→RUNNING transition via sm.send("alive"), timeout refresh via
+        _update_expire_time. No Ray dependency.
+        """
+        sm = await self._get_current_statemachine(sandbox_id)
+        if sm is None:
+            raise BadRequestRockError(f"Sandbox {sandbox_id} not found")
+
+        sandbox_info = sm.sandbox_info or {}
+        host_ip = sandbox_info.get("host_ip")
+
+        is_alive = False
+        operator_sandbox_info = None
+        if host_ip and sm.current_state.value in (State.RUNNING, State.PENDING):
+            remote_status = await self._get_remote_status(sandbox_id, host_ip)
+            is_alive = await self._check_alive_status(sandbox_id, host_ip, remote_status)
+
+            if is_alive:
+                operator_sandbox_info = dict(sandbox_info)
+                operator_sandbox_info["state"] = State.RUNNING
+                operator_sandbox_info.update(remote_status.to_dict())
+
+            if sm.current_state.value == State.PENDING and is_alive:
+                await sm.send(
+                    "alive",
+                    sandbox_id=sandbox_id,
+                    meta_store=self._meta_store,
+                    sandbox_info=operator_sandbox_info,
+                )
+
+            if is_alive and operator_sandbox_info.get("state") in (State.PENDING, State.RUNNING):
+                await self._update_expire_time(sandbox_id)
+
+        if not include_all_states and sm.current_state.value not in (State.PENDING, State.RUNNING):
+            raise BadRequestRockError(f"Sandbox {sandbox_id} not found")
+
+        info = operator_sandbox_info if operator_sandbox_info is not None else sandbox_info
+
+        return SandboxStatusResponse(
+            sandbox_id=sandbox_id,
+            status=info.get("phases"),
+            port_mapping=info.get("port_mapping"),
+            state=info.get("state"),
+            host_name=info.get("host_name"),
+            host_ip=host_ip,
+            is_alive=is_alive,
+            image=info.get("image"),
+            swe_rex_version=swe_version,
+            gateway_version=gateway_version,
+            user_id=info.get("user_id"),
+            experiment_id=info.get("experiment_id"),
+            namespace=info.get("namespace"),
+            cpus=info.get("cpus"),
+            memory=info.get("memory"),
+            disk=info.get("disk"),
+            disk_limit_rootfs=info.get("disk"),
+            start_time=info.get("start_time"),
+            stop_time=info.get("stop_time"),
+            create_time=info.get("create_time"),
+            state_history=sm.sandbox_info.get("state_history", []) if sm.sandbox_info else [],
+        )
+
+    async def _get_remote_status(self, sandbox_id: str, host_ip: str) -> ServiceStatus:
+        """Probe rocklet for ServiceStatus (phases + port_mapping) via shared _rpc_client pool."""
+        service_status_path = PersistedServiceStatus.gen_service_status_path(sandbox_id)
+        headers = self._headers(sandbox_id)
+        rocklet_port = env_vars.ROCK_WORKER_ROCKLET_PORT if env_vars.ROCK_WORKER_ROCKLET_PORT else Port.PROXY
+        base_url = f"http://{host_ip}:{rocklet_port}"
+
+        try:
+            find_resp = await self._rpc_client.post(
+                f"{base_url}/execute",
+                headers=headers,
+                json={"command": ["ls", service_status_path], "sandbox_id": sandbox_id},
+            )
+            find_data = find_resp.json()
+            if find_data.get("exit_code") != 0:
+                return ServiceStatus()
+        except Exception as e:
+            logger.warning(f"Failed to check service status file for {sandbox_id}: {e}")
+            return ServiceStatus()
+
+        try:
+            read_resp = await self._rpc_client.post(
+                f"{base_url}/read_file",
+                headers=headers,
+                json={"path": service_status_path, "sandbox_id": sandbox_id},
+            )
+            read_data = read_resp.json()
+            if read_data.get("content"):
+                try:
+                    return ServiceStatus.from_content(read_data["content"])
+                except Exception:
+                    return ServiceStatus()
+        except Exception as e:
+            logger.warning(f"Failed to read service status for {sandbox_id}: {e}")
+
+        return ServiceStatus()
+
+    async def _check_alive_status(self, sandbox_id: str, host_ip: str, remote_status: ServiceStatus) -> bool:
+        """Probe rocklet /is_alive via shared _rpc_client pool."""
+        try:
+            proxy_port = remote_status.get_mapped_port(Port.PROXY)
+        except KeyError:
+            proxy_port = Port.PROXY.value
+        try:
+            resp = await self._rpc_client.get(
+                f"http://{host_ip}:{proxy_port}/is_alive",
+                headers=self._headers(sandbox_id),
+            )
+            return IsAliveResponse(**resp.json()).is_alive
+        except Exception:
+            return False

--- a/rock/sandbox/service/sandbox_proxy_service.py
+++ b/rock/sandbox/service/sandbox_proxy_service.py
@@ -37,16 +37,16 @@ from rock.admin.proto.request import SandboxWriteFileRequest as WriteFileRequest
 from rock.admin.proto.response import SandboxListResponse, SandboxListStatusResponse, SandboxStatusResponse
 from rock.config import OssConfig, ProxyServiceConfig, RockConfig
 from rock.deployments.constants import Port
-from rock.deployments.status import PersistedServiceStatus, ServiceStatus
+from rock.deployments.status import ServiceStatus
 from rock.common.port_validation import validate_port_forward_port
 from rock.logger import init_logger
 from rock.sandbox.sandbox_meta_store import SandboxMetaStore
 from rock.sandbox.utils.proxy import build_upstream_ws_headers
+from rock.sandbox.utils.rocklet_probe import check_alive_status, get_remote_status
 from rock.sandbox.utils.timeout import SandboxTimeoutHelper
 from rock.sdk.common.exceptions import BadRequestRockError
 from rock.rocklet import __version__ as swe_version
 from rock.sandbox import __version__ as gateway_version
-from rock.sandbox.sandbox_statemachine import SandboxStateMachine
 from rock.utils import EAGLE_EYE_TRACE_ID, trace_id_ctx_var
 
 logger = init_logger(__name__)
@@ -1017,16 +1017,6 @@ class SandboxProxyService:
         finally:
             await resp.aclose()
 
-    async def _get_current_statemachine(self, sandbox_id: str) -> SandboxStateMachine | None:
-        """Fetch current state from meta store and return a restored SandboxStateMachine, or None.
-
-        Same pattern as SandboxManager._get_current_statemachine.
-        """
-        info = await self._meta_store.get(sandbox_id, check_db=True)
-        if info is None:
-            return None
-        return await SandboxStateMachine.from_state_value(info.get("state"), sandbox_info=info)
-
     @monitor_sandbox_operation()
     async def get_status(self, sandbox_id: str, include_all_states: bool = False) -> SandboxStatusResponse:
         """Get sandbox status via meta_store + rocklet RPC (reuses _rpc_client pool).
@@ -1036,37 +1026,46 @@ class SandboxProxyService:
         (can I send traffic?) rather than container-process existence.
         PENDING→RUNNING transition via sm.send("alive"), timeout refresh via
         _update_expire_time. No Ray dependency.
+
+        State machine is initialized lazily — only when a PENDING→RUNNING transition
+        is needed, avoiding the overhead of SandboxStateMachine.from_state_value()
+        for the common (already-running) path.
         """
-        sm = await self._get_current_statemachine(sandbox_id)
-        if sm is None:
+        sandbox_info = await self._meta_store.get(sandbox_id, check_db=True)
+        if sandbox_info is None:
             raise BadRequestRockError(f"Sandbox {sandbox_id} not found")
 
-        sandbox_info = sm.sandbox_info or {}
+        state = sandbox_info.get("state")
         host_ip = sandbox_info.get("host_ip")
 
         is_alive = False
         operator_sandbox_info = None
-        if host_ip and sm.current_state.value in (State.RUNNING, State.PENDING):
-            remote_status = await self._get_remote_status(sandbox_id, host_ip)
-            is_alive = await self._check_alive_status(sandbox_id, host_ip, remote_status)
+        if host_ip and state in (State.RUNNING, State.PENDING):
+            remote_status = await get_remote_status(sandbox_id, host_ip, http_client=self._rpc_client)
+            is_alive = await check_alive_status(sandbox_id, host_ip, remote_status, http_client=self._rpc_client)
 
             if is_alive:
                 operator_sandbox_info = dict(sandbox_info)
                 operator_sandbox_info["state"] = State.RUNNING
                 operator_sandbox_info.update(remote_status.to_dict())
 
-            if sm.current_state.value == State.PENDING and is_alive:
+            if state == State.PENDING and is_alive:
+                from rock.sandbox.sandbox_statemachine import SandboxStateMachine
+
+                sm = await SandboxStateMachine.from_state_value(state, sandbox_info=sandbox_info)
                 await sm.send(
                     "alive",
                     sandbox_id=sandbox_id,
                     meta_store=self._meta_store,
                     sandbox_info=operator_sandbox_info,
                 )
+                # on_alive callback updates state_history in sm.sandbox_info
+                sandbox_info = sm.sandbox_info
 
-            if is_alive and operator_sandbox_info.get("state") in (State.PENDING, State.RUNNING):
+            if is_alive:
                 await self._update_expire_time(sandbox_id)
 
-        if not include_all_states and sm.current_state.value not in (State.PENDING, State.RUNNING):
+        if not include_all_states and state not in (State.PENDING, State.RUNNING):
             raise BadRequestRockError(f"Sandbox {sandbox_id} not found")
 
         info = operator_sandbox_info if operator_sandbox_info is not None else sandbox_info
@@ -1092,57 +1091,5 @@ class SandboxProxyService:
             start_time=info.get("start_time"),
             stop_time=info.get("stop_time"),
             create_time=info.get("create_time"),
-            state_history=sm.sandbox_info.get("state_history", []) if sm.sandbox_info else [],
+            state_history=sandbox_info.get("state_history", []),
         )
-
-    async def _get_remote_status(self, sandbox_id: str, host_ip: str) -> ServiceStatus:
-        """Probe rocklet for ServiceStatus (phases + port_mapping) via shared _rpc_client pool."""
-        service_status_path = PersistedServiceStatus.gen_service_status_path(sandbox_id)
-        headers = self._headers(sandbox_id)
-        rocklet_port = env_vars.ROCK_WORKER_ROCKLET_PORT if env_vars.ROCK_WORKER_ROCKLET_PORT else Port.PROXY
-        base_url = f"http://{host_ip}:{rocklet_port}"
-
-        try:
-            find_resp = await self._rpc_client.post(
-                f"{base_url}/execute",
-                headers=headers,
-                json={"command": ["ls", service_status_path], "sandbox_id": sandbox_id},
-            )
-            find_data = find_resp.json()
-            if find_data.get("exit_code") != 0:
-                return ServiceStatus()
-        except Exception as e:
-            logger.warning(f"Failed to check service status file for {sandbox_id}: {e}")
-            return ServiceStatus()
-
-        try:
-            read_resp = await self._rpc_client.post(
-                f"{base_url}/read_file",
-                headers=headers,
-                json={"path": service_status_path, "sandbox_id": sandbox_id},
-            )
-            read_data = read_resp.json()
-            if read_data.get("content"):
-                try:
-                    return ServiceStatus.from_content(read_data["content"])
-                except Exception:
-                    return ServiceStatus()
-        except Exception as e:
-            logger.warning(f"Failed to read service status for {sandbox_id}: {e}")
-
-        return ServiceStatus()
-
-    async def _check_alive_status(self, sandbox_id: str, host_ip: str, remote_status: ServiceStatus) -> bool:
-        """Probe rocklet /is_alive via shared _rpc_client pool."""
-        try:
-            proxy_port = remote_status.get_mapped_port(Port.PROXY)
-        except KeyError:
-            proxy_port = Port.PROXY.value
-        try:
-            resp = await self._rpc_client.get(
-                f"http://{host_ip}:{proxy_port}/is_alive",
-                headers=self._headers(sandbox_id),
-            )
-            return IsAliveResponse(**resp.json()).is_alive
-        except Exception:
-            return False

--- a/rock/sandbox/service/sandbox_proxy_service.py
+++ b/rock/sandbox/service/sandbox_proxy_service.py
@@ -1044,6 +1044,8 @@ class SandboxProxyService:
             remote_status = await get_remote_status(sandbox_id, host_ip, http_client=self._rpc_client)
             is_alive = await check_alive_status(sandbox_id, host_ip, remote_status, http_client=self._rpc_client)
 
+            await self._update_expire_time(sandbox_id)
+
             if is_alive:
                 operator_sandbox_info = dict(sandbox_info)
                 operator_sandbox_info["state"] = State.RUNNING
@@ -1061,9 +1063,6 @@ class SandboxProxyService:
                 )
                 # on_alive callback updates state_history in sm.sandbox_info
                 sandbox_info = sm.sandbox_info
-
-            if is_alive:
-                await self._update_expire_time(sandbox_id)
 
         if not include_all_states and state not in (State.PENDING, State.RUNNING):
             raise BadRequestRockError(f"Sandbox {sandbox_id} not found")

--- a/rock/sandbox/utils/rocklet_probe.py
+++ b/rock/sandbox/utils/rocklet_probe.py
@@ -1,0 +1,107 @@
+"""Shared rocklet probe helpers — used by both RayOperator and SandboxProxyService.
+
+These functions talk to rocklet over HTTP to fetch ServiceStatus (phases + port_mapping)
+and check liveness. They have no dependency on Ray or Kubernetes operators.
+
+HTTP client parameterization:
+- Pass http_client=None to use HttpUtils (per-request, for RayOperator)
+- Pass http_client=httpx.AsyncClient to reuse connection pool (for Proxy)
+"""
+
+import httpx
+
+from rock import env_vars
+from rock.actions import IsAliveResponse
+from rock.deployments.constants import Port
+from rock.deployments.status import PersistedServiceStatus, ServiceStatus
+from rock.logger import init_logger
+from rock.utils import EAGLE_EYE_TRACE_ID, trace_id_ctx_var
+from rock.utils.http import HttpUtils
+
+logger = init_logger(__name__)
+
+
+def _parse_response(resp: dict | httpx.Response) -> dict:
+    """Normalize response: httpx.Response → dict via .json(), dict passthrough."""
+    if isinstance(resp, dict):
+        return resp
+    return resp.json()
+
+
+async def get_remote_status(
+    sandbox_id: str, host_ip: str, http_client: httpx.AsyncClient | None = None
+) -> ServiceStatus:
+    service_status_path = PersistedServiceStatus.gen_service_status_path(sandbox_id)
+    worker_rocklet_port = env_vars.ROCK_WORKER_ROCKLET_PORT if env_vars.ROCK_WORKER_ROCKLET_PORT else Port.PROXY
+    execute_url = f"http://{host_ip}:{worker_rocklet_port}/execute"
+    read_file_url = f"http://{host_ip}:{worker_rocklet_port}/read_file"
+    headers = {"sandbox_id": sandbox_id, EAGLE_EYE_TRACE_ID: trace_id_ctx_var.get()}
+
+    try:
+        # Check if service status file exists
+        if http_client is None:
+            find_file_rsp_raw = await HttpUtils.post(
+                url=execute_url,
+                headers=headers,
+                data={"command": ["ls", service_status_path], "sandbox_id": sandbox_id},
+                read_timeout=60,
+            )
+        else:
+            find_file_rsp_raw = await http_client.post(
+                execute_url,
+                headers=headers,
+                json={"command": ["ls", service_status_path], "sandbox_id": sandbox_id},
+            )
+
+        find_file_rsp = _parse_response(find_file_rsp_raw)
+
+        # When the file does not exist, exit_code = 2
+        if find_file_rsp.get("exit_code") and find_file_rsp.get("exit_code") == 2:
+            return ServiceStatus()
+
+        # Read the service status file
+        if http_client is None:
+            response_raw = await HttpUtils.post(
+                url=read_file_url,
+                headers=headers,
+                data={"path": service_status_path, "sandbox_id": sandbox_id},
+                read_timeout=60,
+            )
+        else:
+            response_raw = await http_client.post(
+                read_file_url,
+                headers=headers,
+                json={"path": service_status_path, "sandbox_id": sandbox_id},
+            )
+
+        response = _parse_response(response_raw)
+
+        if response.get("content"):
+            return ServiceStatus.from_content(response.get("content"))
+        logger.warning(f"{service_status_path} exists, but content is empty")
+    except Exception as e:
+        logger.warning(f"Failed to get remote status for {sandbox_id}: {e}")
+
+    return ServiceStatus()
+
+
+async def check_alive_status(
+    sandbox_id: str, host_ip: str, remote_status: ServiceStatus, http_client: httpx.AsyncClient | None = None
+) -> bool:
+    """Check if sandbox is alive"""
+    try:
+        url = f"http://{host_ip}:{remote_status.get_mapped_port(Port.PROXY)}/is_alive"
+        headers = {
+            "sandbox_id": sandbox_id,
+            EAGLE_EYE_TRACE_ID: trace_id_ctx_var.get(),
+        }
+
+        if http_client is None:
+            alive_resp_raw = await HttpUtils.get(url=url, headers=headers)
+        else:
+            alive_resp_raw = await http_client.get(url, headers=headers)
+
+        alive_resp = _parse_response(alive_resp_raw)
+        return IsAliveResponse(**alive_resp).is_alive
+    except Exception:
+        return False

--- a/tests/unit/sandbox/operator/test_ray_operator_get_remote_status.py
+++ b/tests/unit/sandbox/operator/test_ray_operator_get_remote_status.py
@@ -9,49 +9,44 @@ the rocklet, which bubbles up through ``get_status_v2`` as
 ``Failed to get status``.
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from rock.sandbox.operator.ray import RayOperator
-
-
-@pytest.fixture
-def operator() -> RayOperator:
-    return RayOperator(ray_service=MagicMock(), runtime_config=MagicMock())
+from rock.sandbox.utils.rocklet_probe import get_remote_status
 
 
 @pytest.mark.asyncio
-async def test_get_remote_status_passes_sandbox_id_to_execute_body(operator: RayOperator):
+async def test_get_remote_status_passes_sandbox_id_to_execute_body():
     sandbox_id = "sb-abc"
     host_ip = "10.0.0.1"
-    with patch("rock.sandbox.operator.ray.HttpUtils.post", new=AsyncMock()) as mock_post:
+    with patch("rock.sandbox.utils.rocklet_probe.HttpUtils.post", new=AsyncMock()) as mock_post:
         # exit_code == 2 short-circuits before /read_file is called.
         mock_post.return_value = {"exit_code": 2}
-        await operator.get_remote_status(sandbox_id, host_ip)
+        await get_remote_status(sandbox_id, host_ip)
 
     assert mock_post.call_count == 1
     kwargs = mock_post.call_args.kwargs
     assert "/execute" in kwargs["url"]
-    assert kwargs["data"].get("sandbox_id") == sandbox_id, (
-        "rocklet /execute requires sandbox_id in body (NonBlankStr); header-only sandbox_id triggers 422"
-    )
+    assert (
+        kwargs["data"].get("sandbox_id") == sandbox_id
+    ), "rocklet /execute requires sandbox_id in body (NonBlankStr); header-only sandbox_id triggers 422"
 
 
 @pytest.mark.asyncio
-async def test_get_remote_status_passes_sandbox_id_to_read_file_body(operator: RayOperator):
+async def test_get_remote_status_passes_sandbox_id_to_read_file_body():
     sandbox_id = "sb-abc"
     host_ip = "10.0.0.1"
-    with patch("rock.sandbox.operator.ray.HttpUtils.post", new=AsyncMock()) as mock_post:
+    with patch("rock.sandbox.utils.rocklet_probe.HttpUtils.post", new=AsyncMock()) as mock_post:
         mock_post.side_effect = [
             {"exit_code": 0},  # ls succeeded -> proceed to read_file
             {"content": ""},  # empty content path
         ]
-        await operator.get_remote_status(sandbox_id, host_ip)
+        await get_remote_status(sandbox_id, host_ip)
 
     assert mock_post.call_count == 2
     read_file_kwargs = mock_post.call_args_list[1].kwargs
     assert "/read_file" in read_file_kwargs["url"]
-    assert read_file_kwargs["data"].get("sandbox_id") == sandbox_id, (
-        "rocklet /read_file requires sandbox_id in body (NonBlankStr); header-only sandbox_id triggers 422"
-    )
+    assert (
+        read_file_kwargs["data"].get("sandbox_id") == sandbox_id
+    ), "rocklet /read_file requires sandbox_id in body (NonBlankStr); header-only sandbox_id triggers 422"

--- a/tests/unit/sandbox/test_get_status_include_all_states.py
+++ b/tests/unit/sandbox/test_get_status_include_all_states.py
@@ -37,7 +37,8 @@ def mock_operator():
 @pytest.fixture
 def mock_meta_store():
     store = AsyncMock()
-    store.get = AsyncMock(return_value=None)
+    # Default: return sandbox info (not None) so get_status can proceed
+    store.get = AsyncMock(return_value=_make_sandbox_info(state=State.PENDING))
     store.update = AsyncMock()
     return store
 
@@ -82,13 +83,13 @@ class TestGetStatusIncludeAllStates:
         mock_meta_store.update.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_operator_data_with_flag_true_skips_db_fallback(
-        self, sandbox_manager, mock_operator, mock_meta_store
-    ):
-        """operator returns data + include_all_states=True → check_db=True never triggered."""
+    async def test_running_state_skips_state_machine_init(self, sandbox_manager, mock_operator, mock_meta_store):
+        """When meta_store and operator both say RUNNING, state machine is NOT initialized (optimization)."""
+        # Set meta_store to return RUNNING (not PENDING) so no transition is needed
+        mock_meta_store.get = AsyncMock(return_value=_make_sandbox_info(state=State.RUNNING))
         mock_operator.get_status = AsyncMock(return_value=_make_sandbox_info(state=State.RUNNING))
 
         await sandbox_manager.get_status("sandbox-1", include_all_states=True)
 
-        for c in mock_meta_store.get.call_args_list:
-            assert not c.kwargs.get("check_db")
+        # State machine should NOT be initialized when no PENDING→RUNNING transition needed
+        sandbox_manager._get_current_statemachine.assert_not_called()

--- a/tests/unit/sandbox/test_proxy_get_status.py
+++ b/tests/unit/sandbox/test_proxy_get_status.py
@@ -1,0 +1,197 @@
+"""
+Unit tests for SandboxProxyService.get_status.
+
+Covers:
+  - meta_store miss → BadRequestRockError
+  - RUNNING sandbox: rocklet RPCs populate phases/port_mapping/is_alive
+  - PENDING → RUNNING transition writes start_time + meta_store.update
+  - STOPPED + include_all_states=False → BadRequestRockError
+  - STOPPED + include_all_states=True → response returned (is_alive=False)
+  - rocklet RPC failure falls back to ServiceStatus() and is_alive=False
+  - _rpc_client is reused (connection pool)
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from rock.actions.sandbox.response import State
+from rock.admin.proto.response import SandboxStatusResponse
+from rock.sdk.common.exceptions import BadRequestRockError
+
+
+def _make_meta_info(state: State = State.RUNNING, host_ip: str = "10.0.0.1") -> dict:
+    return {
+        "sandbox_id": "sandbox-1",
+        "state": state,
+        "host_ip": host_ip,
+        "host_name": "node-1",
+        "image": "python:3.11",
+        "user_id": "u1",
+        "experiment_id": "e1",
+        "namespace": "ns1",
+        "cpus": 1.0,
+        "memory": "2g",
+        "disk": "10g",
+        "create_time": "2026-01-01T00:00:00",
+        "state_history": [],
+    }
+
+
+def _make_rpc_execute_not_found():
+    resp = MagicMock()
+    resp.json.return_value = {"exit_code": 2, "output": ""}
+    return resp
+
+
+def _make_rpc_read_file(content: str):
+    resp = MagicMock()
+    resp.json.return_value = {"content": content}
+    return resp
+
+
+def _make_rpc_is_alive(is_alive: bool):
+    resp = MagicMock()
+    resp.json.return_value = {"is_alive": is_alive, "message": "node-1"}
+    return resp
+
+
+SERVICE_STATUS_JSON = (
+    '{"phases":{"image_pull":{"status":"success","message":"done"},'
+    '"docker_run":{"status":"running","message":"running"}},'
+    '"port_mapping":{"22555":22555,"8080":8080}}'
+)
+
+
+@pytest.fixture
+def mock_meta_store():
+    store = AsyncMock()
+    store.get = AsyncMock(return_value=None)
+    store.update = AsyncMock()
+    store.get_timeout = AsyncMock(return_value=None)
+    store.update_timeout = AsyncMock()
+    return store
+
+
+@pytest.fixture
+def mock_rpc_client():
+    return AsyncMock()
+
+
+@pytest.fixture
+def proxy_service(mock_meta_store, mock_rpc_client, rock_config):
+    """Build a SandboxProxyService with mocked _meta_store and _rpc_client.
+
+    Uses __new__ to skip __init__ (which constructs OSS clients, MetricsMonitor, etc.).
+    """
+    from rock.config import OssConfig, ProxyServiceConfig
+    from rock.sandbox.service.sandbox_proxy_service import SandboxProxyService
+
+    svc = SandboxProxyService.__new__(SandboxProxyService)
+    svc._meta_store = mock_meta_store
+    svc._rpc_client = mock_rpc_client
+    svc._rock_config = rock_config
+    svc.oss_config = OssConfig()
+    svc.proxy_config = ProxyServiceConfig()
+    svc._batch_get_status_max_count = 100
+    svc._update_expire_time = AsyncMock()
+    return svc
+
+
+class TestProxyGetStatus:
+    async def test_not_found_raises(self, proxy_service, mock_meta_store):
+        mock_meta_store.get.return_value = None
+
+        with pytest.raises(BadRequestRockError):
+            await proxy_service.get_status("sandbox-1")
+
+    async def test_running_sandbox_returns_phases_and_port_mapping(
+        self, proxy_service, mock_meta_store, mock_rpc_client
+    ):
+        mock_meta_store.get.return_value = _make_meta_info(state=State.RUNNING)
+
+        # Sequence: POST /execute (ls), POST /read_file, GET /is_alive
+        mock_rpc_client.post.side_effect = [
+            MagicMock(json=MagicMock(return_value={"exit_code": 0})),
+            _make_rpc_read_file(SERVICE_STATUS_JSON),
+        ]
+        mock_rpc_client.get.return_value = _make_rpc_is_alive(True)
+
+        result = await proxy_service.get_status("sandbox-1")
+
+        assert isinstance(result, SandboxStatusResponse)
+        assert result.state == State.RUNNING
+        assert result.is_alive is True
+        assert result.status == {
+            "image_pull": {"status": "success", "message": "done"},
+            "docker_run": {"status": "running", "message": "running"},
+        }
+        assert result.port_mapping == {22555: 22555, 8080: 8080}
+
+    async def test_pending_to_running_triggers_meta_update(self, proxy_service, mock_meta_store, mock_rpc_client):
+        mock_meta_store.get.return_value = _make_meta_info(state=State.PENDING, host_ip="10.0.0.1")
+        mock_rpc_client.post.side_effect = [
+            MagicMock(json=MagicMock(return_value={"exit_code": 0})),
+            _make_rpc_read_file(SERVICE_STATUS_JSON),
+        ]
+        mock_rpc_client.get.return_value = _make_rpc_is_alive(True)
+
+        result = await proxy_service.get_status("sandbox-1")
+
+        assert result.state == State.RUNNING
+        mock_meta_store.update.assert_awaited_once()
+        updated_info = mock_meta_store.update.await_args[0][1]
+        assert updated_info["state"] == State.RUNNING
+        assert updated_info["start_time"] is not None
+
+    async def test_stopped_with_include_all_states_false_raises(self, proxy_service, mock_meta_store):
+        mock_meta_store.get.return_value = _make_meta_info(state=State.STOPPED)
+
+        with pytest.raises(BadRequestRockError):
+            await proxy_service.get_status("sandbox-1", include_all_states=False)
+
+    async def test_stopped_with_include_all_states_true_returns_response(self, proxy_service, mock_meta_store):
+        info = _make_meta_info(state=State.STOPPED)
+        mock_meta_store.get.return_value = info
+
+        result = await proxy_service.get_status("sandbox-1", include_all_states=True)
+
+        assert isinstance(result, SandboxStatusResponse)
+        assert result.state == State.STOPPED
+        assert result.is_alive is False
+
+    async def test_rocklet_failure_falls_back_gracefully(self, proxy_service, mock_meta_store, mock_rpc_client):
+        mock_meta_store.get.return_value = _make_meta_info(state=State.RUNNING)
+        mock_rpc_client.post.side_effect = Exception("connection refused")
+        mock_rpc_client.get.side_effect = Exception("connection refused")
+
+        result = await proxy_service.get_status("sandbox-1")
+
+        assert isinstance(result, SandboxStatusResponse)
+        assert result.is_alive is False
+        # Falls back to meta_store snapshot (no phases stored there → None)
+        assert result.status is None
+
+    async def test_no_host_ip_skips_rocklet_calls(self, proxy_service, mock_meta_store, mock_rpc_client):
+        mock_meta_store.get.return_value = _make_meta_info(state=State.PENDING, host_ip=None)
+
+        result = await proxy_service.get_status("sandbox-1", include_all_states=True)
+
+        assert result.is_alive is False
+        mock_rpc_client.post.assert_not_awaited()
+        mock_rpc_client.get.assert_not_awaited()
+
+    async def test_uses_rpc_client_connection_pool(self, proxy_service, mock_rpc_client, mock_meta_store):
+        """Ensure rocklet calls go through self._rpc_client (shared httpx pool),
+        not per-request HttpUtils clients."""
+        mock_meta_store.get.return_value = _make_meta_info(state=State.RUNNING)
+        mock_rpc_client.post.side_effect = [
+            _make_rpc_execute_not_found(),
+        ]
+        mock_rpc_client.get.return_value = _make_rpc_is_alive(True)
+
+        await proxy_service.get_status("sandbox-1")
+
+        # At least one post (execute/ls) and one get (is_alive) through the shared client
+        assert mock_rpc_client.post.await_count >= 1
+        assert mock_rpc_client.get.await_count >= 1

--- a/tests/unit/sandbox/test_proxy_get_status.py
+++ b/tests/unit/sandbox/test_proxy_get_status.py
@@ -44,6 +44,12 @@ def _make_rpc_execute_not_found():
     return resp
 
 
+def _make_rpc_execute_success():
+    resp = MagicMock()
+    resp.json.return_value = {"exit_code": 0, "output": ""}
+    return resp
+
+
 def _make_rpc_read_file(content: str):
     resp = MagicMock()
     resp.json.return_value = {"content": content}
@@ -186,7 +192,8 @@ class TestProxyGetStatus:
         not per-request HttpUtils clients."""
         mock_meta_store.get.return_value = _make_meta_info(state=State.RUNNING)
         mock_rpc_client.post.side_effect = [
-            _make_rpc_execute_not_found(),
+            _make_rpc_execute_success(),
+            _make_rpc_read_file(SERVICE_STATUS_JSON),
         ]
         mock_rpc_client.get.return_value = _make_rpc_is_alive(True)
 

--- a/tests/unit/sandbox/test_proxy_get_status_route.py
+++ b/tests/unit/sandbox/test_proxy_get_status_route.py
@@ -1,0 +1,78 @@
+"""
+Route-level tests for GET /get_status on sandbox_proxy_router.
+
+Uses a mocked SandboxProxyService injected via set_sandbox_proxy_service.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from rock.actions.sandbox.response import State
+from rock.admin.entrypoints.sandbox_proxy_api import sandbox_proxy_router, set_sandbox_proxy_service
+from rock.admin.proto.response import SandboxStatusResponse
+from rock.sandbox.service.sandbox_proxy_service import SandboxProxyService
+from rock.sdk.common.exceptions import BadRequestRockError
+
+
+@pytest.fixture
+def mock_service():
+    svc = MagicMock(spec=SandboxProxyService)
+    svc.get_status = AsyncMock()
+    set_sandbox_proxy_service(svc)
+    return svc
+
+
+@pytest.fixture
+def app(mock_service):
+    a = FastAPI()
+    a.include_router(sandbox_proxy_router)
+    return a
+
+
+@pytest.fixture
+def client(app):
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+class TestGetStatusRoute:
+    async def test_get_status_success(self, client, mock_service):
+        mock_service.get_status.return_value = SandboxStatusResponse(
+            sandbox_id="sandbox-1",
+            state=State.RUNNING,
+            is_alive=True,
+            host_ip="10.0.0.1",
+        )
+
+        resp = await client.get("/get_status", params={"sandbox_id": "sandbox-1"})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["result"]["sandbox_id"] == "sandbox-1"
+        assert body["result"]["state"] == State.RUNNING
+        assert body["result"]["is_alive"] is True
+        mock_service.get_status.assert_awaited_once_with("sandbox-1", False)
+
+    async def test_get_status_passes_include_all_states(self, client, mock_service):
+        mock_service.get_status.return_value = SandboxStatusResponse(
+            sandbox_id="sandbox-1", state=State.STOPPED, is_alive=False
+        )
+
+        resp = await client.get("/get_status", params={"sandbox_id": "sandbox-1", "include_all_states": True})
+
+        assert resp.status_code == 200
+        mock_service.get_status.assert_awaited_once_with("sandbox-1", True)
+
+    async def test_get_status_not_found_returns_failed(self, client, mock_service):
+        mock_service.get_status.side_effect = BadRequestRockError("Sandbox sandbox-1 not found")
+
+        resp = await client.get("/get_status", params={"sandbox_id": "sandbox-1"})
+
+        body = resp.json()
+        assert body["status"] == "Failed"
+
+    async def test_get_status_missing_sandbox_id_returns_422(self, client, mock_service):
+        resp = await client.get("/get_status")
+        assert resp.status_code == 422

--- a/uv.lock
+++ b/uv.lock
@@ -3524,6 +3524,69 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg2-binary"
+version = "2.9.12"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/2a/60/a3624f79acea344c16fbef3a94d28b89a8042ddfb8f3e4ca83f538671409/psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/78/80/49bacf9e51617d8309f6f0123e29edc793f6f5f6700c7d1f1b20782fbb37/psycopg2_binary-2.9.12-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b818ceff717f98851a64bffd4c5eb5b3059ae280276dcecc52ac658dcf006a4" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/d3/f2/98eeac7d60c43df9338287834edf9b3e69be68a2db78a57b1b81d705e735/psycopg2_binary-2.9.12-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d2fa0d7caca8635c56e373055094eeda3208d901d55dd0ff5abc1d4e47f82b56" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/9f/7c/30575e75f14d5351a56a1971bb43fe7f8bf7edf1b654fb1bec65c42a8812/psycopg2_binary-2.9.12-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:864c261b3690e1207d14bbfe0a61e27567981b80c47a778561e49f676f7ce433" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/65/9b/4df366d89f28c527dc39d0b6c98a5ca74e30d37ac097b73f3352147568ae/psycopg2_binary-2.9.12-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c5ee5213445dd45312459029b8c4c0a695461eb517b753d2582315bd07995f5e" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/4e/8a/c566803818eb03161ba869b6ba612bf7ad56816d98b9e5121e0a22ad6b0b/psycopg2_binary-2.9.12-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6f9cae1f848779b5b01f417e762c40d026ea93eb0648249a604728cda991dde3" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/63/fe/0dfa5797e0b229e0567bc378695224caf14d547f73b05be0c80549089772/psycopg2_binary-2.9.12-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:63a3ebbd543d3d1eda088ac99164e8c5bac15293ee91f20281fd17d050aee1c4" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/3c/89/28063adf17a4ba501eedd9890feab0c649ee4d8bd0a97df0ff1e9584feab/psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d6fcbba8c9fed08a73b8ac61ea79e4821e45b1e92bb466230c5e746bbf3d5256" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/84/94/5a01de0aa4ead0b8d8d1aa4ec18cec0bd36d03fa714eaa5bb8a0b1b50020/psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:36512911ebb2b60a0c3e44d0bb5048c1980aced91235d133b7874f3d1d93487c" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/7a/85/723bb085a61c6ac2dc0a0043f375f2fe7365363e27b073bad56ca5bda979/psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:8ffdb59fe88f99589e34354a130217aa1fd2d615612402d6edc8b3dbc7a44463" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/b4/67/4d8b1e0d2fc4166677380eac0edf9cdff91013aca2546e8ef7bc04b56158/psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a46fe069b65255df410f856d842bc235f90e22ffdf532dda625fd4213d3fd9b1" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/73/99/21af7a5498637ea4dc91a17c281a53bc1d632fbafe00f6689fbfb32a9fed/psycopg2_binary-2.9.12-cp310-cp310-win_amd64.whl", hash = "sha256:ab29414b25dcb698bf26bf213e3348abdcd07bbd5de032a5bec15bd75b298b03" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/d5/19/d4ce60954f3bb9d8e3bc5e5c4d1f2487de2d3851bf2391d54954c9df12a6/psycopg2_binary-2.9.12-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5c8ce6c61bd1b1f6b9c24ee32211599f6166af2c55abb19456090a21fd16554b" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/53/71/c85409ee0d78890f0660eff262e815e7dd2bb741a17611d82e9e8cd9dc5e/psycopg2_binary-2.9.12-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b4a9eaa6e7f4ff91bec10aa3fb296878e75187bced5cc4bafe17dc40915e1326" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/3c/ed/60486c2c7f0d4d1ede2bfb1ed27e2498477ce646bc7f6b2759906303117e/psycopg2_binary-2.9.12-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c6528cefc8e50fcc6f4a107e27a672058b36cc5736d665476aeb413ba88dbb06" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/0b/b9/656cb03fad9f4f49f2145c334b1126ee75189929ca4e6187d485a2d59951/psycopg2_binary-2.9.12-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e4e184b1fb6072bf05388aa41c697e1b2d01b3473f107e7ec44f186a32cfd0b8" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/99/66/08cf0da0e25cc6fb142c89be45fc8418792858f0c4cbff5e24530ff02cd6/psycopg2_binary-2.9.12-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4766ab678563054d3f1d064a4db19cc4b5f9e3a8d9018592a8285cf200c248f3" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/17/d7/eecd9ce8e146d3721115d82d3836efdbb712187e4590325df549989d18f4/psycopg2_binary-2.9.12-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5a0253224780c978746cb9be55a946bcdaf40fe3519c0f622924cdabdafe2c39" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/b6/2e/b1dc289b362cc8d45697b57eefbd673186f49a4ea0906928988e3affcc98/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0dc9228d47c46bda253d2ecd6bb93b56a9f2d7ad33b684a1fa3622bf74ffe30c" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/eb/e4/4c4aea6473214dbdbd0fbba11aa4691e76dc01722c55724c5951719865ff/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f921f3cd87035ef7df233383011d7a53ea1d346224752c1385f1edfd790ceb6a" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/ba/5d/b03b99986446a4f57b170ed9a2579fb7ff9783ca0fa5226b19db99737fee/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d999bd982a723113c1a45b55a7a6a90d64d0ed2278020ed625c490ff7bef96c" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/14/86/382ee4afbd1d97500c9d2862b20c2fdeddf4b7335e984df3fb4309f64108/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:29d4d134bd0ab46ffb04e94aa3c5fa3ef582e9026609165e2f758ff76fc3a3be" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/a8/16/9a57c75ba1eda7165c017342f526810d5f5a12647dde749c99ae9a7141d7/psycopg2_binary-2.9.12-cp311-cp311-win_amd64.whl", hash = "sha256:cb4a1dacdd48077150dc762a9e5ddbf32c256d66cb46f80839391aa458774936" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/e2/9f/ef4ef3c8e15083df90ca35265cfd1a081a2f0cc07bb229c6314c6af817f4/psycopg2_binary-2.9.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5cdc05117180c5fa9c40eea8ea559ce64d73824c39d928b7da9fb5f6a9392433" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/b5/01/3dd14e46ba48c1e1a6ec58ee599fa1b5efa00c246d5046cd903d0eeb1af1/psycopg2_binary-2.9.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3227a3bc228c10d21011a99245edca923e4e8bf461857e869a507d9a41fe9f6" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/a6/f7/0640e4901119d8a9f7a1784b927f494e2198e213ceb593753d1f2c8b1b30/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:995ce929eede89db6254b50827e2b7fd61e50d11f0b116b29fffe4a2e53c4580" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/b0/55/44df3965b5f297c50cc0b1b594a31c67d6127a9d133045b8a66611b14dfb/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9fe06d93e72f1c048e731a2e3e7854a5bfaa58fc736068df90b352cefe66f03f" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/b0/4b/74535248b1eac0c9336862e8617c765ac94dac76f9e25d7c4a79588c8907/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40e7b28b63aaf737cb3a1edc3a9bbc9a9f4ad3dcb7152e8c1130e4050eddcb7d" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/f2/ba/f1bf8d2ae71868ad800b661099086ee52bc0f8d9f05be1acd8ebb06757cc/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:89d19a9f7899e8eb0656a2b3a08e0da04c720a06db6e0033eab5928aabe60fa9" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/45/46/c15706c338403b7c420bcc0c2905aad116cc064545686d8bf85f1999ea00/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:612b965daee295ae2da8f8218ce1d274645dc76ef3f1abf6a0a94fd57eff876d" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/b3/7c/a2d5dc09b64a4564db242a0fe418fde7d33f6f8259dd2c5b9d7def00fb5a/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b9a339b79d37c1b45f3235265f07cdeb0cb5ad7acd2ac7720a5920989c17c24e" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/c0/e8/cc8c9a4ce71461f9ec548d38cadc41dc184b34c73e6455450775a9334ccd/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:3471336e1acfd9c7fe507b8bad5af9317b6a89294f9eb37bd9a030bb7bebcdc6" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/19/6a/31e2296bc0787c5ab75d3d118e40b239db8151b5192b90b77c72bc9256e9/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7af18183109e23502c8b2ae7f6926c0882766f35b5175a4cd737ad825e4d7a1b" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/5f/a8/75f4e3e11203b590150abed2cf7794b9c9c9f7eceddae955191138b44dde/psycopg2_binary-2.9.12-cp312-cp312-win_amd64.whl", hash = "sha256:398fcd4db988c7d7d3713e2b8e18939776fd3fb447052daae4f24fa39daede4c" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/91/bb/4608c96f970f6e0c56572e87027ef4404f709382a3503e9934526d7ba051/psycopg2_binary-2.9.12-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7c729a73c7b1b84de3582f73cdd27d905121dc2c531f3d9a3c32a3011033b965" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/5e/af/48f76af9d50d61cf390f8cd657b503168b089e2e9298e48465d029fcc713/psycopg2_binary-2.9.12-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4413d0caef93c5cf50b96863df4c2efe8c269bf2267df353225595e7e15e8df7" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/7a/df/aba0f99397cd811d32e06fc0cc781f1f3ce98bc0e729cb423925085d781a/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4dfcf8e45ebb0c663be34a3442f65e17311f3367089cd4e5e3a3e8e62c978777" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/95/9c/eaa74021ac4e4d5c2f83d82fc6615a63f4fe6c94dc4e94c3990427053f67/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c41321a14dd74aceb6a9a643b9253a334521babfa763fa873e33d89cfa122fb5" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/35/ed/c25deff98bd26187ba48b3b250a3ffc3037c46c5b89362534a15d200e0db/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83946ba43979ebfdc99a3cd0ee775c89f221df026984ba19d46133d8d75d3cd9" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/9a/81/8d0e21ca77373c6c9589e5c4528f6e8f0c08c62cafc76fb0bddb7a2cee22/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:411e85815652d13560fbe731878daa5d92378c4995a22302071890ec3397d019" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/00/fc/f481e2435bd8f742d0123309174aae4165160ad3ef17c1b99c3622c241d2/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c8ad4c08e00f7679559eaed7aff1edfffc60c086b976f93972f686384a95e2c" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/53/79/b9f46466bdbe9f239c96cde8be33c1aace4842f06013b47b730dc9759187/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:00814e40fa23c2b37ef0a1e3c749d89982c73a9cb5046137f0752a22d432e82f" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/3f/19/7dc003b32fe35024df89b658104f7c8538a8b2dcbde7a4e746ce929742e7/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:98062447aebc20ed20add1f547a364fd0ef8933640d5372ff1873f8deb9b61be" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/91/58/2dbd7db5c604d45f4950d988506aae672a14126ec22998ced5021cbb76bb/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:66a7685d7e548f10fb4ce32fb01a7b7f4aa702134de92a292c7bd9e0d3dbd290" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/42/ee/dee8dcaad07f735824de3d6563bc67119fa6c28257b17977a8d624f02fab/psycopg2_binary-2.9.12-cp313-cp313-win_amd64.whl", hash = "sha256:b6937f5fe4e180aeee87de907a2fa982ded6f7f15d7218f78a083e4e1d68f2a0" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/13/1b/708c0dca874acfad6d65314271859899a79007686f3a1f74e82a2ed4b645/psycopg2_binary-2.9.12-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f3b3de8a74ef8db215f22edffb19e32dc6fa41340456de7ec99efdc8a7b3ec2" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/d6/39/ddbea9d4b4de6aca9431b6ed253f530f8a02d3b8f9bcfd0dbfe2b3de6fe4/psycopg2_binary-2.9.12-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1006fb62f0f0bc5ce256a832356c6262e91be43f5e4eb15b5eaf38079464caf2" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/bf/a0/bc2fef74b106fa345567122a0659e6d94512ed7dc0131ec44c9e5aba3725/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:840066105706cd2eb29b9a1c2329620056582a4bf3e8169dec5c447042d0869f" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/57/d7/d4e3b2005d3de607ca4fbb0e8742e248056e52184a6b94ebda3c1c2c329b/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:863f5d12241ebe1c76a72a04c2113b6dc905f90b9cef0e9be0efd994affd9354" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/2e/42/c9853f8db3967fe08bcde11f53d53b85d351750cae726ce001cb68afa9c1/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a99eaab34a9010f1a086b126de467466620a750634d114d20455f3a824aae033" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/eb/fd/b82b5601a97630308bef079f545ffec481bbbc795c2ba5ec416a01d03f60/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ffdd7dc5463ccd61845ac37b7012d0f35a1548df9febe14f8dd549be4a0bc81e" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/62/8c/32ca69b0389ef25dd22937bf9e8fbe2ce27aea20b05ded48c4ce4cb42475/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:54a0dfecab1b48731f934e06139dfe11e24219fb6d0ceb32177cf0375f14c7b5" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/c4/29/96992a2b59e3b9d730fcf9612d0a387305025dc867a9fc490a9e496e074e/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:96937c9c5d891f772430f418a7a8b4691a90c3e6b93cf72b5bd7cad8cbca32a5" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/56/ad/44b06659949b243ae10112cd3b20a197f9bf3e81d5651379b9eb889bfaad/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:77b348775efd4cdab410ec6609d81ccecd1139c90265fa583a7255c8064bc03d" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/1d/f2/10a1bcebadb6aa55e280e1f58975c36a7b560ea525184c7aa4064c466633/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:527e6342b3e44c2f0544f6b8e927d60de7f163f5723b8f1dfa7d2a84298738cd" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/20/be/b732c8418ffa5bcfda002890f5dc4c869fc17db66ff11f53b17cfe44afc0/psycopg2_binary-2.9.12-cp314-cp314-win_amd64.whl", hash = "sha256:f12ae41fcafadb39b2785e64a40f9db05d6de2ac114077457e0e7c597f3af980" },
+]
+
+[[package]]
 name = "ptyprocess"
 version = "0.7.0"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple/" }
@@ -4372,6 +4435,7 @@ admin = [
     { name = "pexpect", marker = "sys_platform != 'win32'" },
     { name = "pip" },
     { name = "psutil" },
+    { name = "psycopg2-binary" },
     { name = "ray", extra = ["default"] },
     { name = "redis" },
     { name = "sqlmodel" },
@@ -4401,6 +4465,7 @@ all = [
     { name = "pexpect", marker = "sys_platform != 'win32'" },
     { name = "pip" },
     { name = "psutil" },
+    { name = "psycopg2-binary" },
     { name = "ray", extra = ["default"] },
     { name = "redis" },
     { name = "sqlmodel" },
@@ -4499,6 +4564,7 @@ requires-dist = [
     { name = "pip", marker = "extra == 'admin'" },
     { name = "psutil", marker = "extra == 'model-service'" },
     { name = "psutil", marker = "extra == 'rocklet'" },
+    { name = "psycopg2-binary", marker = "extra == 'admin'" },
     { name = "pydantic" },
     { name = "python-multipart" },
     { name = "python-statemachine", specifier = ">=3.1.1" },


### PR DESCRIPTION
closes #1212

## Summary
Add `/get_status` to the sandbox proxy API (rocklet RPC path, no Ray dependency) and lazily initialize the state machine in `SandboxManager.get_status` only when a PENDING→RUNNING transition is needed.

## Key changes
- New `GET /get_status` route on `sandbox_proxy_router` backed by `SandboxProxyService.get_status`
- Extract `check_alive_status` and `get_remote_status` into `rock/sandbox/utils/rocklet_probe.py`, shared by `RayOperator` and `SandboxProxyService`
- `SandboxManager.get_status`: skip `_get_current_statemachine` when operator already reports RUNNING; read `state_history` directly from `sandbox_info`
- Remove unused `concurrent_helper` utility and dead imports in `RayOperator`
- Tests: `test_proxy_get_status.py`, `test_proxy_get_status_route.py`; updated `test_get_status_include_all_states.py`