### PR TITLE
fix: bound remote HTTP and scheduler worker calls with timeouts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 authors = [{ name = "chatos@alibaba" }]
 requires-python = "<4.0,>=3.10"
 name = "rl-rock"
-version = "1.10.1"
+version = "1.10.2"
 description = "ROCK-Reinforcement Open Construction Kit"
 readme = "README.md"
 dependencies = [

--- a/rock/admin/scheduler/task_base.py
+++ b/rock/admin/scheduler/task_base.py
@@ -265,7 +265,7 @@ class BaseTask(ABC):
         async def run_with_limit(ip: str) -> tuple[str, bool, str | None]:
             async with semaphore:
                 try:
-                    await self.run_on_worker(ip)
+                    await asyncio.wait_for(self.run_on_worker(ip), timeout=90)
                     return (ip, True, None)
                 except Exception:
                     return (ip, False, traceback.format_exc())

--- a/rock/sandbox/remote_sandbox.py
+++ b/rock/sandbox/remote_sandbox.py
@@ -176,7 +176,10 @@ class RemoteSandboxRuntime(AbstractSandbox):
     def _request(self, endpoint: str, request: BaseModel | None, output_class: Any):
         """Small helper to make requests to the server and handle errors and output."""
         response = requests.post(
-            f"{self._api_url}/{endpoint}", json=request.model_dump() if request else None, headers=self._headers
+            f"{self._api_url}/{endpoint}",
+            json=request.model_dump() if request else None,
+            headers=self._headers,
+            timeout=90,
         )
         self._handle_response_errors(response)
         return output_class(**response.json())

--- a/tests/unit/admin/scheduler/test_task_base.py
+++ b/tests/unit/admin/scheduler/test_task_base.py
@@ -1,0 +1,35 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from rock import env_vars
+from rock.admin.scheduler.task_base import BaseTask
+
+
+class _Task(BaseTask):
+    def __init__(self):
+        super().__init__(type="test", interval_seconds=60)
+
+    async def run_action(self, runtime):
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_run_times_out_each_worker_after_90_seconds(tmp_path, monkeypatch):
+    monkeypatch.setattr(env_vars, "ROCK_SCHEDULER_STATUS_DIR", str(tmp_path))
+    task = _Task()
+    task.run_on_worker = AsyncMock()
+    observed_timeouts = []
+
+    async def record_timeout(awaitable, timeout):
+        observed_timeouts.append(timeout)
+        awaitable.close()
+        raise TimeoutError("worker timed out")
+
+    with patch("rock.admin.scheduler.task_base.asyncio.wait_for", side_effect=record_timeout):
+        await task.run(["10.0.0.1"])
+
+    assert observed_timeouts == [90]
+    report = (tmp_path / "test_run_report.json").read_text()
+    assert '"failed_count": 1' in report
+    assert "worker timed out" in report

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 1
 requires-python = ">=3.10, <4.0"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform != 'win32'",
@@ -4408,7 +4408,7 @@ wheels = [
 
 [[package]]
 name = "rl-rock"
-version = "1.10.0"
+version = "1.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
refs #1231

## Summary
Add a timeout to the two blocking calls that could otherwise hang forever, so an unresponsive peer fails fast instead of stalling the caller.

## Key changes
- `remote_sandbox.py`: add `timeout=90` to `RemoteSandboxRuntime._request` HTTP POST.
- `scheduler/task_base.py`: wrap `run_on_worker` in `asyncio.wait_for(..., timeout=90)`.
- Add unit test covering the scheduler worker timeout behavior.