### PR TITLE
fix(sdk): parse BashJob reward results (#1214)

### DIFF
--- a/docs/dev/job/result-protocol.md
+++ b/docs/dev/job/result-protocol.md
@@ -394,26 +394,23 @@ score: 0.71
 
 该 fallback 只用于兼容没有 trial 级 `result.json` 的旧 BashJob。新任务应优先写结构化 result。
 
-## 8. Harbor 与 Bash 当前模型差异
+## 8. Harbor 与 Bash 当前模型关系
 
-长期协议建议使用同一套字段。当前代码中 Harbor 和 Bash 的 result model 还存在轻微差异：
+SDK 使用同一套 reward protocol 模型解析 Harbor 和 Bash 的 trial 级 `result.json`：
 
-| 字段 / 行为 | Bash `RewardTrialResult` | Harbor `HarborTrialResult` |
-|-------------|--------------------------|-----------------------------|
-| `trial_uri` | 有 | 无 |
-| `task_id` | 有 | 无 |
-| `task_checksum` | 有 | 无 |
-| `config` | 有 | 无 |
-| `trial_name` | 有 | 有 |
-| `source` | 有 | 有 |
-| `agent_info` | 有 | 有 |
-| `agent_result` | 有 | 有 |
-| `verifier_result` | 有 | 有 |
-| timing fields | 有 | 有 |
-| `score` | 强转为 `float` | 返回 `int | float` |
+- 共享模型定义在 `rock.sdk.reward.result`。
+- `RewardTrialResult` 负责协议字段、`score`、`token_ids`、状态和耗时计算。
+- `HarborTrialResult` 是 `RewardTrialResult` 的薄子类，保留 `from_harbor_json()` 和 Harbor 历史 import 路径。
+- `rock.sdk.job.result` 只保留 Job 聚合结果模型，并 re-export reward model 兼容旧 import。
+
+当前行为差异主要来自 collector，而不是协议模型：
+
+| 行为 | Bash | Harbor |
+|------|------|--------|
+| trial result 路径 | `<root>/<trial_name>/result.json` | `<jobs_dir>/<job_name>/<trial_name>/result.json` |
+| root 查找来源 | `LOG_DIR`、`ROCK_ARTIFACT_DIR`、默认 artifact root | `jobs_dir/job_name` |
 | no trial result fallback | stdout `score:`，再基础 `TrialResult` | `HarborNoTrials` 基础 `TrialResult` |
-
-另外，`AgentInfo`、`AgentResult`、`VerifierResult`、`TimingInfo` 在 Bash 与 Harbor 侧当前是两套同构类型。字段结构一致，但 Python 类型身份不同。
+| exit code 传播 | 传播到每个 parsed `RewardTrialResult` | Harbor collector 按 Harbor 流程处理 |
 
 ## 9. 生产者要求
 

--- a/docs/dev/job/result-protocol.md
+++ b/docs/dev/job/result-protocol.md
@@ -1,0 +1,438 @@
+# Rock Job Result 协议说明
+
+## 1. 定位
+
+Rock Job Result 协议用于描述一次 Job 执行后的结构化结果。它服务两个层次：
+
+1. **Job 级结果**：描述整次 Job 的聚合状态。
+2. **Trial 级结果**：描述单个 task / trial 的执行结果、分数、异常、agent 输出和 verifier 输出。
+
+SDK 的核心消费对象是 trial 级 `result.json`。`JobResult.score` 由 `trial_results[*].score` 聚合得到。
+
+## 2. 目录布局
+
+### 2.1 通用布局
+
+一个 Job 的结果目录应至少包含 Job 根目录和若干 trial 子目录：
+
+```text
+<job_result_root>/
+├── result.json
+└── <trial_name>/
+    ├── result.json
+    ├── reward.txt
+    └── reward.json
+```
+
+说明：
+
+- `<job_result_root>/result.json` 是 Job 级结果。
+- `<job_result_root>/<trial_name>/result.json` 是 Trial 级结果。
+- `reward.txt` 和 `reward.json` 是可选辅助文件；SDK 以 trial 级 `result.json` 为主。
+- `<trial_name>` 必须是单层目录名，不能包含 `/`。
+
+### 2.2 HarborJob 路径
+
+HarborJob 当前读取：
+
+```text
+<jobs_dir>/<job_name>/<trial_name>/result.json
+```
+
+SDK 查找方式：
+
+```bash
+find <jobs_dir>/<job_name> -mindepth 2 -maxdepth 2 -name result.json
+```
+
+### 2.3 BashJob 路径
+
+BashJob 默认 artifact root：
+
+```text
+/data/logs/user-defined
+```
+
+BashJob 当前会在这些 roots 下查找：
+
+```text
+LOG_DIR
+ROCK_ARTIFACT_DIR
+/data/logs/user-defined
+```
+
+SDK 查找方式：
+
+```bash
+find <root> -mindepth 2 -maxdepth 2 -name result.json
+```
+
+因此 BashJob 模板必须写成：
+
+```text
+<root>/<trial_name>/result.json
+```
+
+不要写成：
+
+```text
+<root>/<path>/<trial_name>/result.json
+```
+
+如果原始任务名是 `tasks/T01zh_email_triage`，应将它转换为 path-safe `trial_name` 前缀，例如：
+
+```text
+tasks_T01zh_email_triage__Ab3xY9k
+```
+
+`task_name` 字段仍保留原始任务名。
+
+## 3. Job 级 `result.json`
+
+Job 级 `result.json` 放在 Job 根目录，用于描述整次 Job 聚合状态。
+
+### 3.1 字段
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `id` | string | 是 | Job 结果 ID，通常为 UUID |
+| `started_at` | string/null | 否 | Job 开始时间，建议 ISO-8601 UTC |
+| `finished_at` | string/null | 否 | Job 结束时间，建议 ISO-8601 UTC |
+| `n_total_trials` | integer | 否 | 预期 trial 总数 |
+| `stats` | object | 否 | 聚合统计 |
+| `stats.n_trials` | integer | 否 | 成功完成的 trial 数 |
+| `stats.n_errors` | integer | 否 | 失败 trial 数 |
+| `stats.evals` | object | 否 | evaluator 维度的扩展统计 |
+
+### 3.2 示例
+
+```json
+{
+  "id": "job-0a9ddf9d",
+  "started_at": "2026-07-06T02:00:00Z",
+  "finished_at": "2026-07-06T02:10:00Z",
+  "n_total_trials": 1,
+  "stats": {
+    "n_trials": 1,
+    "n_errors": 0,
+    "evals": {}
+  }
+}
+```
+
+### 3.3 SDK 行为
+
+当前 Job SDK 不依赖 Job 级 `result.json` 计算 `JobResult.score`。分数来自 trial 级结果。
+
+Job 级 `result.json` 主要用于：
+
+- 外部 viewer 展示聚合状态
+- 任务平台做完成度统计
+- 排查 Job 是否成功写出协议文件
+
+## 4. Trial 级 `result.json`
+
+Trial 级 `result.json` 是 SDK 解析的核心协议。
+
+### 4.1 字段
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `id` | string | 否 | Trial 结果 ID |
+| `task_name` | string | 是 | 原始任务名 |
+| `trial_name` | string | 是 | Trial 目录名，必须 path-safe |
+| `trial_uri` | string/null | Bash 建议 | Trial 目录 URI，例如 `file:///data/logs/user-defined/task__abc` |
+| `task_id` | object/null | Bash 建议 | 任务 ID 信息，常见形式为 `{ "path": "..." }` |
+| `source` | string/null | 否 | 任务来源，例如 `tasks` |
+| `task_checksum` | string/null | Bash 建议 | 任务内容或任务名 checksum |
+| `config` | object/null | Bash 建议 | Trial 配置快照 |
+| `agent_info` | object/null | 否 | Agent 元信息 |
+| `agent_result` | object/null | 否 | Agent 执行结果 |
+| `verifier_result` | object/null | 是 | Verifier 结果 |
+| `exception_info` | object/null | 否 | 异常信息；非空表示 trial failed |
+| `started_at` | string/null | 否 | Trial 开始时间 |
+| `finished_at` | string/null | 否 | Trial 结束时间 |
+| `environment_setup` | object/null | 否 | 环境初始化耗时段 |
+| `agent_setup` | object/null | 否 | Agent 初始化耗时段 |
+| `agent_execution` | object/null | 否 | Agent 执行耗时段 |
+| `verifier` | object/null | 否 | Verifier 执行耗时段 |
+
+### 4.2 `verifier_result`
+
+`verifier_result.rewards` 是 flat dict。
+
+主分数 key 必须是：
+
+```text
+reward
+```
+
+示例：
+
+```json
+{
+  "verifier_result": {
+    "rewards": {
+      "reward": 0.85,
+      "task_score": 0.85,
+      "accuracy": 0.85
+    }
+  }
+}
+```
+
+SDK 的 `trial.score` 读取：
+
+```text
+verifier_result.rewards.reward
+```
+
+如果缺失，分数为 `0.0`。
+
+### 4.3 `agent_info`
+
+```json
+{
+  "agent_info": {
+    "name": "unknown",
+    "version": "",
+    "model_info": {
+      "name": "gpt-4.1",
+      "provider": "openai"
+    }
+  }
+}
+```
+
+字段：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `name` | string | Agent 名称 |
+| `version` | string | Agent 版本 |
+| `model_info.name` | string | 模型名 |
+| `model_info.provider` | string | 模型提供方 |
+
+### 4.4 `agent_result`
+
+```json
+{
+  "agent_result": {
+    "n_input_tokens": 1000,
+    "n_cache_tokens": 200,
+    "n_output_tokens": 300,
+    "cost_usd": 0.01,
+    "rollout_details": [
+      {
+        "completion_token_ids": [1, 2, 3]
+      }
+    ]
+  }
+}
+```
+
+字段：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `n_input_tokens` | integer/null | 输入 token 数 |
+| `n_cache_tokens` | integer/null | cache token 数 |
+| `n_output_tokens` | integer/null | 输出 token 数 |
+| `cost_usd` | number/null | 估算成本 |
+| `rollout_details` | array/null | rollout 详情 |
+
+SDK 的 `token_ids` 来自：
+
+```text
+agent_result.rollout_details[*].completion_token_ids
+```
+
+### 4.5 `exception_info`
+
+```json
+{
+  "exception_info": {
+    "exception_type": "NoScore",
+    "exception_message": "task_score missing",
+    "exception_traceback": "",
+    "occurred_at": "2026-07-06T02:10:00Z"
+  }
+}
+```
+
+字段：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `exception_type` | string | 异常类型 |
+| `exception_message` | string | 异常信息 |
+| `exception_traceback` | string | traceback，可为空 |
+| `occurred_at` | string/null | 发生时间 |
+
+SDK 的 `trial.status` 规则：
+
+```text
+exception_info is null -> completed
+exception_info not null -> failed
+```
+
+### 4.6 时间段字段
+
+`environment_setup`、`agent_setup`、`agent_execution`、`verifier` 使用同一结构：
+
+```json
+{
+  "started_at": "2026-07-06T02:00:00Z",
+  "finished_at": "2026-07-06T02:01:00Z"
+}
+```
+
+Trial 顶层 `started_at` / `finished_at` 用于计算 `duration_sec`。
+
+## 5. 完整示例
+
+```json
+{
+  "id": "trial-2d6f0c23",
+  "task_name": "tasks/T01zh_email_triage",
+  "trial_name": "tasks_T01zh_email_triage__Ab3xY9k",
+  "trial_uri": "file:///data/logs/user-defined/tasks_T01zh_email_triage__Ab3xY9k",
+  "task_id": {
+    "path": "/data/logs/user-defined/tasks_T01zh_email_triage__Ab3xY9k"
+  },
+  "source": "tasks",
+  "task_checksum": "372f063cd131b",
+  "config": {
+    "trial_name": "tasks_T01zh_email_triage__Ab3xY9k"
+  },
+  "agent_info": {
+    "name": "unknown",
+    "version": "",
+    "model_info": null
+  },
+  "agent_result": {
+    "n_input_tokens": null,
+    "n_cache_tokens": null,
+    "n_output_tokens": null,
+    "cost_usd": null,
+    "rollout_details": null
+  },
+  "verifier_result": {
+    "rewards": {
+      "reward": 0.71,
+      "task_score": 0.71
+    }
+  },
+  "exception_info": null,
+  "started_at": "2026-07-06T02:00:00Z",
+  "finished_at": "2026-07-06T02:10:00Z",
+  "environment_setup": null,
+  "agent_setup": null,
+  "agent_execution": null,
+  "verifier": null
+}
+```
+
+## 6. `reward.txt` 和 `reward.json`
+
+### 6.1 `reward.txt`
+
+`reward.txt` 是 trial 主分数的纯文本表示。
+
+```text
+0.71
+```
+
+要求：
+
+- 内容是裸数字。
+- 不要求换行。
+- 应与 `verifier_result.rewards.reward` 一致。
+
+### 6.2 `reward.json`
+
+`reward.json` 是 trial reward 字典的独立表示。
+
+```json
+{
+  "reward": 0.71,
+  "task_score": 0.71,
+  "accuracy": 0.71
+}
+```
+
+要求：
+
+- 必须包含主分数 key `reward`。
+- 应与 trial 级 `result.json` 中的 `verifier_result.rewards` 一致。
+
+### 6.3 SDK 优先级
+
+当前 SDK 读取优先级：
+
+1. trial 级 `result.json`
+2. BashJob stdout `score:` fallback
+3. 基础 `TrialResult(score=0.0)`
+
+当前 SDK 不直接读取 `reward.txt` 或 `reward.json` 计算分数。
+
+## 7. stdout `score:` fallback
+
+BashJob 兼容 stdout 分数行：
+
+```text
+=== Score Summary ===
+score: 0.71
+```
+
+规则：
+
+- 只匹配行首 `score: <value>`。
+- 多个 `score:` 行时取最后一个。
+- `score: N/A` 不作为有效分数。
+- 解析成功后生成最小 `RewardTrialResult`，其 `verifier_result.rewards.reward` 为该分数。
+
+该 fallback 只用于兼容没有 trial 级 `result.json` 的旧 BashJob。新任务应优先写结构化 result。
+
+## 8. Harbor 与 Bash 当前模型差异
+
+长期协议建议使用同一套字段。当前代码中 Harbor 和 Bash 的 result model 还存在轻微差异：
+
+| 字段 / 行为 | Bash `RewardTrialResult` | Harbor `HarborTrialResult` |
+|-------------|--------------------------|-----------------------------|
+| `trial_uri` | 有 | 无 |
+| `task_id` | 有 | 无 |
+| `task_checksum` | 有 | 无 |
+| `config` | 有 | 无 |
+| `trial_name` | 有 | 有 |
+| `source` | 有 | 有 |
+| `agent_info` | 有 | 有 |
+| `agent_result` | 有 | 有 |
+| `verifier_result` | 有 | 有 |
+| timing fields | 有 | 有 |
+| `score` | 强转为 `float` | 返回 `int | float` |
+| no trial result fallback | stdout `score:`，再基础 `TrialResult` | `HarborNoTrials` 基础 `TrialResult` |
+
+另外，`AgentInfo`、`AgentResult`、`VerifierResult`、`TimingInfo` 在 Bash 与 Harbor 侧当前是两套同构类型。字段结构一致，但 Python 类型身份不同。
+
+## 9. 生产者要求
+
+写 result 的脚本或框架必须满足：
+
+1. `trial_name` 是 path-safe 单层目录名。
+2. trial 级 `result.json` 放在 `<root>/<trial_name>/result.json`。
+3. `verifier_result.rewards.reward` 是主分数。
+4. `exception_info` 为空表示成功，非空表示失败。
+5. `task_name` 保留原始任务名，不要为了 path-safe 改写原始语义。
+6. `reward.txt`、`reward.json` 和 trial `result.json` 的主分数保持一致。
+
+## 10. 消费者要求
+
+消费 result 的 SDK / viewer 应遵循：
+
+1. 优先读取 trial 级 `result.json`。
+2. 不把 Job 根目录 `result.json` 当成 trial 结果。
+3. 不默认递归读取深层 `result.json`，避免误读 benchmark 内部产物。
+4. 用 `verifier_result.rewards.reward` 作为主分数。
+5. 用 `exception_info` 判断 trial 成败。
+6. 允许未知字段存在，以便协议向前扩展。

--- a/docs/proposals/bashjob-reward-result-parsing.md
+++ b/docs/proposals/bashjob-reward-result-parsing.md
@@ -1,0 +1,229 @@
+# BashJob reward result 解析适配方案
+
+## 背景
+
+ROCK Job SDK 中，`HarborTrial.collect()` 会读取 Harbor 生成的 trial 级 `result.json`，并从 `verifier_result.rewards.reward` 得到 `trial.score`。但 `BashTrial.collect()` 之前只按进程退出码构造基础 `TrialResult`：
+
+- `exit_code == 0` 时标记 completed
+- `exit_code != 0` 时填充 `BashExitCode`
+- `TrialResult.score` 恒为 `0.0`
+
+这导致 BashJob 即使在 sandbox 内写出了 reward protocol 产物，SDK 侧也不会读取结构化结果。外部系统如果只看 stdout 的 `score:` 还能拿到分数，但 `JobResult.trial_results` 中的分数、trial 元数据、token 信息和异常信息都会丢失。
+
+对应 issue: https://github.com/alibaba/ROCK/issues/1214
+
+## 目标
+
+1. BashJob 支持读取 reward protocol 的 trial 级 `result.json`。
+2. `trial.score` 与 `verifier_result.rewards.reward` 对齐。
+3. 保持 `JobExecutor` / `Job` 的现有抽象：`Trial.collect()` 可以返回单个 `TrialResult` 或 `list[TrialResult]`，由 Job 层统一 flatten。
+4. 对老 BashJob 保持兼容：没有 `result.json` 时仍返回基础 `TrialResult`；如果 stdout 中有标准 `score:` 行，可作为 fallback。
+5. 不改变 Harbor 的 result 解析路径。
+
+## 非目标
+
+- 不在 SDK 侧修复 path-like `trial_name` 造成的嵌套目录问题。SDK 只读取协议约定的位置，模板或任务脚本需要保证 `trial_name` 是 path-safe。
+- 不把 BashJob 强制绑定到某个 benchmark 模板。
+- 不引入新的 job result 协议，只适配已有 reward protocol。
+
+## reward protocol 约定
+
+BashJob 产物根目录默认为：
+
+```text
+/data/logs/user-defined
+```
+
+单 trial 场景需要写出：
+
+```text
+/data/logs/user-defined/
+├── result.json
+└── <trial_name>/
+    ├── result.json
+    ├── reward.txt
+    └── reward.json
+```
+
+SDK 解析的核心文件是 trial 级：
+
+```text
+<artifact_root>/<trial_name>/result.json
+```
+
+主分数读取路径：
+
+```text
+verifier_result.rewards.reward
+```
+
+`trial_name` 必须是单层目录名，例如 `task_1__Ab3xY9k`。如果任务名是 `tasks/T01zh_email_triage` 这类 path-like 值，模板应先生成 path-safe label，例如 `tasks_T01zh_email_triage__Ab3xY9k`，但 `task_name` 字段仍保留原始任务名，便于追踪。
+
+## 方案
+
+### 1. 新增 `RewardTrialResult`
+
+在 `rock.sdk.job.result` 中新增 `RewardTrialResult(TrialResult)`，作为 Bash reward protocol 的结构化结果模型。
+
+核心字段：
+
+| 字段 | 来源 | 说明 |
+|------|------|------|
+| `task_name` | trial `result.json` | 原始任务名 |
+| `trial_name` | trial `result.json` | trial 目录名 |
+| `trial_uri` | trial `result.json` | trial 目录 URI |
+| `task_id` / `source` / `task_checksum` | trial `result.json` | 任务追踪信息 |
+| `agent_info` | trial `result.json` | agent / model 信息 |
+| `agent_result` | trial `result.json` | token / cost / rollout details |
+| `verifier_result` | trial `result.json` | reward 字典 |
+| `exception_info` | trial `result.json` 或 Bash exit code | 异常信息 |
+
+`score` 属性覆盖为：
+
+```python
+return float(self.verifier_result.rewards.get("reward", 0.0))
+```
+
+这样 `JobResult.score` 仍可复用现有逻辑：对所有 trial 的 `score` 求平均。
+
+### 2. BashJob session 默认注入 `LOG_DIR`
+
+`BashTrial.on_sandbox_ready()` 中注入：
+
+```python
+env.setdefault("LOG_DIR", env_vars.ROCK_BASH_JOB_ARTIFACT_DIR)
+```
+
+目的：
+
+- 给 Bash 模板一个稳定默认写入位置。
+- 不覆盖用户显式传入的 `LOG_DIR`。
+- 与已有 OSS mirror 的 `ROCK_ARTIFACT_DIR` 保持兼容。
+
+### 3. `BashTrial.collect()` 优先读取 trial result
+
+收集顺序：
+
+1. 在候选 artifact roots 下查找 trial 级 `result.json`
+2. 找到后读取并解析为 `RewardTrialResult`
+3. 若进程 exit code 非 0 且 result 中没有 `exception_info`，补充 `BashExitCode`
+4. 返回 `list[RewardTrialResult]`
+
+候选 roots：
+
+```python
+[
+    env.get("LOG_DIR"),
+    env.get("ROCK_ARTIFACT_DIR"),
+    env_vars.ROCK_BASH_JOB_ARTIFACT_DIR,
+]
+```
+
+查找命令：
+
+```bash
+find <root> -mindepth 2 -maxdepth 2 -name result.json
+```
+
+`mindepth=2/maxdepth=2` 的含义是只匹配：
+
+```text
+<root>/<trial_name>/result.json
+```
+
+不会把 job 根目录的 `result.json` 当成 trial 结果，也不会递归吞掉任意深层文件。
+
+### 4. stdout `score:` fallback
+
+如果没有找到 trial result 文件，则解析 stdout 中最后一个标准分数行：
+
+```text
+score: 0.625
+```
+
+解析成功时返回 `RewardTrialResult`，只填充最小字段：
+
+- `task_name = job_name`
+- `raw_output`
+- `exit_code`
+- `verifier_result.rewards.reward = parsed_score`
+
+这个 fallback 用于兼容已有 Bash 模板或 CI 输出，不替代结构化 result。
+
+### 5. 最后回退到基础 `TrialResult`
+
+如果既没有 trial result，也没有可解析的 stdout score，则保持旧行为：
+
+- `exit_code == 0`: `TrialResult(status=completed, score=0.0)`
+- `exit_code != 0`: `TrialResult(exception_info=BashExitCode, score=0.0)`
+
+## 数据流
+
+```text
+Bash script
+  ├─ writes <LOG_DIR>/<trial_name>/result.json
+  ├─ optionally prints "score: <float>"
+  └─ exits with code
+
+JobExecutor._do_wait()
+  ├─ captures stdout / exit_code
+  └─ calls BashTrial.collect(sandbox, output, exit_code)
+
+BashTrial.collect()
+  ├─ parse trial result.json -> list[RewardTrialResult]
+  ├─ else parse stdout score -> RewardTrialResult
+  └─ else base TrialResult
+
+Job._build_result()
+  └─ flatten list results into JobResult.trial_results
+```
+
+## 兼容性
+
+- 对没有 reward protocol 的 BashJob 无行为破坏，仍返回基础 `TrialResult`。
+- 对只打印 `score:` 的 BashJob，`trial.score` 从 stdout fallback 得到非零值。
+- 对产出多个 trial result 的 BashJob，`collect()` 返回 list，Job 层已有 flatten 支持。
+- 对 HarborJob 无影响，Harbor 仍使用 `HarborTrialResult.from_harbor_json()`。
+
+## 边界与风险
+
+### path-like `trial_name`
+
+如果模板把原始 `TASKS=tasks/T01zh_email_triage` 直接拼进 `TRIAL_NAME`，实际文件会落到：
+
+```text
+/data/logs/user-defined/tasks/T01zh_email_triage__xxx/result.json
+```
+
+这不符合 `<root>/<trial_name>/result.json` 的单层目录协议，SDK 不会读取。修复点应在模板侧：`trial_name` 使用 path-safe label，`task_name` 保留原始值。
+
+### 多个 roots 重复发现
+
+`LOG_DIR`、`ROCK_ARTIFACT_DIR` 和默认 artifact dir 可能指向同一路径。SDK 对发现到的 `result.json` 路径去重，避免重复 trial。
+
+### result 文件解析失败
+
+单个文件解析失败只记录 warning，不阻断其它 trial result。若全部失败，则进入 stdout fallback / 基础 fallback。
+
+## 测试方案
+
+新增和覆盖以下单元测试：
+
+1. `RewardTrialResult.from_reward_json()` 能从 `verifier_result.rewards.reward` 得到 score。
+2. `BashTrial.collect()` 能读取 trial 级 `result.json` 并返回 `list[RewardTrialResult]`。
+3. 没有 result 文件时，`BashTrial.collect()` 能从 stdout `score:` 行得到 score。
+4. 公开导出 `RewardTrialResult`，保证 SDK import 面可用。
+
+验证命令：
+
+```bash
+uv run --extra admin --group test pytest tests/unit/sdk/job -q
+uv run ruff check rock/sdk/job/__init__.py rock/sdk/job/result.py rock/sdk/job/trial/bash.py tests/unit/sdk/job/test_integration.py tests/unit/sdk/job/test_result.py tests/unit/sdk/job/test_trial_bash.py
+uv run ruff format --check rock/sdk/job/__init__.py rock/sdk/job/result.py rock/sdk/job/trial/bash.py tests/unit/sdk/job/test_integration.py tests/unit/sdk/job/test_result.py tests/unit/sdk/job/test_trial_bash.py
+```
+
+## 后续
+
+1. 如果需要支持嵌套历史产物，可另开 issue 讨论是否在 SDK 中增加递归扫描模式；默认不建议，因为会扩大误读范围。
+2. Bash 模板侧应统一生成 path-safe `trial_name`，避免 `TASKS` / 文件路径 / CSV 路径直接成为目录结构。
+3. 可在未来的 JobViewer 文档中补充 Bash reward result 的读取路径和兼容层级。

--- a/docs/proposals/bashjob-reward-result-parsing.md
+++ b/docs/proposals/bashjob-reward-result-parsing.md
@@ -61,9 +61,17 @@ verifier_result.rewards.reward
 
 ## 方案
 
-### 1. 新增 `RewardTrialResult`
+### 1. 共用 reward protocol result model
 
-在 `rock.sdk.job.result` 中新增 `RewardTrialResult(TrialResult)`，作为 Bash reward protocol 的结构化结果模型。
+在 `rock.sdk.reward.result` 中提供共享 `RewardTrialResult(TrialResult)`，作为 Bash 和 Harbor 都能复用的 reward protocol 结构化结果模型。
+
+兼容导出：
+
+- `rock.sdk.job.result.RewardTrialResult`
+- `rock.sdk.job.RewardTrialResult`
+- `rock.sdk.bench.models.trial.result.HarborTrialResult`
+
+其中 `HarborTrialResult` 是 `RewardTrialResult` 的薄子类，用于保留 Harbor 侧历史 API。
 
 核心字段：
 

--- a/rock/sdk/bench/models/trial/result.py
+++ b/rock/sdk/bench/models/trial/result.py
@@ -1,120 +1,27 @@
-"""Harbor trial result models.
-
-The base TrialResult lives in rock.sdk.job.result.
-This module extends it with Harbor-specific fields as HarborTrialResult.
-"""
+"""Harbor trial result models."""
 
 from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, Field
-
 from rock.sdk.job.result import ExceptionInfo
-from rock.sdk.job.result import TrialResult as _BaseTrialResult
+from rock.sdk.reward.result import AgentInfo, AgentResult, ModelInfo, RewardTrialResult, TimingInfo, VerifierResult
+
+__all__ = [
+    "AgentInfo",
+    "AgentResult",
+    "ExceptionInfo",
+    "HarborTrialResult",
+    "ModelInfo",
+    "TimingInfo",
+    "VerifierResult",
+]
 
 
-class ModelInfo(BaseModel):
-    name: str = ""
-    provider: str = ""
-
-
-class AgentInfo(BaseModel):
-    name: str = ""
-    version: str = ""
-    model_info: ModelInfo | None = None
-
-
-class VerifierResult(BaseModel):
-    rewards: dict[str, float | int] | None = None
-
-
-class AgentResult(BaseModel):
-    n_input_tokens: int | None = None
-    n_cache_tokens: int | None = None
-    n_output_tokens: int | None = None
-    cost_usd: float | None = None
-    rollout_details: list[dict[str, Any]] | None = None
-
-
-class TimingInfo(BaseModel):
-    started_at: str | None = None
-    finished_at: str | None = None
-
-
-class HarborTrialResult(_BaseTrialResult):
-    """Harbor-specific TrialResult: extends the base with agent/verifier/timing fields."""
-
-    trial_name: str = ""
-    source: str | None = None
-    agent_info: AgentInfo = Field(default_factory=AgentInfo)
-    agent_result: AgentResult | None = None
-    verifier_result: VerifierResult | None = None
-    environment_setup: TimingInfo | None = None
-    agent_setup: TimingInfo | None = None
-    agent_execution: TimingInfo | None = None
-    verifier: TimingInfo | None = None
-
-    @property
-    def score(self) -> float:
-        if self.verifier_result and self.verifier_result.rewards:
-            return self.verifier_result.rewards.get("reward", 0.0)
-        return 0.0
-
-    @property
-    def status(self) -> str:
-        return "failed" if self.exception_info else "completed"
-
-    @property
-    def token_ids(self) -> list[int]:
-        if self.agent_result and self.agent_result.rollout_details:
-            ids = []
-            for detail in self.agent_result.rollout_details:
-                ids.extend(detail.get("completion_token_ids", []))
-            return ids
-        return []
+class HarborTrialResult(RewardTrialResult):
+    """Harbor trial result backed by the shared reward protocol model."""
 
     @classmethod
     def from_harbor_json(cls, data: dict[str, Any]) -> HarborTrialResult:
         """Parse a harbor trial-level result.json dict into HarborTrialResult."""
-        exception_info = None
-        if data.get("exception_info"):
-            ei = data["exception_info"]
-            if isinstance(ei, dict):
-                exception_info = ExceptionInfo(**ei)
-            else:
-                exception_info = ExceptionInfo(exception_type="unknown", exception_message=str(ei))
-
-        agent_info_data = data.get("agent_info") or {}
-        model_info = None
-        if agent_info_data.get("model_info"):
-            model_info = ModelInfo(**agent_info_data["model_info"])
-        agent_info = AgentInfo(
-            name=agent_info_data.get("name", ""),
-            version=agent_info_data.get("version", ""),
-            model_info=model_info,
-        )
-
-        verifier_result = None
-        if data.get("verifier_result"):
-            verifier_result = VerifierResult(**data["verifier_result"])
-
-        agent_result = None
-        if data.get("agent_result"):
-            agent_result = AgentResult(**data["agent_result"])
-
-        return cls(
-            task_name=data.get("task_name", ""),
-            trial_name=data.get("trial_name", ""),
-            source=data.get("source"),
-            agent_info=agent_info,
-            agent_result=agent_result,
-            verifier_result=verifier_result,
-            exception_info=exception_info,
-            started_at=data.get("started_at"),
-            finished_at=data.get("finished_at"),
-            environment_setup=TimingInfo(**data["environment_setup"]) if data.get("environment_setup") else None,
-            agent_setup=TimingInfo(**data["agent_setup"]) if data.get("agent_setup") else None,
-            agent_execution=TimingInfo(**data["agent_execution"]) if data.get("agent_execution") else None,
-            verifier=TimingInfo(**data["verifier"]) if data.get("verifier") else None,
-        )
+        return cls.from_reward_json(data)

--- a/rock/sdk/job/__init__.py
+++ b/rock/sdk/job/__init__.py
@@ -6,8 +6,9 @@ from rock.sdk.job.api import Job
 from rock.sdk.job.config import BashJobConfig, JobConfig
 from rock.sdk.job.executor import JobClient, JobExecutor, TrialClient
 from rock.sdk.job.operator import Operator, ScatterOperator
-from rock.sdk.job.result import ExceptionInfo, JobResult, JobStatus, RewardTrialResult, TrialResult
+from rock.sdk.job.result import ExceptionInfo, JobResult, JobStatus, TrialResult
 from rock.sdk.job.trial import AbstractTrial, register_trial
+from rock.sdk.reward.result import RewardTrialResult
 
 __all__ = [
     "Job",

--- a/rock/sdk/job/__init__.py
+++ b/rock/sdk/job/__init__.py
@@ -6,7 +6,7 @@ from rock.sdk.job.api import Job
 from rock.sdk.job.config import BashJobConfig, JobConfig
 from rock.sdk.job.executor import JobClient, JobExecutor, TrialClient
 from rock.sdk.job.operator import Operator, ScatterOperator
-from rock.sdk.job.result import ExceptionInfo, JobResult, JobStatus, TrialResult
+from rock.sdk.job.result import ExceptionInfo, JobResult, JobStatus, RewardTrialResult, TrialResult
 from rock.sdk.job.trial import AbstractTrial, register_trial
 
 __all__ = [
@@ -16,6 +16,7 @@ __all__ = [
     "JobResult",
     "JobStatus",
     "TrialResult",
+    "RewardTrialResult",
     "ExceptionInfo",
     "JobExecutor",
     "JobClient",

--- a/rock/sdk/job/result.py
+++ b/rock/sdk/job/result.py
@@ -1,14 +1,14 @@
 """Result models for the Job system.
 
-Base classes: TrialResult, JobStatus, JobResult[T].
-Harbor-specific subclasses in rock.sdk.agent.models.trial.result.
+Base classes: TrialResult, RewardTrialResult, JobStatus, JobResult[T].
+Harbor-specific subclasses live in rock.sdk.bench.models.trial.result.
 """
 
 from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel, Field
 
@@ -59,6 +59,116 @@ class TrialResult(BaseModel):
             except (ValueError, TypeError):
                 pass
         return 0.0
+
+
+class ModelInfo(BaseModel):
+    name: str = ""
+    provider: str = ""
+
+
+class AgentInfo(BaseModel):
+    name: str = ""
+    version: str = ""
+    model_info: ModelInfo | None = None
+
+
+class VerifierResult(BaseModel):
+    rewards: dict[str, float | int] | None = None
+
+
+class AgentResult(BaseModel):
+    n_input_tokens: int | None = None
+    n_cache_tokens: int | None = None
+    n_output_tokens: int | None = None
+    cost_usd: float | None = None
+    rollout_details: list[dict[str, Any]] | None = None
+
+
+class TimingInfo(BaseModel):
+    started_at: str | None = None
+    finished_at: str | None = None
+
+
+class RewardTrialResult(TrialResult):
+    """Trial result parsed from the reward protocol's trial-level result.json."""
+
+    trial_name: str = ""
+    trial_uri: str | None = None
+    task_id: dict[str, Any] | None = None
+    source: str | None = None
+    task_checksum: str | None = None
+    config: dict[str, Any] | None = None
+    agent_info: AgentInfo = Field(default_factory=AgentInfo)
+    agent_result: AgentResult | None = None
+    verifier_result: VerifierResult | None = None
+    environment_setup: TimingInfo | None = None
+    agent_setup: TimingInfo | None = None
+    agent_execution: TimingInfo | None = None
+    verifier: TimingInfo | None = None
+
+    @property
+    def score(self) -> float:
+        if self.verifier_result and self.verifier_result.rewards:
+            return float(self.verifier_result.rewards.get("reward", 0.0))
+        return 0.0
+
+    @property
+    def token_ids(self) -> list[int]:
+        if self.agent_result and self.agent_result.rollout_details:
+            ids = []
+            for detail in self.agent_result.rollout_details:
+                ids.extend(detail.get("completion_token_ids", []))
+            return ids
+        return []
+
+    @classmethod
+    def from_reward_json(cls, data: dict[str, Any]) -> RewardTrialResult:
+        """Parse a reward-protocol trial-level result.json dict."""
+        exception_info = None
+        if data.get("exception_info"):
+            ei = data["exception_info"]
+            if isinstance(ei, dict):
+                exception_info = ExceptionInfo(**ei)
+            else:
+                exception_info = ExceptionInfo(exception_type="unknown", exception_message=str(ei))
+
+        agent_info_data = data.get("agent_info") or {}
+        model_info = None
+        if agent_info_data.get("model_info"):
+            model_info = ModelInfo(**agent_info_data["model_info"])
+        agent_info = AgentInfo(
+            name=agent_info_data.get("name", ""),
+            version=agent_info_data.get("version", ""),
+            model_info=model_info,
+        )
+
+        verifier_result = None
+        if data.get("verifier_result"):
+            verifier_result = VerifierResult(**data["verifier_result"])
+
+        agent_result = None
+        if data.get("agent_result"):
+            agent_result = AgentResult(**data["agent_result"])
+
+        return cls(
+            task_name=data.get("task_name", ""),
+            trial_name=data.get("trial_name", ""),
+            trial_uri=data.get("trial_uri"),
+            task_id=data.get("task_id"),
+            source=data.get("source"),
+            task_checksum=data.get("task_checksum"),
+            config=data.get("config"),
+            agent_info=agent_info,
+            agent_result=agent_result,
+            verifier_result=verifier_result,
+            exception_info=exception_info,
+            started_at=data.get("started_at"),
+            finished_at=data.get("finished_at"),
+            environment_setup=TimingInfo(**data["environment_setup"]) if data.get("environment_setup") else None,
+            agent_setup=TimingInfo(**data["agent_setup"]) if data.get("agent_setup") else None,
+            agent_execution=TimingInfo(**data["agent_execution"]) if data.get("agent_execution") else None,
+            verifier=TimingInfo(**data["verifier"]) if data.get("verifier") else None,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/rock/sdk/job/result.py
+++ b/rock/sdk/job/result.py
@@ -1,175 +1,31 @@
 """Result models for the Job system.
 
-Base classes: TrialResult, RewardTrialResult, JobStatus, JobResult[T].
-Harbor-specific subclasses live in rock.sdk.bench.models.trial.result.
+Base classes: TrialResult, JobStatus, JobResult[T].
+Reward-protocol result models live in rock.sdk.reward.result.
 """
 
 from __future__ import annotations
 
-from datetime import datetime
 from enum import Enum
-from typing import Any, Generic, TypeVar
+from typing import Generic, TypeVar
 
 from pydantic import BaseModel, Field
 
-# ---------------------------------------------------------------------------
-# TrialResult base — common fields
-# ---------------------------------------------------------------------------
+from rock.sdk.result import ExceptionInfo, TrialResult
+from rock.sdk.reward.result import AgentInfo, AgentResult, ModelInfo, RewardTrialResult, TimingInfo, VerifierResult
 
-
-class ExceptionInfo(BaseModel):
-    """General exception info."""
-
-    exception_type: str = ""
-    exception_message: str = ""
-    exception_traceback: str = ""
-    occurred_at: str | None = None
-
-
-class TrialResult(BaseModel):
-    """Base class for a single execution result — common fields.
-
-    Harbor's TrialResult inherits this class and adds agent_info, verifier_result, etc.
-    Subclasses can override the score and status properties.
-    """
-
-    task_name: str = ""
-    exception_info: ExceptionInfo | None = None
-    started_at: str | None = None
-    finished_at: str | None = None
-    # G5: process-level outputs captured by JobExecutor
-    raw_output: str = ""
-    exit_code: int = 0
-
-    @property
-    def score(self) -> float:
-        return 0.0
-
-    @property
-    def status(self) -> str:
-        return "failed" if self.exception_info else "completed"
-
-    @property
-    def duration_sec(self) -> float:
-        if self.started_at and self.finished_at:
-            try:
-                start = datetime.fromisoformat(self.started_at.replace("Z", "+00:00"))
-                end = datetime.fromisoformat(self.finished_at.replace("Z", "+00:00"))
-                return (end - start).total_seconds()
-            except (ValueError, TypeError):
-                pass
-        return 0.0
-
-
-class ModelInfo(BaseModel):
-    name: str = ""
-    provider: str = ""
-
-
-class AgentInfo(BaseModel):
-    name: str = ""
-    version: str = ""
-    model_info: ModelInfo | None = None
-
-
-class VerifierResult(BaseModel):
-    rewards: dict[str, float | int] | None = None
-
-
-class AgentResult(BaseModel):
-    n_input_tokens: int | None = None
-    n_cache_tokens: int | None = None
-    n_output_tokens: int | None = None
-    cost_usd: float | None = None
-    rollout_details: list[dict[str, Any]] | None = None
-
-
-class TimingInfo(BaseModel):
-    started_at: str | None = None
-    finished_at: str | None = None
-
-
-class RewardTrialResult(TrialResult):
-    """Trial result parsed from the reward protocol's trial-level result.json."""
-
-    trial_name: str = ""
-    trial_uri: str | None = None
-    task_id: dict[str, Any] | None = None
-    source: str | None = None
-    task_checksum: str | None = None
-    config: dict[str, Any] | None = None
-    agent_info: AgentInfo = Field(default_factory=AgentInfo)
-    agent_result: AgentResult | None = None
-    verifier_result: VerifierResult | None = None
-    environment_setup: TimingInfo | None = None
-    agent_setup: TimingInfo | None = None
-    agent_execution: TimingInfo | None = None
-    verifier: TimingInfo | None = None
-
-    @property
-    def score(self) -> float:
-        if self.verifier_result and self.verifier_result.rewards:
-            return float(self.verifier_result.rewards.get("reward", 0.0))
-        return 0.0
-
-    @property
-    def token_ids(self) -> list[int]:
-        if self.agent_result and self.agent_result.rollout_details:
-            ids = []
-            for detail in self.agent_result.rollout_details:
-                ids.extend(detail.get("completion_token_ids", []))
-            return ids
-        return []
-
-    @classmethod
-    def from_reward_json(cls, data: dict[str, Any]) -> RewardTrialResult:
-        """Parse a reward-protocol trial-level result.json dict."""
-        exception_info = None
-        if data.get("exception_info"):
-            ei = data["exception_info"]
-            if isinstance(ei, dict):
-                exception_info = ExceptionInfo(**ei)
-            else:
-                exception_info = ExceptionInfo(exception_type="unknown", exception_message=str(ei))
-
-        agent_info_data = data.get("agent_info") or {}
-        model_info = None
-        if agent_info_data.get("model_info"):
-            model_info = ModelInfo(**agent_info_data["model_info"])
-        agent_info = AgentInfo(
-            name=agent_info_data.get("name", ""),
-            version=agent_info_data.get("version", ""),
-            model_info=model_info,
-        )
-
-        verifier_result = None
-        if data.get("verifier_result"):
-            verifier_result = VerifierResult(**data["verifier_result"])
-
-        agent_result = None
-        if data.get("agent_result"):
-            agent_result = AgentResult(**data["agent_result"])
-
-        return cls(
-            task_name=data.get("task_name", ""),
-            trial_name=data.get("trial_name", ""),
-            trial_uri=data.get("trial_uri"),
-            task_id=data.get("task_id"),
-            source=data.get("source"),
-            task_checksum=data.get("task_checksum"),
-            config=data.get("config"),
-            agent_info=agent_info,
-            agent_result=agent_result,
-            verifier_result=verifier_result,
-            exception_info=exception_info,
-            started_at=data.get("started_at"),
-            finished_at=data.get("finished_at"),
-            environment_setup=TimingInfo(**data["environment_setup"]) if data.get("environment_setup") else None,
-            agent_setup=TimingInfo(**data["agent_setup"]) if data.get("agent_setup") else None,
-            agent_execution=TimingInfo(**data["agent_execution"]) if data.get("agent_execution") else None,
-            verifier=TimingInfo(**data["verifier"]) if data.get("verifier") else None,
-        )
-
+__all__ = [
+    "AgentInfo",
+    "AgentResult",
+    "ExceptionInfo",
+    "JobResult",
+    "JobStatus",
+    "ModelInfo",
+    "RewardTrialResult",
+    "TimingInfo",
+    "TrialResult",
+    "VerifierResult",
+]
 
 # ---------------------------------------------------------------------------
 # JobStatus + JobResult[T]

--- a/rock/sdk/job/trial/bash.py
+++ b/rock/sdk/job/trial/bash.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+import json
 import os
+import re
 import secrets
 from pathlib import Path
 
 from rock import env_vars
+from rock.actions import Command, ReadFileRequest
 from rock.logger import init_logger
 from rock.sdk.job.config import BashJobConfig
-from rock.sdk.job.result import ExceptionInfo, TrialResult
+from rock.sdk.job.result import ExceptionInfo, RewardTrialResult, TrialResult, VerifierResult
 from rock.sdk.job.trial.abstract import AbstractTrial
 from rock.sdk.job.trial.registry import register_trial
 from rock.sdk.sandbox.client import Sandbox
@@ -23,6 +26,8 @@ _OSS_CREDENTIAL_FIELDS = (
     "oss_region",
     "oss_bucket",
 )
+
+_SCORE_RE = re.compile(r"^score:\s*(?P<score>\S+)\s*$", re.MULTILINE)
 
 
 class BashTrial(AbstractTrial):
@@ -49,8 +54,14 @@ class BashTrial(AbstractTrial):
         session env.
         """
         await super().on_sandbox_ready(sandbox)
+        self._prepare_reward_session_env()
         if self._oss_mirror_enabled():
             self._prepare_oss_session_env()
+
+    def _prepare_reward_session_env(self) -> None:
+        """Inject default reward-protocol paths for bash templates."""
+        env = self._config.environment.env
+        env.setdefault("LOG_DIR", env_vars.ROCK_BASH_JOB_ARTIFACT_DIR)
 
     def _prepare_oss_session_env(self) -> None:
         """Resolve OSS credentials, validate, and inject derived ROCK_* keys.
@@ -83,9 +94,9 @@ class BashTrial(AbstractTrial):
                 raise ValueError(f"oss_mirror.enabled=True but {env_key} is not resolvable")
 
         env["ROCK_ARTIFACT_DIR"] = env_vars.ROCK_BASH_JOB_ARTIFACT_DIR
-        env[
-            "ROCK_OSS_PREFIX"
-        ] = f"artifacts/{self._config.namespace}/{self._config.experiment_id}/{self._config.job_name}"
+        env["ROCK_OSS_PREFIX"] = (
+            f"artifacts/{self._config.namespace}/{self._config.experiment_id}/{self._config.job_name}"
+        )
 
     @staticmethod
     def _render_wrapper(user_script: str, token: str | None = None) -> str:
@@ -148,13 +159,83 @@ class BashTrial(AbstractTrial):
             return script
         return self._render_wrapper(script)
 
-    async def collect(self, sandbox: Sandbox, output: str, exit_code: int) -> TrialResult:
+    def _result_roots(self) -> list[str]:
+        env = self._config.environment.env
+        roots = [
+            env.get("LOG_DIR"),
+            env.get("ROCK_ARTIFACT_DIR"),
+            env_vars.ROCK_BASH_JOB_ARTIFACT_DIR,
+        ]
+        return list(dict.fromkeys(root for root in roots if root))
+
+    @staticmethod
+    def _bash_exception(exit_code: int) -> ExceptionInfo | None:
+        if exit_code == 0:
+            return None
+        return ExceptionInfo(
+            exception_type="BashExitCode",
+            exception_message=f"Bash script exited with code {exit_code}",
+        )
+
+    async def _collect_reward_results(self, sandbox: Sandbox, exit_code: int) -> list[RewardTrialResult]:
+        """Read reward-protocol trial-level result.json files from sandbox."""
+        trial_files: list[str] = []
+        for root in self._result_roots():
+            try:
+                list_result = await sandbox.execute(
+                    Command(command=["find", root, "-mindepth", "2", "-maxdepth", "2", "-name", "result.json"])
+                )
+                stdout = getattr(list_result, "stdout", "")
+                if isinstance(stdout, str):
+                    trial_files.extend(line.strip() for line in stdout.strip().split("\n") if line.strip())
+            except Exception as e:
+                logger.debug(f"Failed to list bash reward results under {root}: {e}")
+
+        results: list[RewardTrialResult] = []
+        for trial_file in dict.fromkeys(trial_files):
+            try:
+                response = await sandbox.read_file(ReadFileRequest(path=trial_file))
+                data = json.loads(response.content)
+                result = RewardTrialResult.from_reward_json(data)
+                if exit_code != 0 and result.exception_info is None:
+                    result.exception_info = self._bash_exception(exit_code)
+                results.append(result)
+            except Exception as e:
+                logger.warning(f"Failed to parse bash reward result {trial_file}: {e}")
+        return results
+
+    def _collect_stdout_score(self, output: str, exit_code: int) -> RewardTrialResult | None:
+        matches = _SCORE_RE.findall(output or "")
+        if not matches:
+            return None
+        raw_score = matches[-1]
+        if raw_score.upper() == "N/A":
+            return None
+        try:
+            score = float(raw_score)
+        except ValueError:
+            logger.warning(f"Failed to parse bash score summary value: {raw_score!r}")
+            return None
+        return RewardTrialResult(
+            task_name=self._config.job_name or "",
+            exception_info=self._bash_exception(exit_code),
+            raw_output=output,
+            exit_code=exit_code,
+            verifier_result=VerifierResult(rewards={"reward": score}),
+        )
+
+    async def collect(self, sandbox: Sandbox, output: str, exit_code: int) -> TrialResult | list[TrialResult]:
+        reward_results = await self._collect_reward_results(sandbox, exit_code)
+        if reward_results:
+            return reward_results
+
+        stdout_score = self._collect_stdout_score(output, exit_code)
+        if stdout_score is not None:
+            return stdout_score
+
         exception_info = None
         if exit_code != 0:
-            exception_info = ExceptionInfo(
-                exception_type="BashExitCode",
-                exception_message=f"Bash script exited with code {exit_code}",
-            )
+            exception_info = self._bash_exception(exit_code)
 
         return TrialResult(
             task_name=self._config.job_name or "",

--- a/rock/sdk/job/trial/bash.py
+++ b/rock/sdk/job/trial/bash.py
@@ -12,9 +12,10 @@ from rock import env_vars
 from rock.actions import Command, ReadFileRequest
 from rock.logger import init_logger
 from rock.sdk.job.config import BashJobConfig
-from rock.sdk.job.result import ExceptionInfo, RewardTrialResult, TrialResult, VerifierResult
+from rock.sdk.job.result import ExceptionInfo, TrialResult
 from rock.sdk.job.trial.abstract import AbstractTrial
 from rock.sdk.job.trial.registry import register_trial
+from rock.sdk.reward.result import RewardTrialResult, VerifierResult
 from rock.sdk.sandbox.client import Sandbox
 
 logger = init_logger(__name__)

--- a/rock/sdk/job/trial/bash.py
+++ b/rock/sdk/job/trial/bash.py
@@ -185,9 +185,7 @@ class BashTrial(AbstractTrial):
                 list_result = await sandbox.execute(
                     Command(command=["find", root, "-mindepth", "2", "-maxdepth", "2", "-name", "result.json"])
                 )
-                stdout = getattr(list_result, "stdout", "")
-                if isinstance(stdout, str):
-                    trial_files.extend(line.strip() for line in stdout.strip().split("\n") if line.strip())
+                trial_files.extend(line.strip() for line in list_result.stdout.strip().split("\n") if line.strip())
             except Exception as e:
                 logger.debug(f"Failed to list bash reward results under {root}: {e}")
 
@@ -197,6 +195,7 @@ class BashTrial(AbstractTrial):
                 response = await sandbox.read_file(ReadFileRequest(path=trial_file))
                 data = json.loads(response.content)
                 result = RewardTrialResult.from_reward_json(data)
+                result.exit_code = exit_code
                 if exit_code != 0 and result.exception_info is None:
                     result.exception_info = self._bash_exception(exit_code)
                 results.append(result)

--- a/rock/sdk/result.py
+++ b/rock/sdk/result.py
@@ -1,0 +1,46 @@
+"""Shared SDK result base models."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class ExceptionInfo(BaseModel):
+    """General exception info."""
+
+    exception_type: str = ""
+    exception_message: str = ""
+    exception_traceback: str = ""
+    occurred_at: str | None = None
+
+
+class TrialResult(BaseModel):
+    """Base class for a single execution result."""
+
+    task_name: str = ""
+    exception_info: ExceptionInfo | None = None
+    started_at: str | None = None
+    finished_at: str | None = None
+    raw_output: str = ""
+    exit_code: int = 0
+
+    @property
+    def score(self) -> float:
+        return 0.0
+
+    @property
+    def status(self) -> str:
+        return "failed" if self.exception_info else "completed"
+
+    @property
+    def duration_sec(self) -> float:
+        if self.started_at and self.finished_at:
+            try:
+                start = datetime.fromisoformat(self.started_at.replace("Z", "+00:00"))
+                end = datetime.fromisoformat(self.finished_at.replace("Z", "+00:00"))
+                return (end - start).total_seconds()
+            except (ValueError, TypeError):
+                pass
+        return 0.0

--- a/rock/sdk/reward/__init__.py
+++ b/rock/sdk/reward/__init__.py
@@ -1,0 +1,21 @@
+"""Shared reward protocol models."""
+
+from rock.sdk.reward.result import (
+    AgentInfo,
+    AgentResult,
+    ExceptionInfo,
+    ModelInfo,
+    RewardTrialResult,
+    TimingInfo,
+    VerifierResult,
+)
+
+__all__ = [
+    "AgentInfo",
+    "AgentResult",
+    "ExceptionInfo",
+    "ModelInfo",
+    "RewardTrialResult",
+    "TimingInfo",
+    "VerifierResult",
+]

--- a/rock/sdk/reward/result.py
+++ b/rock/sdk/reward/result.py
@@ -1,0 +1,85 @@
+"""Shared reward protocol result models."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+from rock.sdk.result import ExceptionInfo, TrialResult
+
+
+class ModelInfo(BaseModel):
+    name: str = ""
+    provider: str = ""
+
+
+class AgentInfo(BaseModel):
+    name: str = ""
+    version: str = ""
+    model_info: ModelInfo | None = None
+
+
+class VerifierResult(BaseModel):
+    rewards: dict[str, float | int] | None = None
+
+
+class AgentResult(BaseModel):
+    n_input_tokens: int | None = None
+    n_cache_tokens: int | None = None
+    n_output_tokens: int | None = None
+    cost_usd: float | None = None
+    rollout_details: list[dict[str, Any]] | None = None
+
+
+class TimingInfo(BaseModel):
+    started_at: str | None = None
+    finished_at: str | None = None
+
+
+class RewardTrialResult(TrialResult):
+    """Trial result parsed from the reward protocol's trial-level result.json."""
+
+    trial_name: str = ""
+    trial_uri: str | None = None
+    task_id: dict[str, Any] | None = None
+    source: str | None = None
+    task_checksum: str | None = None
+    config: dict[str, Any] | None = None
+    agent_info: AgentInfo = Field(default_factory=AgentInfo)
+    agent_result: AgentResult | None = None
+    verifier_result: VerifierResult | None = None
+    environment_setup: TimingInfo | None = None
+    agent_setup: TimingInfo | None = None
+    agent_execution: TimingInfo | None = None
+    verifier: TimingInfo | None = None
+
+    @field_validator("exception_info", mode="before")
+    @classmethod
+    def _coerce_exception_info(cls, value: Any) -> Any:
+        if not value or isinstance(value, ExceptionInfo) or isinstance(value, dict):
+            return value
+        return {
+            "exception_type": "unknown",
+            "exception_message": str(value),
+        }
+
+    @property
+    def score(self) -> float:
+        if self.verifier_result and self.verifier_result.rewards:
+            return float(self.verifier_result.rewards.get("reward", 0.0))
+        return 0.0
+
+    @property
+    def token_ids(self) -> list[int]:
+        if self.agent_result and self.agent_result.rollout_details:
+            ids = []
+            for detail in self.agent_result.rollout_details:
+                ids.extend(detail.get("completion_token_ids", []))
+            return ids
+        return []
+
+    @classmethod
+    def from_reward_json(cls, data: dict[str, Any]) -> RewardTrialResult:
+        """Parse a reward-protocol trial-level result.json dict."""
+        return cls.model_validate(data)

--- a/tests/unit/sdk/job/test_executor.py
+++ b/tests/unit/sdk/job/test_executor.py
@@ -22,6 +22,7 @@ def _make_mock_sandbox():
     sandbox.close = AsyncMock()
     sandbox.create_session = AsyncMock()
     sandbox.write_file_by_path = AsyncMock(return_value=MagicMock(success=True))
+    sandbox.execute = AsyncMock(return_value=MagicMock(stdout=""))
 
     # fs.upload_dir for _upload_files — returns success obs
     upload_obs = MagicMock()
@@ -232,9 +233,9 @@ class TestExecutorPaths:
         # Inspect the path passed to write_file_by_path — must start with USER_DEFINED_LOGS
         write_call = mock_sandbox.write_file_by_path.call_args
         script_path = write_call.args[1] if len(write_call.args) >= 2 else write_call.kwargs["path"]
-        assert script_path.startswith(
-            USER_DEFINED_LOGS
-        ), f"script path {script_path!r} must live under {USER_DEFINED_LOGS!r}, not /tmp"
+        assert script_path.startswith(USER_DEFINED_LOGS), (
+            f"script path {script_path!r} must live under {USER_DEFINED_LOGS!r}, not /tmp"
+        )
 
     async def test_do_submit_passes_nohup_tmp_file_under_user_defined_logs(self):
         mock_sandbox = _make_mock_sandbox()

--- a/tests/unit/sdk/job/test_integration.py
+++ b/tests/unit/sdk/job/test_integration.py
@@ -15,10 +15,11 @@ class TestPublicImports:
         assert issubclass(BashJobConfig, JobConfig)
 
     def test_import_results(self):
-        from rock.sdk.job import JobStatus, TrialResult
+        from rock.sdk.job import JobStatus, RewardTrialResult, TrialResult
 
         assert JobStatus.COMPLETED == "completed"
         assert TrialResult is not None
+        assert RewardTrialResult is not None
 
     def test_import_operator(self):
         from rock.sdk.job import Operator, ScatterOperator

--- a/tests/unit/sdk/job/test_job.py
+++ b/tests/unit/sdk/job/test_job.py
@@ -24,6 +24,7 @@ def _make_mock_sandbox():
     sandbox.close = AsyncMock()
     sandbox.create_session = AsyncMock()
     sandbox.write_file_by_path = AsyncMock()
+    sandbox.execute = AsyncMock(return_value=MagicMock(stdout=""))
     sandbox.arun = AsyncMock()
 
     upload_obs = MagicMock()

--- a/tests/unit/sdk/job/test_result.py
+++ b/tests/unit/sdk/job/test_result.py
@@ -71,6 +71,14 @@ class TestJobResult:
 
 
 class TestRewardTrialResult:
+    def test_reward_protocol_models_are_shared_with_harbor(self):
+        from rock.sdk.bench.models.trial.result import VerifierResult as HarborVerifierResult
+        from rock.sdk.job.result import VerifierResult as JobVerifierResult
+        from rock.sdk.reward.result import VerifierResult as SharedVerifierResult
+
+        assert JobVerifierResult is SharedVerifierResult
+        assert HarborVerifierResult is SharedVerifierResult
+
     def test_score_comes_from_verifier_reward(self):
         result = RewardTrialResult.from_reward_json(
             {

--- a/tests/unit/sdk/job/test_result.py
+++ b/tests/unit/sdk/job/test_result.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import BaseModel
 
-from rock.sdk.job.result import JobResult, JobStatus
+from rock.sdk.job.result import JobResult, JobStatus, RewardTrialResult
 
 
 class _Item(BaseModel):
@@ -68,3 +68,19 @@ class TestJobResult:
         r = JobResult(raw_output="output", exit_code=1)
         assert r.raw_output == "output"
         assert r.exit_code == 1
+
+
+class TestRewardTrialResult:
+    def test_score_comes_from_verifier_reward(self):
+        result = RewardTrialResult.from_reward_json(
+            {
+                "task_name": "task-1",
+                "trial_name": "task-1__abc",
+                "verifier_result": {"rewards": {"reward": 0.85, "task_score": 0.85}},
+                "exception_info": None,
+            }
+        )
+
+        assert result.task_name == "task-1"
+        assert result.trial_name == "task-1__abc"
+        assert result.score == pytest.approx(0.85)

--- a/tests/unit/sdk/job/test_trial_bash.py
+++ b/tests/unit/sdk/job/test_trial_bash.py
@@ -138,6 +138,9 @@ class TestBashTrialCollect:
         cfg = BashJobConfig(script="echo hi", job_name="myjob")
         trial = BashTrial(cfg)
         mock_sandbox = AsyncMock()
+        list_result = MagicMock()
+        list_result.stdout = ""
+        mock_sandbox.execute = AsyncMock(return_value=list_result)
 
         result = await trial.collect(mock_sandbox, output="hi\n", exit_code=0)
 
@@ -149,6 +152,9 @@ class TestBashTrialCollect:
         cfg = BashJobConfig(script="false", job_name="myjob")
         trial = BashTrial(cfg)
         mock_sandbox = AsyncMock()
+        list_result = MagicMock()
+        list_result.stdout = ""
+        mock_sandbox.execute = AsyncMock(return_value=list_result)
 
         result = await trial.collect(mock_sandbox, output="", exit_code=1)
 
@@ -182,6 +188,121 @@ class TestBashTrialCollect:
         assert len(result) == 1
         assert result[0].task_name == "task-1"
         assert result[0].score == pytest.approx(0.85)
+
+    async def test_collect_propagates_exit_code_to_reward_result(self):
+        cfg = BashJobConfig(script="false", job_name="myjob")
+        trial = BashTrial(cfg)
+        mock_sandbox = AsyncMock()
+
+        list_result = MagicMock()
+        list_result.stdout = "/data/logs/user-defined/task-1__abc/result.json\n"
+        mock_sandbox.execute = AsyncMock(return_value=list_result)
+
+        response = MagicMock()
+        response.content = json.dumps(
+            {
+                "task_name": "task-1",
+                "trial_name": "task-1__abc",
+                "verifier_result": {"rewards": {"reward": 0.85}},
+                "exception_info": None,
+            }
+        )
+        mock_sandbox.read_file = AsyncMock(return_value=response)
+
+        result = await trial.collect(mock_sandbox, output="ignored", exit_code=7)
+
+        assert isinstance(result, list)
+        assert result[0].exit_code == 7
+        assert result[0].exception_info is not None
+        assert result[0].exception_info.exception_type == "BashExitCode"
+
+    async def test_collect_reads_multiple_reward_protocol_trial_results(self):
+        cfg = BashJobConfig(script="echo hi", job_name="myjob")
+        trial = BashTrial(cfg)
+        mock_sandbox = AsyncMock()
+
+        first = "/data/logs/user-defined/task-1__abc/result.json"
+        second = "/data/logs/user-defined/task-2__def/result.json"
+        list_result = MagicMock()
+        list_result.stdout = f"{first}\n{second}\n"
+        mock_sandbox.execute = AsyncMock(return_value=list_result)
+
+        payloads = {
+            first: {
+                "task_name": "task-1",
+                "trial_name": "task-1__abc",
+                "verifier_result": {"rewards": {"reward": 0.25}},
+            },
+            second: {
+                "task_name": "task-2",
+                "trial_name": "task-2__def",
+                "verifier_result": {"rewards": {"reward": 0.75}},
+            },
+        }
+
+        async def read_file(req):
+            response = MagicMock()
+            response.content = json.dumps(payloads[req.path])
+            return response
+
+        mock_sandbox.read_file = AsyncMock(side_effect=read_file)
+
+        result = await trial.collect(mock_sandbox, output="ignored", exit_code=0)
+
+        assert isinstance(result, list)
+        assert [r.task_name for r in result] == ["task-1", "task-2"]
+        assert [r.score for r in result] == [pytest.approx(0.25), pytest.approx(0.75)]
+
+    async def test_collect_skips_broken_reward_json_and_uses_stdout_score(self):
+        cfg = BashJobConfig(script="echo hi", job_name="myjob")
+        trial = BashTrial(cfg)
+        mock_sandbox = AsyncMock()
+
+        list_result = MagicMock()
+        list_result.stdout = "/data/logs/user-defined/task-1__abc/result.json\n"
+        mock_sandbox.execute = AsyncMock(return_value=list_result)
+
+        response = MagicMock()
+        response.content = "{not-json"
+        mock_sandbox.read_file = AsyncMock(return_value=response)
+
+        result = await trial.collect(
+            mock_sandbox,
+            output="=== Score Summary ===\nscore: 0.625\n",
+            exit_code=0,
+        )
+
+        assert result.task_name == "myjob"
+        assert result.score == pytest.approx(0.625)
+
+    async def test_collect_deduplicates_reward_result_paths(self):
+        cfg = BashJobConfig(
+            script="echo hi",
+            job_name="myjob",
+            environment=EnvironmentConfig(env={"LOG_DIR": "/logs", "ROCK_ARTIFACT_DIR": "/other"}),
+        )
+        trial = BashTrial(cfg)
+        mock_sandbox = AsyncMock()
+
+        list_result = MagicMock()
+        list_result.stdout = "/logs/task-1__abc/result.json\n/logs/task-1__abc/result.json\n"
+        mock_sandbox.execute = AsyncMock(return_value=list_result)
+
+        response = MagicMock()
+        response.content = json.dumps(
+            {
+                "task_name": "task-1",
+                "trial_name": "task-1__abc",
+                "verifier_result": {"rewards": {"reward": 0.85}},
+            }
+        )
+        mock_sandbox.read_file = AsyncMock(return_value=response)
+
+        result = await trial.collect(mock_sandbox, output="ignored", exit_code=0)
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert mock_sandbox.read_file.call_count == 1
 
     async def test_collect_uses_stdout_score_when_no_result_json_exists(self):
         cfg = BashJobConfig(script="echo hi", job_name="myjob")
@@ -268,6 +389,7 @@ def _oss_sandbox(ns="ns", exp="exp"):
     sb._namespace = ns
     sb._experiment_id = exp
     sb.arun = AsyncMock(return_value=MagicMock(exit_code=0, output=""))
+    sb.execute = AsyncMock(return_value=MagicMock(stdout=""))
     sb.fs.ensure_ossutil = AsyncMock(return_value=True)
     sb.fs.upload_dir = AsyncMock(return_value=MagicMock(exit_code=0))
     return sb

--- a/tests/unit/sdk/job/test_trial_bash.py
+++ b/tests/unit/sdk/job/test_trial_bash.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -154,6 +155,50 @@ class TestBashTrialCollect:
         assert result.exception_info is not None
         assert result.exception_info.exception_type == "BashExitCode"
         assert result.status == "failed"
+
+    async def test_collect_reads_reward_protocol_trial_result_json(self):
+        cfg = BashJobConfig(script="echo hi", job_name="myjob")
+        trial = BashTrial(cfg)
+        mock_sandbox = AsyncMock()
+
+        list_result = MagicMock()
+        list_result.stdout = "/data/logs/user-defined/task-1__abc/result.json\n"
+        mock_sandbox.execute = AsyncMock(return_value=list_result)
+
+        response = MagicMock()
+        response.content = json.dumps(
+            {
+                "task_name": "task-1",
+                "trial_name": "task-1__abc",
+                "verifier_result": {"rewards": {"reward": 0.85, "task_score": 0.85}},
+                "exception_info": None,
+            }
+        )
+        mock_sandbox.read_file = AsyncMock(return_value=response)
+
+        result = await trial.collect(mock_sandbox, output="ignored", exit_code=0)
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0].task_name == "task-1"
+        assert result[0].score == pytest.approx(0.85)
+
+    async def test_collect_uses_stdout_score_when_no_result_json_exists(self):
+        cfg = BashJobConfig(script="echo hi", job_name="myjob")
+        trial = BashTrial(cfg)
+        mock_sandbox = AsyncMock()
+        list_result = MagicMock()
+        list_result.stdout = ""
+        mock_sandbox.execute = AsyncMock(return_value=list_result)
+
+        result = await trial.collect(
+            mock_sandbox,
+            output="=== Score Summary ===\nscore: 0.625\n",
+            exit_code=0,
+        )
+
+        assert result.task_name == "myjob"
+        assert result.score == pytest.approx(0.625)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
fixes #1214

## Summary

- Add shared reward-protocol result models under `rock.sdk.reward.result`
- Keep `rock.sdk.job.result` and Harbor result import paths backward-compatible via re-exports / thin wrappers
- Teach `BashTrial.collect()` to discover `<trial_name>/result.json` under Bash job artifact roots and parse `verifier_result.rewards.reward` as `trial.score`
- Propagate Bash process `exit_code` onto parsed reward-protocol trial results
- Set a default `LOG_DIR` for BashJob sessions and keep stdout `score:` parsing as a compatibility fallback when no trial result file exists
- Document the adaptation plan in `docs/proposals/bashjob-reward-result-parsing.md`
- Document the Job result protocol in `docs/dev/job/result-protocol.md`

## Root cause

BashJob collection only converted process exit status into the base `TrialResult`. The base result type has no verifier rewards, so `TrialResult.score` remains `0.0` even when the Bash job produced reward protocol artifacts.

## Validation

- [x] `uv run --extra admin --group test pytest tests/unit/sdk/job tests/unit/sdk/agent/test_job.py tests/unit/sdk/agent/test_models.py -q` - 296 passed
- [x] `uv run ruff check rock/sdk/job rock/sdk/bench rock/sdk/reward rock/sdk/result.py tests/unit/sdk/job/test_result.py tests/unit/sdk/agent/test_job.py tests/unit/sdk/agent/test_models.py`
- [x] `uv run ruff format --check rock/sdk/job rock/sdk/bench rock/sdk/reward rock/sdk/result.py tests/unit/sdk/job/test_result.py tests/unit/sdk/agent/test_job.py tests/unit/sdk/agent/test_models.py`
- [x] import smoke for `rock.sdk.reward.result`, `rock.sdk.job.result`, and `rock.sdk.bench.models.trial.result` compatibility