### PR TITLE
fix(admin): protect active container directories during file cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 authors = [{ name = "chatos@alibaba" }]
 requires-python = "<4.0,>=3.10"
 name = "rl-rock"
-version = "1.10.0"
+version = "1.10.1"
 description = "ROCK-Reinforcement Open Construction Kit"
 readme = "README.md"
 dependencies = [

--- a/rock/admin/scheduler/tasks/file_cleanup_task.py
+++ b/rock/admin/scheduler/tasks/file_cleanup_task.py
@@ -1,4 +1,5 @@
 # rock/admin/scheduler/tasks/file_cleanup_task.py
+import re
 from dataclasses import dataclass, field
 
 from rock.admin.proto.request import SandboxCommand as Command
@@ -22,6 +23,8 @@ _PATH_BLACKLIST: tuple[str, ...] = (
     "/",
     "/tmp/miniforge",
 )
+
+_CONTAINER_NAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 
 
 @dataclass
@@ -251,7 +254,31 @@ class FileCleanupTask(BaseTask):
 
         return " ".join(parts) + " "
 
-    def _build_cleanup_command(self, dir_config: TargetDirConfig) -> str:
+    @staticmethod
+    def _parse_running_container_names(output: str) -> list[str]:
+        names = []
+        seen = set()
+        for line in output.splitlines():
+            name = line.strip()
+            if not name:
+                continue
+            if not _CONTAINER_NAME_PATTERN.fullmatch(name):
+                raise ValueError(f"Invalid Docker container name in output: {name!r}")
+            if name not in seen:
+                names.append(name)
+                seen.add(name)
+        return names
+
+    @staticmethod
+    def _build_container_exclude_dirs(target_dir: str, container_names: list[str]) -> list[str]:
+        root = target_dir.rstrip("/")
+        return [f"{root}/{name}" for name in container_names]
+
+    def _build_cleanup_command(
+        self,
+        dir_config: TargetDirConfig,
+        extra_exclude_dirs: list[str] | None = None,
+    ) -> str:
         """Build the shell command for cleaning up files in a single directory.
 
         Performance:
@@ -280,6 +307,8 @@ class FileCleanupTask(BaseTask):
 
         Args:
             dir_config: The target directory configuration with its exclusions
+            extra_exclude_dirs: Runtime directory paths to exclude in addition to
+                the configured directory exclusions.
 
         Returns:
             Shell command string
@@ -287,10 +316,15 @@ class FileCleanupTask(BaseTask):
         target_dir = dir_config.path
         size_bytes = parse_size_to_bytes(self.max_file_size)
         size_find_expr = f"-size +{size_bytes}c"
-        exclude_expr = self._build_exclude_expr(dir_config)
+        effective_config = TargetDirConfig(
+            path=dir_config.path,
+            exclude_dirs=[*dir_config.exclude_dirs, *(extra_exclude_dirs or [])],
+            exclude_files=dir_config.exclude_files,
+        )
+        exclude_expr = self._build_exclude_expr(effective_config)
 
         dir_exclude_not_parts = []
-        for exclude_dir in dir_config.exclude_dirs:
+        for exclude_dir in effective_config.exclude_dirs:
             dir_exclude_not_parts.append(self._build_not_path_pattern(exclude_dir, target_dir, is_dir=True))
         dir_exclude_expr = " ".join(dir_exclude_not_parts) + " " if dir_exclude_not_parts else ""
 
@@ -326,13 +360,36 @@ class FileCleanupTask(BaseTask):
             logger.warning("No target directories configured for file cleanup task")
             return {"status": TaskStatusEnum.SUCCESS, "message": "no target directories configured"}
 
+        try:
+            docker_result = await runtime.execute(
+                Command(
+                    command="docker ps --format '{{.Names}}'",
+                    shell=True,
+                    check=True,
+                    sandbox_id="scheduler-task",
+                )
+            )
+            if docker_result.exit_code != 0:
+                raise RuntimeError(f"docker ps failed with exit code {docker_result.exit_code}")
+            running_container_names = self._parse_running_container_names(docker_result.stdout or "")
+        except Exception as e:
+            logger.exception(f"[{self.type}] [{runtime._config.host}] Failed to list running Docker containers: {e}")
+            raise
+
         results = {}
         has_error = False
 
         for dir_config in self.target_dirs:
             target_dir = dir_config.path
             try:
-                command = self._build_cleanup_command(dir_config)
+                container_exclude_dirs = self._build_container_exclude_dirs(
+                    target_dir,
+                    running_container_names,
+                )
+                command = self._build_cleanup_command(
+                    dir_config,
+                    extra_exclude_dirs=container_exclude_dirs,
+                )
                 result = await runtime.execute(
                     Command(command=command, shell=True, check=True, sandbox_id="scheduler-task")
                 )

--- a/tests/unit/admin/scheduler/test_file_cleanup_task.py
+++ b/tests/unit/admin/scheduler/test_file_cleanup_task.py
@@ -105,7 +105,27 @@ class TestFileCleanupTaskBlacklist:
 
 
 # --------------------------------------------------------------------------- #
-# Section C: _build_cleanup_command — uses -delete (the perf change)
+# Section C: running container names — parsing and safe exclusion paths
+# --------------------------------------------------------------------------- #
+
+
+class TestRunningContainerNames:
+    def test_parse_running_container_names(self):
+        assert FileCleanupTask._parse_running_container_names("worker-a\nworker_b\nworker-a\n\n") == [
+            "worker-a",
+            "worker_b",
+        ]
+
+    def test_parse_running_container_names_rejects_unsafe_output(self):
+        with pytest.raises(ValueError, match="Invalid Docker container name"):
+            FileCleanupTask._parse_running_container_names("worker-a; rm -rf /\n")
+
+    def test_parse_running_container_names_handles_empty_output(self):
+        assert FileCleanupTask._parse_running_container_names(" \n\n") == []
+
+
+# --------------------------------------------------------------------------- #
+# Section D: _build_cleanup_command — uses -delete (the perf change)
 # --------------------------------------------------------------------------- #
 
 
@@ -164,6 +184,29 @@ class TestBuildCleanupCommand:
         cmd = task._build_cleanup_command(dir_cfg)
         assert "-prune" not in cmd
         assert '-not -path "*/important.log"' in cmd
+
+    def test_command_merges_runtime_exclude_dirs_without_mutating_config(self):
+        dir_cfg = TargetDirConfig(
+            path="/data/logs",
+            exclude_dirs=["manual_keep"],
+            exclude_files=["docuum.log"],
+        )
+        task = self._new_task(target_dirs=[dir_cfg])
+
+        cmd = task._build_cleanup_command(
+            dir_cfg,
+            extra_exclude_dirs=["/data/logs/worker-a"],
+        )
+
+        file_find = [part for part in cmd.split(";") if "-type f" in part][0]
+        empty_dir_find = [part for part in cmd.split(";") if "-type d -empty" in part][0]
+        for find_command in (file_find, empty_dir_find):
+            assert '-not -path "/data/logs/worker-a"' in find_command
+            assert '-not -path "/data/logs/worker-a/*"' in find_command
+            assert '-not -path "*/manual_keep"' in find_command
+            assert '-not -path "*/manual_keep/*"' in find_command
+        assert '-not -path "*/docuum.log"' in file_find
+        assert dir_cfg.exclude_dirs == ["manual_keep"]
 
     def test_command_no_prune_anywhere(self):
         """Since both -delete (Step 1) and -depth (Step 2) disable -prune,
@@ -295,8 +338,7 @@ class TestBuildCleanupCommand:
                 task = self._new_task(target_dirs=[cfg], max_age_mins=max_age)
                 cmd = task._build_cleanup_command(cfg)
                 assert "-empty -delete" not in cmd, (
-                    f"unguarded empty-dir delete leaked into command for "
-                    f"max_age_mins={max_age}, dir_cfg={cfg}: {cmd}"
+                    f"unguarded empty-dir delete leaked into command for max_age_mins={max_age}, dir_cfg={cfg}: {cmd}"
                 )
 
 
@@ -379,24 +421,101 @@ class TestRunAction:
 
         runtime = AsyncMock()
         runtime._config = type("C", (), {"host": "10.0.0.1"})()
-        runtime.execute = AsyncMock(return_value=_FakeExecResult())
+        runtime.execute = AsyncMock(
+            side_effect=[
+                _FakeExecResult(stdout=""),
+                _FakeExecResult(stdout="cleanup_done"),
+            ]
+        )
 
         result = await task.run_action(runtime)
         assert result["status"] == TaskStatusEnum.SUCCESS
         assert result["target_dirs"] == ["/data/cache"]
 
         # Verify the executed shell command actually used -delete (not -exec rm).
-        executed_cmd = runtime.execute.await_args.args[0].command
+        executed_cmd = runtime.execute.await_args_list[1].args[0].command
         assert "-delete" in executed_cmd
         assert "-exec rm" not in executed_cmd
 
     @pytest.mark.asyncio
-    async def test_run_action_re_raises_on_error(self):
+    async def test_run_action_excludes_running_containers_from_every_target(self):
+        task = FileCleanupTask(
+            target_dirs=[
+                TargetDirConfig(path="/data/logs", exclude_files=["docuum.log"]),
+                TargetDirConfig(path="/data/service_status"),
+            ]
+        )
+        runtime = AsyncMock()
+        runtime._config = type("C", (), {"host": "10.0.0.1"})()
+        runtime.execute = AsyncMock(
+            side_effect=[
+                _FakeExecResult(stdout="worker-a\nworker-b\n"),
+                _FakeExecResult(stdout="cleanup_done"),
+                _FakeExecResult(stdout="cleanup_done"),
+            ]
+        )
+
+        result = await task.run_action(runtime)
+
+        assert result["status"] == TaskStatusEnum.SUCCESS
+        assert runtime.execute.await_count == 3
+        commands = [call.args[0].command for call in runtime.execute.await_args_list]
+        assert commands[0] == "docker ps --format '{{.Names}}'"
+        assert '-not -path "/data/logs/worker-a/*"' in commands[1]
+        assert '-not -path "/data/logs/worker-b/*"' in commands[1]
+        assert '-not -path "/data/service_status/worker-a/*"' in commands[2]
+        assert '-not -path "/data/service_status/worker-b/*"' in commands[2]
+
+    @pytest.mark.asyncio
+    async def test_run_action_skips_all_cleanup_when_docker_query_fails(self):
+        task = FileCleanupTask(target_dirs=[TargetDirConfig(path="/data/logs")])
+        runtime = AsyncMock()
+        runtime._config = type("C", (), {"host": "10.0.0.1"})()
+        runtime.execute = AsyncMock(side_effect=RuntimeError("docker unavailable"))
+
+        with pytest.raises(RuntimeError, match="docker unavailable"):
+            await task.run_action(runtime)
+
+        assert runtime.execute.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_run_action_skips_all_cleanup_on_nonzero_docker_result(self):
+        task = FileCleanupTask(target_dirs=[TargetDirConfig(path="/data/logs")])
+        runtime = AsyncMock()
+        runtime._config = type("C", (), {"host": "10.0.0.1"})()
+        runtime.execute = AsyncMock(return_value=_FakeExecResult(exit_code=1, stdout=""))
+
+        with pytest.raises(RuntimeError, match="docker ps failed with exit code 1"):
+            await task.run_action(runtime)
+
+        assert runtime.execute.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_run_action_skips_all_cleanup_on_invalid_container_name(self):
+        task = FileCleanupTask(target_dirs=[TargetDirConfig(path="/data/logs")])
+        runtime = AsyncMock()
+        runtime._config = type("C", (), {"host": "10.0.0.1"})()
+        runtime.execute = AsyncMock(return_value=_FakeExecResult(stdout="bad;name\n"))
+
+        with pytest.raises(ValueError, match="Invalid Docker container name"):
+            await task.run_action(runtime)
+
+        assert runtime.execute.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_run_action_re_raises_on_cleanup_error(self):
         task = FileCleanupTask(target_dirs=[TargetDirConfig(path="/data/cache")])
 
         runtime = AsyncMock()
         runtime._config = type("C", (), {"host": "10.0.0.1"})()
-        runtime.execute = AsyncMock(side_effect=RuntimeError("boom"))
+        runtime.execute = AsyncMock(
+            side_effect=[
+                _FakeExecResult(stdout=""),
+                RuntimeError("boom"),
+            ]
+        )
 
         with pytest.raises(RuntimeError, match="boom"):
             await task.run_action(runtime)
+
+        assert runtime.execute.await_count == 2


### PR DESCRIPTION
closes #1227

## Summary
Backport active-container directory protection to release/v1.10.

## Key changes
- Query and validate running Docker container names once before cleanup, failing closed on discovery errors.
- Merge per-target container directories with existing exclusions for file and empty-directory cleanup.
- Add regression coverage and bump the package version to 1.10.1.
