### PR TITLE
feat: support Harbor verifier env config

### DIFF
--- a/rock/sdk/bench/models/trial/config.py
+++ b/rock/sdk/bench/models/trial/config.py
@@ -85,6 +85,7 @@ class VerifierConfig(BaseModel):
     patch: bool | None = None
     mode: Literal["harbor", "native"] | None = None
     native_config: NativeConfig = Field(default_factory=NativeConfig)
+    env: dict[str, str] = Field(default_factory=dict)
 
 
 class TaskConfig(BaseModel):

--- a/rock/ts-sdk/src/bench/models/job/config.test.ts
+++ b/rock/ts-sdk/src/bench/models/job/config.test.ts
@@ -346,6 +346,7 @@ describe('HarborJobConfig', () => {
       expect(result.environment.image).toBe('python:3.11');
       expect(result.orchestrator.type).toBe(OrchestratorType.LOCAL);
       expect(result.verifier.disable).toBe(false);
+      expect(result.verifier.env).toEqual({});
       expect(result.metrics).toEqual([]);
     });
 

--- a/rock/ts-sdk/src/bench/models/trial/config.test.ts
+++ b/rock/ts-sdk/src/bench/models/trial/config.test.ts
@@ -139,6 +139,7 @@ describe('VerifierConfig', () => {
       expect(result.disable).toBe(false);
       expect(result.patch).toBeNull();
       expect(result.mode).toBeNull();
+      expect(result.env).toEqual({});
       expect(result.native_config).toEqual({
         image: null,
         script: null,
@@ -158,6 +159,19 @@ describe('VerifierConfig', () => {
       expect(result.mode).toBe('native');
       expect(result.native_config.image).toBe('ubuntu:latest');
       expect(result.native_config.script).toBe('bash run.sh');
+    });
+
+    test('parses verifier env', () => {
+      const result = VerifierConfigSchema.parse({
+        env: {
+          OPENAI_API_KEY: '${OPENAI_API_KEY}',
+          JUDGE_MODEL: 'openai/gpt-5',
+        },
+      });
+      expect(result.env).toEqual({
+        OPENAI_API_KEY: '${OPENAI_API_KEY}',
+        JUDGE_MODEL: 'openai/gpt-5',
+      });
     });
 
     test('rejects invalid mode', () => {

--- a/rock/ts-sdk/src/bench/models/trial/config.ts
+++ b/rock/ts-sdk/src/bench/models/trial/config.ts
@@ -185,6 +185,7 @@ export const VerifierConfigSchema = z.object({
   patch: z.boolean().nullable().default(null),
   mode: z.enum(['harbor', 'native']).nullable().default(null),
   native_config: NativeConfigSchema.default({}),
+  env: z.record(z.string()).default({}),
 });
 
 export type VerifierConfig = z.infer<typeof VerifierConfigSchema>;

--- a/tests/unit/sdk/agent/test_models.py
+++ b/tests/unit/sdk/agent/test_models.py
@@ -110,6 +110,7 @@ class TestVerifierConfig:
         assert v.disable is False
         assert v.patch is None
         assert v.mode is None
+        assert v.env == {}
 
     def test_mode_harbor(self):
         v = VerifierConfig(mode="harbor")

--- a/tests/unit/sdk/job/test_config.py
+++ b/tests/unit/sdk/job/test_config.py
@@ -463,6 +463,32 @@ class TestNativeConfig:
         assert data["template"]["name"] == "my-agent/my-org/my-dataset"
 
 
+class TestVerifierConfig:
+    def test_env_default_empty(self):
+        cfg = VerifierConfig()
+        assert cfg.env == {}
+
+    def test_env_serializes_for_harbor_yaml(self):
+        cfg = HarborJobConfig(
+            experiment_id="test-exp",
+            verifier=VerifierConfig(
+                env={
+                    "OPENAI_API_KEY": "${OPENAI_API_KEY}",
+                    "OPENAI_BASE_URL": "https://example.com/v1",
+                    "JUDGE_MODEL": "openai/gpt-5",
+                }
+            ),
+        )
+
+        data = yaml.safe_load(cfg.to_harbor_yaml())
+
+        assert data["verifier"]["env"] == {
+            "OPENAI_API_KEY": "${OPENAI_API_KEY}",
+            "OPENAI_BASE_URL": "https://example.com/v1",
+            "JUDGE_MODEL": "openai/gpt-5",
+        }
+
+
 class TestHarborInheritsBase:
     def test_harbor_inherits_base_fields(self):
         """HarborJobConfig (agent's) inherits all base JobConfig fields."""


### PR DESCRIPTION
Fixes #1221

## Summary
- add `verifier.env` to the Harbor verifier config mirror
- preserve `verifier.env` when serializing ROCK `HarborJobConfig` to Harbor YAML
- keep TypeScript SDK schemas aligned with Python

## Notes
- This does not add a ROCK `--ve` CLI flag. Harbor's `--ve` is represented in YAML as `verifier.env`.

## Tests
- `uv run python -m pytest tests/unit/sdk/job/test_config.py tests/unit/sdk/agent/test_models.py`
- Python serialization smoke test for `HarborJobConfig(verifier.env)`

TS jest was not run because the local ts-sdk environment has no usable jest binary (`npm test` reports: `sh: 1: jest: Permission denied`).
