### PR TITLE
feat(cli): unify job run orchestration for dataset tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ uv run ruff format .               # Format
 
 | Command   | Module                    | Role                                              |
 |-----------|---------------------------|----------------------------------------------------|
-| `rock`    | `rock.cli.main`           | CLI tool (admin start, sandbox build/push/run)     |
+| `rock`    | `rock.cli.main`           | CLI tool (admin start, sandbox build/push/run, job viewer) |
 | `admin`   | `rock.admin.main`         | FastAPI orchestrator — sandbox lifecycle via API    |
 | `rocklet` | `rock.rocklet.server`     | FastAPI proxy — runs inside containers, executes commands |
 | `envhub`  | `rock.envhub.server`      | Environment repository CRUD server                 |
@@ -42,7 +42,7 @@ rock/
 ├── sandbox/        # SandboxManager, Operators (Ray/K8s), SandboxActor
 ├── deployments/    # AbstractDeployment → Docker/Ray/Local/Remote, configs, validator
 ├── rocklet/        # Lightweight sandbox runtime server
-├── sdk/            # Client SDK: Sandbox client, agent integrations, EnvHub client
+├── sdk/            # Client SDK: Sandbox client, agent integrations, EnvHub client, JobViewer
 ├── envhub/         # Environment hub service with SQLModel database
 ├── actions/        # Request/response models for sandbox and env actions
 ├── config.py       # Dataclass-based config (RayConfig, K8sConfig, RuntimeConfig, ...)

--- a/rock/cli/command/job.py
+++ b/rock/cli/command/job.py
@@ -29,6 +29,14 @@ class JobCommand(Command):
     async def arun(self, args: argparse.Namespace):
         if args.job_command == "run":
             await self._job_run(args)
+        elif args.job_command == "list":
+            self._job_list(args)
+        elif args.job_command == "show":
+            self._job_show(args)
+        elif args.job_command == "trials":
+            self._job_trials(args)
+        elif args.job_command == "trial":
+            self._job_trial(args)
         else:
             logger.error(f"Unknown job subcommand: {args.job_command}")
 
@@ -163,6 +171,109 @@ class JobCommand(Command):
                 )
         return config
 
+    # ------------------------------------------------------------------
+    # Viewer subcommands: list / show / trials / trial
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _build_viewer(args: argparse.Namespace):
+        from rock.sdk.job.viewer import JobViewer
+
+        if getattr(args, "use_admin", False):
+            return JobViewer.from_admin(
+                admin_base_url=args.base_url,
+                namespace=args.namespace,
+                experiment_id=args.experiment_id,
+                auth_token=getattr(args, "auth_token", None),
+                extra_headers=getattr(args, "extra_headers", None),
+            )
+        return JobViewer.from_credentials(
+            oss_endpoint=args.oss_endpoint,
+            oss_bucket=args.oss_bucket,
+            access_key_id=args.oss_access_key_id,
+            access_key_secret=args.oss_access_key_secret,
+            namespace=args.namespace,
+            experiment_id=args.experiment_id,
+            oss_region=getattr(args, "oss_region", None),
+        )
+
+    def _job_list(self, args: argparse.Namespace):
+        viewer = self._build_viewer(args)
+        jobs = viewer.list_jobs()
+        if not jobs:
+            print("No jobs found.")
+            return
+        for name in jobs:
+            print(f"  {name}")
+        print(f"\nTotal: {len(jobs)} jobs")
+
+    def _job_show(self, args: argparse.Namespace):
+        viewer = self._build_viewer(args)
+        meta = viewer.get_job_meta(args.job_name)
+        if meta:
+            print(f"Job: {meta.job_name}")
+            print(f"  type: {meta.job_type}")
+            print(f"  status: {meta.status}")
+            print(f"  user: {meta.user_id or '-'}")
+            print(f"  image: {meta.image or '-'}")
+            print(f"  started_at: {meta.started_at or '-'}")
+            print(f"  finished_at: {meta.finished_at or '-'}")
+            print(f"  exit_code: {meta.exit_code if meta.exit_code is not None else '-'}")
+            if meta.labels:
+                print(f"  labels: {meta.labels}")
+            return
+        result = viewer.get_job_result(args.job_name)
+        if result is None:
+            print(f"Job not found: {args.job_name}")
+            return
+        print(f"Job: {args.job_name}")
+        print(f"  id: {result.get('id', '-')}")
+        print(f"  started_at: {result.get('started_at', '-')}")
+        print(f"  finished_at: {result.get('finished_at', '-')}")
+        print(f"  n_total_trials: {result.get('n_total_trials', '-')}")
+
+    def _job_trials(self, args: argparse.Namespace):
+        viewer = self._build_viewer(args)
+        trials = viewer.get_trial_results(args.job_name)
+        if not trials:
+            print(f"No trials found for job: {args.job_name}")
+            return
+        header = f"{'NAME':<40} {'STATUS':<12} {'SCORE':<8} {'TASK'}"
+        print(header)
+        print("-" * len(header))
+        for name, trial in sorted(trials.items()):
+            score = f"{trial.score:.2f}" if trial.score is not None else "-"
+            print(f"  {name:<38} {trial.status:<12} {score:<8} {trial.task_name}")
+        print(f"\nTotal: {len(trials)} trials")
+
+    def _job_trial(self, args: argparse.Namespace):
+        viewer = self._build_viewer(args)
+        trial = viewer.get_trial_result(args.job_name, args.trial_name)
+        if trial is None:
+            print(f"Trial not found: {args.trial_name}")
+            return
+        print(f"Trial: {args.trial_name}")
+        print(f"  task: {trial.task_name}")
+        agent = trial.agent_info
+        model = agent.model_info
+        model_str = f" ({model.name})" if model and model.name else ""
+        print(f"  agent: {agent.name} {agent.version}{model_str}")
+        print(f"  status: {trial.status}")
+        print(f"  score: {trial.score:.2f}")
+        print(f"  started_at: {trial.started_at or '-'}")
+        print(f"  finished_at: {trial.finished_at or '-'}")
+        if trial.exception_info:
+            print(f"  exception: {trial.exception_info.exception_type}: {trial.exception_info.exception_message}")
+
+        verifier = viewer.get_verifier_output(args.job_name, args.trial_name)
+        has_verifier = any([verifier.stdout, verifier.stderr, verifier.ctrf])
+        if has_verifier:
+            print("\n  Verifier:")
+            if verifier.stdout:
+                print(f"    stdout: [{len(verifier.stdout)} chars]")
+            if verifier.stderr:
+                print(f"    stderr: [{len(verifier.stderr)} chars]")
+
     def _config_from_flags(self, args: argparse.Namespace):
         """Build a BashJobConfig purely from CLI flags (mode B)."""
         from rock.sdk.bench.models.trial.config import RockEnvironmentConfig
@@ -270,3 +381,35 @@ class JobCommand(Command):
 
         # Stash on the class so _job_run can call parser.error() with the right parser.
         JobCommand._run_parser = run_parser
+
+        # ── Viewer subcommands (shared OSS args via parent) ──────────
+        def _add_viewer_args(parser: argparse.ArgumentParser):
+            parser.add_argument("--namespace", required=True, help="OSS namespace")
+            parser.add_argument("--experiment-id", required=True, help="Experiment ID")
+            parser.add_argument("--oss-endpoint", default=None, help="OSS endpoint (AK/SK mode)")
+            parser.add_argument("--oss-bucket", default=None, help="OSS bucket (AK/SK mode)")
+            parser.add_argument("--oss-access-key-id", default=None, help="OSS access key ID")
+            parser.add_argument("--oss-access-key-secret", default=None, help="OSS access key secret")
+            parser.add_argument("--oss-region", default=None, help="OSS region")
+            parser.add_argument(
+                "--use-admin",
+                action="store_true",
+                default=False,
+                help="Use admin STS auth (requires --base-url)",
+            )
+
+        list_parser = job_subparsers.add_parser("list", help="List jobs from OSS artifacts")
+        _add_viewer_args(list_parser)
+
+        show_parser = job_subparsers.add_parser("show", help="Show job details from OSS")
+        show_parser.add_argument("job_name", help="Job name")
+        _add_viewer_args(show_parser)
+
+        trials_parser = job_subparsers.add_parser("trials", help="List trials for a job")
+        trials_parser.add_argument("job_name", help="Job name")
+        _add_viewer_args(trials_parser)
+
+        trial_parser = job_subparsers.add_parser("trial", help="Show trial details")
+        trial_parser.add_argument("job_name", help="Job name")
+        trial_parser.add_argument("trial_name", help="Trial name")
+        _add_viewer_args(trial_parser)

--- a/rock/cli/command/job.py
+++ b/rock/cli/command/job.py
@@ -29,18 +29,18 @@ class JobCommand(Command):
     async def arun(self, args: argparse.Namespace):
         if args.job_command == "run":
             await self._job_run(args)
-        elif args.job_command == "runs":
-            self._job_runs(args)
-        elif args.job_command == "status":
-            self._job_status(args)
-        elif args.job_command == "list":
-            self._job_list(args)
-        elif args.job_command == "show":
-            self._job_show(args)
-        elif args.job_command == "trials":
-            self._job_trials(args)
-        elif args.job_command == "trial":
-            self._job_trial(args)
+        elif args.job_command == "run-list":
+            self._job_run_list(args)
+        elif args.job_command == "run-status":
+            self._job_run_status(args)
+        elif args.job_command == "job-list":
+            self._job_artifact_list(args)
+        elif args.job_command == "job-show":
+            self._job_artifact_show(args)
+        elif args.job_command == "trial-list":
+            self._job_trial_list(args)
+        elif args.job_command == "trial-show":
+            self._job_trial_show(args)
         else:
             logger.error(f"Unknown job subcommand: {args.job_command}")
 
@@ -251,7 +251,7 @@ class JobCommand(Command):
         return config
 
     # ------------------------------------------------------------------
-    # Viewer subcommands: list / show / trials / trial
+    # Viewer subcommands: job-list / job-show / trial-list / trial-show
     # ------------------------------------------------------------------
 
     @staticmethod
@@ -292,7 +292,7 @@ class JobCommand(Command):
             return RunMetaRepository.from_job_config(config)._viewer
         return self._build_viewer(args)
 
-    def _job_runs(self, args: argparse.Namespace):
+    def _job_run_list(self, args: argparse.Namespace):
         from rock.sdk.job.run_meta import RunMetaRepository
 
         runs = RunMetaRepository(self._build_viewer_from_locator(args)).list()
@@ -315,7 +315,7 @@ class JobCommand(Command):
                 f"{meta.pending_tasks:<8} {pass_rate:<10} {avg_score:<10} {meta.dataset or '-'}"
             )
 
-    def _job_status(self, args: argparse.Namespace):
+    def _job_run_status(self, args: argparse.Namespace):
         from rock.sdk.job.run_meta import RunMetaRepository
 
         repo = RunMetaRepository(self._build_viewer_from_locator(args))
@@ -350,7 +350,7 @@ class JobCommand(Command):
                 score = f"{job.score:.2f}" if job.score is not None else "-"
                 print(f"{job.task_id:<20} {job.job_name:<40} {job.status:<12} {score:<8} {job.sandbox_id or '-'}")
 
-    def _job_list(self, args: argparse.Namespace):
+    def _job_artifact_list(self, args: argparse.Namespace):
         viewer = self._build_viewer(args)
         jobs = viewer.list_jobs()
         if not jobs:
@@ -360,7 +360,7 @@ class JobCommand(Command):
             print(f"  {name}")
         print(f"\nTotal: {len(jobs)} jobs")
 
-    def _job_show(self, args: argparse.Namespace):
+    def _job_artifact_show(self, args: argparse.Namespace):
         viewer = self._build_viewer_from_locator(args)
         job_name = args.job_name_option or args.job_name
         if not job_name and args.run_id and args.task_id:
@@ -397,7 +397,7 @@ class JobCommand(Command):
         print(f"  finished_at: {result.get('finished_at', '-')}")
         print(f"  n_total_trials: {result.get('n_total_trials', '-')}")
 
-    def _job_trials(self, args: argparse.Namespace):
+    def _job_trial_list(self, args: argparse.Namespace):
         viewer = self._build_viewer(args)
         trials = viewer.get_trial_results(args.job_name)
         if not trials:
@@ -411,7 +411,7 @@ class JobCommand(Command):
             print(f"  {name:<38} {trial.status:<12} {score:<8} {trial.task_name}")
         print(f"\nTotal: {len(trials)} trials")
 
-    def _job_trial(self, args: argparse.Namespace):
+    def _job_trial_show(self, args: argparse.Namespace):
         viewer = self._build_viewer(args)
         trial = viewer.get_trial_result(args.job_name, args.trial_name)
         if trial is None:
@@ -485,9 +485,14 @@ class JobCommand(Command):
     @staticmethod
     def _add_viewer_args(parser: argparse.ArgumentParser, *, required: bool = True, include_job_config: bool = False):
         if include_job_config:
-            parser.add_argument("--job-config", dest="job_config", default=None, help="JobConfig YAML locator")
-        parser.add_argument("--namespace", required=required, help="OSS namespace")
-        parser.add_argument("--experiment-id", required=required, help="Experiment ID")
+            parser.add_argument(
+                "--job-config",
+                dest="job_config",
+                default=None,
+                help="YAML config used to locate OSS artifacts",
+            )
+        parser.add_argument("--namespace", required=required, help="OSS artifact namespace")
+        parser.add_argument("--experiment-id", required=required, help="OSS artifact experiment id")
         parser.add_argument("--oss-endpoint", default=None, help="OSS endpoint (AK/SK mode)")
         parser.add_argument("--oss-bucket", default=None, help="OSS bucket (AK/SK mode)")
         parser.add_argument("--oss-access-key-id", default=None, help="OSS access key ID")
@@ -580,13 +585,26 @@ class JobCommand(Command):
         # Stash on the class so _job_run can call parser.error() with the right parser.
         JobCommand._run_parser = run_parser
 
-        runs_parser = job_subparsers.add_parser("runs", help="List run metadata")
+        runs_parser = job_subparsers.add_parser(
+            "run-list",
+            help="List historical job runs from run metadata",
+            description="List historical job runs from run metadata.",
+        )
         runs_parser.add_argument("--output", choices=["table", "json"], default="table")
         JobCommand._add_viewer_args(runs_parser, required=False, include_job_config=True)
 
-        status_parser = job_subparsers.add_parser("status", help="Show run status")
-        status_parser.add_argument("--run-id", required=True, help="Run ID")
-        status_parser.add_argument("--jobs", action="store_true", default=False, help="Show task/job rows")
+        status_parser = job_subparsers.add_parser(
+            "run-status",
+            help="Show summary and task/job status for one run",
+            description="Show summary and task/job status for one run.",
+        )
+        status_parser.add_argument("--run-id", required=True, help="Run id from rock job run or run-list")
+        status_parser.add_argument(
+            "--jobs",
+            action="store_true",
+            default=False,
+            help="Include task/job status rows for this run",
+        )
         status_parser.add_argument("--output", choices=["table", "json"], default="table")
         JobCommand._add_viewer_args(status_parser, required=False, include_job_config=True)
 
@@ -594,21 +612,37 @@ class JobCommand(Command):
         def _add_viewer_args(parser: argparse.ArgumentParser):
             JobCommand._add_viewer_args(parser)
 
-        list_parser = job_subparsers.add_parser("list", help="List jobs from OSS artifacts")
+        list_parser = job_subparsers.add_parser(
+            "job-list",
+            help="List job artifact directories in an experiment",
+            description="List job artifact directories in an experiment.",
+        )
         _add_viewer_args(list_parser)
 
-        show_parser = job_subparsers.add_parser("show", help="Show job details from OSS")
-        show_parser.add_argument("job_name", nargs="?", help="Job name")
-        show_parser.add_argument("--job-name", dest="job_name_option", default=None, help="Job name")
-        show_parser.add_argument("--run-id", default=None, help="Run ID")
-        show_parser.add_argument("--task-id", default=None, help="Task ID")
+        show_parser = job_subparsers.add_parser(
+            "job-show",
+            help="Show one job artifact by job name or run/task id",
+            description="Show one job artifact by job name or run/task id.",
+        )
+        show_parser.add_argument("job_name", nargs="?", help="Job artifact name")
+        show_parser.add_argument("--job-name", dest="job_name_option", default=None, help="Job artifact name")
+        show_parser.add_argument("--run-id", default=None, help="Run id from rock job run or run-list")
+        show_parser.add_argument("--task-id", default=None, help="Task id inside the run; use with --run-id")
         JobCommand._add_viewer_args(show_parser, required=False, include_job_config=True)
 
-        trials_parser = job_subparsers.add_parser("trials", help="List trials for a job")
-        trials_parser.add_argument("job_name", help="Job name")
+        trials_parser = job_subparsers.add_parser(
+            "trial-list",
+            help="List trial results under one job artifact",
+            description="List trial results under one job artifact.",
+        )
+        trials_parser.add_argument("job_name", help="Job artifact name")
         _add_viewer_args(trials_parser)
 
-        trial_parser = job_subparsers.add_parser("trial", help="Show trial details")
-        trial_parser.add_argument("job_name", help="Job name")
-        trial_parser.add_argument("trial_name", help="Trial name")
+        trial_parser = job_subparsers.add_parser(
+            "trial-show",
+            help="Show one trial result and verifier details",
+            description="Show one trial result and verifier details.",
+        )
+        trial_parser.add_argument("job_name", help="Job artifact name")
+        trial_parser.add_argument("trial_name", help="Trial name under the job artifact")
         _add_viewer_args(trial_parser)

--- a/rock/cli/command/job.py
+++ b/rock/cli/command/job.py
@@ -29,6 +29,10 @@ class JobCommand(Command):
     async def arun(self, args: argparse.Namespace):
         if args.job_command == "run":
             await self._job_run(args)
+        elif args.job_command == "runs":
+            self._job_runs(args)
+        elif args.job_command == "status":
+            self._job_status(args)
         elif args.job_command == "list":
             self._job_list(args)
         elif args.job_command == "show":
@@ -41,16 +45,27 @@ class JobCommand(Command):
             logger.error(f"Unknown job subcommand: {args.job_command}")
 
     async def _job_run(self, args: argparse.Namespace):
-        # Import lazily to avoid pulling in bench/Harbor modules for bash-only uses
-        from rock.sdk.job import Job
+        from rock.cli.job_run import (
+            JsonlProgressReporter,
+            NullProgressReporter,
+            UnifiedJobRunHandler,
+            generate_run_id,
+            resolve_task_ids,
+            split_dataset_name,
+            sync_namespace,
+        )
+        from rock.sdk.job.executor import JobExecutor
+        from rock.sdk.job.job_meta import JobMetaRepository
+        from rock.sdk.job.run_meta import RunMetaRepository
 
         parser = self._run_parser
 
         # ── 1. Mode validation ────────────────────────────────────────
         has_config = bool(args.job_config)
         has_script = bool(args.script or args.script_content)
+        is_resume = bool(args.resume)
 
-        if not has_config and not has_script:
+        if not is_resume and not has_config and not has_script:
             _fail(
                 parser,
                 "Missing job definition. Provide either a YAML config or inline script.",
@@ -98,18 +113,82 @@ class JobCommand(Command):
 
         # ── 3. Apply overrides (shared across both modes) ─────────────
         self._apply_overrides(config, args)
+        sync_namespace(config, args.namespace)
+        if args.experiment_id:
+            config.experiment_id = args.experiment_id
+            config.environment.experiment_id = args.experiment_id
+            if config.environment.oss_mirror:
+                config.environment.oss_mirror.experiment_id = args.experiment_id
 
-        # ── 4. Run ────────────────────────────────────────────────────
         try:
-            result = await Job(config).run()
-            if result.trial_results:
-                for tr in result.trial_results:
-                    output = getattr(tr, "raw_output", None) or ""
-                    if output:
-                        print(output)
-            logger.info(f"Job completed: status={result.status}")
+            run_meta_repo = None
+            job_meta_repo = None
+            try:
+                run_meta_repo = RunMetaRepository.from_job_config(config)
+                job_meta_repo = JobMetaRepository(run_meta_repo._viewer)
+            except ValueError:
+                if is_resume:
+                    _fail(parser, "--resume requires --job-config with oss_mirror or explicit artifact locator.")
+
+            if is_resume:
+                forbidden = [
+                    name
+                    for name in ("task", "tasks", "all", "org", "dataset", "split", "limit")
+                    if getattr(args, name, None)
+                ]
+                if forbidden:
+                    _fail(parser, "--resume cannot be combined with task selection or dataset override arguments.")
+                if run_meta_repo is None:
+                    _fail(parser, "--resume requires an artifact locator.")
+                run_id = args.resume
+                run_meta = run_meta_repo.get(run_id)
+                if run_meta is None:
+                    _fail(parser, f"run_id not found: {run_id}")
+                completed = run_meta_repo.find_completed_tasks(run_id)
+                task_ids = [task_id for task_id in run_meta.task_job_map if task_id not in completed]
+                org, dataset = split_dataset_name(run_meta.dataset or "")
+                dataset_ref = type("DatasetRefValue", (), {
+                    "org": org,
+                    "dataset": dataset,
+                    "split": run_meta.split,
+                    "full_name": run_meta.dataset,
+                })()
+                mode = run_meta.mode
+            else:
+                run_id = generate_run_id()
+                try:
+                    mode, dataset_ref, task_ids = resolve_task_ids(
+                        config,
+                        task=args.task,
+                        tasks=args.tasks,
+                        all_tasks=args.all,
+                        org=args.org,
+                        dataset=args.dataset,
+                        split=args.split,
+                        limit=args.limit,
+                    )
+                except ValueError as exc:
+                    _fail(parser, str(exc))
+                run_meta = None
+
+            result = await UnifiedJobRunHandler(
+                mode=mode,
+                task_ids=task_ids,
+                dataset_ref=dataset_ref,
+                run_id=run_id,
+                run_meta_repo=run_meta_repo,
+                job_meta_repo=job_meta_repo,
+                executor=JobExecutor(max_concurrent=args.concurrency),
+                progress=JsonlProgressReporter() if args.jsonl else NullProgressReporter(),
+                resumed=is_resume,
+                base_run_meta=run_meta,
+            ).run(config)
+            if result.failed > 0:
+                raise SystemExit(1)
+            logger.info("Run completed: run_id=%s failed=%s", result.run_id, result.failed)
         except Exception as e:
-            logger.error(f"Job failed: {e}")
+            logger.error(f"Job run failed: {e}", exc_info=True)
+            raise SystemExit(1)
 
     def _apply_overrides(self, config, args: argparse.Namespace) -> None:
         """Apply CLI overrides that are valid in both YAML and flags modes.
@@ -161,7 +240,7 @@ class JobCommand(Command):
         except Exception as exc:  # YAML parse error, IO error, etc.
             _fail(parser, f"Failed to load --job_config {path!r}:\n{exc}")
 
-        if args.type is not None:
+        if getattr(args, "type", None) is not None:
             actual_type = "bash" if isinstance(config, BashJobConfig) else "harbor"
             if args.type != actual_type:
                 _fail(
@@ -178,6 +257,14 @@ class JobCommand(Command):
     @staticmethod
     def _build_viewer(args: argparse.Namespace):
         from rock.sdk.job.viewer import JobViewer
+        extra_headers = getattr(args, "extra_headers", None)
+        if isinstance(extra_headers, list):
+            parsed_headers = {}
+            for item in extra_headers:
+                key, _, value = item.partition("=")
+                if key:
+                    parsed_headers[key] = value
+            extra_headers = parsed_headers
 
         if getattr(args, "use_admin", False):
             return JobViewer.from_admin(
@@ -185,7 +272,7 @@ class JobCommand(Command):
                 namespace=args.namespace,
                 experiment_id=args.experiment_id,
                 auth_token=getattr(args, "auth_token", None),
-                extra_headers=getattr(args, "extra_headers", None),
+                extra_headers=extra_headers,
             )
         return JobViewer.from_credentials(
             oss_endpoint=args.oss_endpoint,
@@ -196,6 +283,72 @@ class JobCommand(Command):
             experiment_id=args.experiment_id,
             oss_region=getattr(args, "oss_region", None),
         )
+
+    def _build_viewer_from_locator(self, args: argparse.Namespace):
+        if getattr(args, "job_config", None):
+            from rock.sdk.job.run_meta import RunMetaRepository
+
+            config = self._config_from_yaml(self._run_parser or argparse.ArgumentParser(prog="rock job"), args)
+            return RunMetaRepository.from_job_config(config)._viewer
+        return self._build_viewer(args)
+
+    def _job_runs(self, args: argparse.Namespace):
+        from rock.sdk.job.run_meta import RunMetaRepository
+
+        runs = RunMetaRepository(self._build_viewer_from_locator(args)).list()
+        if getattr(args, "output", "table") == "json":
+            import json
+
+            print(json.dumps([run.model_dump(mode="json") for run in runs], ensure_ascii=False))
+            return
+        if not runs:
+            print("No runs found.")
+            return
+        header = f"{'RUN_ID':<28} {'MODE':<8} {'STATUS':<10} {'TOTAL':<7} {'PENDING':<8} {'PASS_RATE':<10} {'AVG_SCORE':<10} DATASET"
+        print(header)
+        print("-" * len(header))
+        for meta in runs:
+            pass_rate = f"{meta.summary.pass_rate:.2f}" if meta.summary else "-"
+            avg_score = f"{meta.summary.avg_score:.3f}" if meta.summary else "-"
+            print(
+                f"{meta.run_id:<28} {meta.mode:<8} {meta.status:<10} {meta.total_tasks:<7} "
+                f"{meta.pending_tasks:<8} {pass_rate:<10} {avg_score:<10} {meta.dataset or '-'}"
+            )
+
+    def _job_status(self, args: argparse.Namespace):
+        from rock.sdk.job.run_meta import RunMetaRepository
+
+        repo = RunMetaRepository(self._build_viewer_from_locator(args))
+        meta = repo.get(args.run_id)
+        if meta is None:
+            print(f"Run not found: {args.run_id}")
+            raise SystemExit(1)
+        jobs = repo.get_run_job_statuses(args.run_id) if args.jobs else []
+        if getattr(args, "output", "table") == "json":
+            import json
+
+            payload = meta.model_dump(mode="json")
+            if args.jobs:
+                payload["jobs"] = [job.model_dump(mode="json") for job in jobs]
+            print(json.dumps(payload, ensure_ascii=False))
+            return
+        print(f"Run: {meta.run_id}")
+        print(f"mode: {meta.mode}")
+        print(f"status: {meta.status}")
+        print(f"dataset: {meta.dataset or '-'}")
+        print(f"split: {meta.split or '-'}")
+        print(f"total_tasks: {meta.total_tasks}")
+        print(f"pending_tasks: {meta.pending_tasks}")
+        if meta.summary:
+            print(f"pass_rate: {meta.summary.pass_rate:.2f}")
+            print(f"avg_score: {meta.summary.avg_score:.3f}")
+        if args.jobs:
+            header = f"{'TASK_ID':<20} {'JOB_NAME':<40} {'STATUS':<12} {'SCORE':<8} SANDBOX"
+            print(header)
+            print("-" * len(header))
+            for job in jobs:
+                score = f"{job.score:.2f}" if job.score is not None else "-"
+                print(f"{job.task_id:<20} {job.job_name:<40} {job.status:<12} {score:<8} {job.sandbox_id or '-'}")
 
     def _job_list(self, args: argparse.Namespace):
         viewer = self._build_viewer(args)
@@ -208,8 +361,20 @@ class JobCommand(Command):
         print(f"\nTotal: {len(jobs)} jobs")
 
     def _job_show(self, args: argparse.Namespace):
-        viewer = self._build_viewer(args)
-        meta = viewer.get_job_meta(args.job_name)
+        viewer = self._build_viewer_from_locator(args)
+        job_name = args.job_name_option or args.job_name
+        if not job_name and args.run_id and args.task_id:
+            from rock.sdk.job.run_meta import RunMetaRepository
+
+            refs = RunMetaRepository(viewer).list_run_jobs(args.run_id)
+            for ref in refs:
+                if ref.task_id == args.task_id:
+                    job_name = ref.job_name
+                    break
+        if not job_name:
+            print("Job not found: provide --job-name or --run-id with --task-id")
+            raise SystemExit(1)
+        meta = viewer.get_job_meta(job_name)
         if meta:
             print(f"Job: {meta.job_name}")
             print(f"  type: {meta.job_type}")
@@ -222,11 +387,11 @@ class JobCommand(Command):
             if meta.labels:
                 print(f"  labels: {meta.labels}")
             return
-        result = viewer.get_job_result(args.job_name)
+        result = viewer.get_job_result(job_name)
         if result is None:
-            print(f"Job not found: {args.job_name}")
+            print(f"Job not found: {job_name}")
             return
-        print(f"Job: {args.job_name}")
+        print(f"Job: {job_name}")
         print(f"  id: {result.get('id', '-')}")
         print(f"  started_at: {result.get('started_at', '-')}")
         print(f"  finished_at: {result.get('finished_at', '-')}")
@@ -318,6 +483,27 @@ class JobCommand(Command):
         )
 
     @staticmethod
+    def _add_viewer_args(parser: argparse.ArgumentParser, *, required: bool = True, include_job_config: bool = False):
+        if include_job_config:
+            parser.add_argument("--job-config", dest="job_config", default=None, help="JobConfig YAML locator")
+        parser.add_argument("--namespace", required=required, help="OSS namespace")
+        parser.add_argument("--experiment-id", required=required, help="Experiment ID")
+        parser.add_argument("--oss-endpoint", default=None, help="OSS endpoint (AK/SK mode)")
+        parser.add_argument("--oss-bucket", default=None, help="OSS bucket (AK/SK mode)")
+        parser.add_argument("--oss-access-key-id", default=None, help="OSS access key ID")
+        parser.add_argument("--oss-access-key-secret", default=None, help="OSS access key secret")
+        parser.add_argument("--oss-region", default=None, help="OSS region")
+        parser.add_argument("--base-url", default=None, help="Admin service base URL")
+        parser.add_argument("--auth-token", default=None, help="Admin auth token")
+        parser.add_argument("--extra-header", action="append", dest="extra_headers", default=None, help="Admin extra header")
+        parser.add_argument(
+            "--use-admin",
+            action="store_true",
+            default=False,
+            help="Use admin STS auth (requires --base-url)",
+        )
+
+    @staticmethod
     async def add_parser_to(subparsers: argparse._SubParsersAction):
         job_parser = subparsers.add_parser("job", help="Manage sandbox jobs")
         job_subparsers = job_parser.add_subparsers(dest="job_command")
@@ -378,32 +564,45 @@ class JobCommand(Command):
             default=None,
             help="XRL authorization token",
         )
+        run_parser.add_argument("--task", default=None, help="Run one explicit task id")
+        run_parser.add_argument("--tasks", default=None, help="Comma-separated task ids")
+        run_parser.add_argument("--all", action="store_true", default=False, help="Run all tasks in dataset split")
+        run_parser.add_argument("--org", default=None, help="Dataset org override")
+        run_parser.add_argument("--dataset", default=None, help="Dataset name override")
+        run_parser.add_argument("--split", default=None, help="Dataset split override")
+        run_parser.add_argument("--limit", type=int, default=None, help="Limit selected tasks")
+        run_parser.add_argument("--concurrency", type=int, default=1, help="Max concurrent jobs")
+        run_parser.add_argument("--resume", default=None, metavar="RUN_ID", help="Resume an existing run id")
+        run_parser.add_argument("--namespace", default=None, help="OSS namespace override")
+        run_parser.add_argument("--experiment-id", default=None, help="Experiment id override")
+        run_parser.add_argument("--jsonl", action="store_true", default=False, help="Emit JSONL run events")
 
         # Stash on the class so _job_run can call parser.error() with the right parser.
         JobCommand._run_parser = run_parser
 
+        runs_parser = job_subparsers.add_parser("runs", help="List run metadata")
+        runs_parser.add_argument("--output", choices=["table", "json"], default="table")
+        JobCommand._add_viewer_args(runs_parser, required=False, include_job_config=True)
+
+        status_parser = job_subparsers.add_parser("status", help="Show run status")
+        status_parser.add_argument("--run-id", required=True, help="Run ID")
+        status_parser.add_argument("--jobs", action="store_true", default=False, help="Show task/job rows")
+        status_parser.add_argument("--output", choices=["table", "json"], default="table")
+        JobCommand._add_viewer_args(status_parser, required=False, include_job_config=True)
+
         # ── Viewer subcommands (shared OSS args via parent) ──────────
         def _add_viewer_args(parser: argparse.ArgumentParser):
-            parser.add_argument("--namespace", required=True, help="OSS namespace")
-            parser.add_argument("--experiment-id", required=True, help="Experiment ID")
-            parser.add_argument("--oss-endpoint", default=None, help="OSS endpoint (AK/SK mode)")
-            parser.add_argument("--oss-bucket", default=None, help="OSS bucket (AK/SK mode)")
-            parser.add_argument("--oss-access-key-id", default=None, help="OSS access key ID")
-            parser.add_argument("--oss-access-key-secret", default=None, help="OSS access key secret")
-            parser.add_argument("--oss-region", default=None, help="OSS region")
-            parser.add_argument(
-                "--use-admin",
-                action="store_true",
-                default=False,
-                help="Use admin STS auth (requires --base-url)",
-            )
+            JobCommand._add_viewer_args(parser)
 
         list_parser = job_subparsers.add_parser("list", help="List jobs from OSS artifacts")
         _add_viewer_args(list_parser)
 
         show_parser = job_subparsers.add_parser("show", help="Show job details from OSS")
-        show_parser.add_argument("job_name", help="Job name")
-        _add_viewer_args(show_parser)
+        show_parser.add_argument("job_name", nargs="?", help="Job name")
+        show_parser.add_argument("--job-name", dest="job_name_option", default=None, help="Job name")
+        show_parser.add_argument("--run-id", default=None, help="Run ID")
+        show_parser.add_argument("--task-id", default=None, help="Task ID")
+        JobCommand._add_viewer_args(show_parser, required=False, include_job_config=True)
 
         trials_parser = job_subparsers.add_parser("trials", help="List trials for a job")
         trials_parser.add_argument("job_name", help="Job name")

--- a/rock/cli/job_run.py
+++ b/rock/cli/job_run.py
@@ -283,7 +283,7 @@ class UnifiedJobRunHandler:
 
     async def run(self, config: JobConfig) -> RunResult:
         started = datetime.now(timezone.utc)
-        planner = SingleTaskPlanner(run_id=self.run_id)
+        planner = SingleTaskPlanner(run_id=self.run_id, preserve_job_name=self.mode == "single")
         planned_jobs = []
         existing_meta_by_task: dict[str, JobMeta] = {}
         for task_id in self.task_ids:

--- a/rock/cli/job_run.py
+++ b/rock/cli/job_run.py
@@ -1,0 +1,525 @@
+"""CLI orchestration for unified ``rock job run``."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import TextIO
+
+from rock.sdk.bench.models.job.config import HarborJobConfig, OssRegistryInfo
+from rock.sdk.envhub.datasets import DatasetClient
+from rock.sdk.job.config import BashJobConfig, JobConfig
+from rock.sdk.job.executor import JobExecutor, TrialClient
+from rock.sdk.job.job_meta import JobMetaRepository
+from rock.sdk.job.meta import JobMeta, RunMeta, RunScoreSummary
+from rock.sdk.job.planner import PlannedJob, ResolvedTask, SingleTaskPlanner
+from rock.sdk.job.result import TrialResult
+from rock.sdk.job.run_meta import RunMetaRepository
+
+
+@dataclass(frozen=True)
+class DatasetRef:
+    org: str | None
+    dataset: str | None
+    split: str | None
+
+    @property
+    def full_name(self) -> str | None:
+        if not self.dataset:
+            return None
+        if "/" in self.dataset or not self.org:
+            return self.dataset
+        return f"{self.org}/{self.dataset}"
+
+
+@dataclass(frozen=True)
+class RunResult:
+    run_id: str
+    total: int
+    failed: int
+    summary: RunScoreSummary
+
+
+class NullProgressReporter:
+    def emit(self, payload: dict) -> None:
+        return None
+
+
+class JsonlProgressReporter:
+    def __init__(self, stream: TextIO | None = None):
+        self._stream = stream or sys.stdout
+
+    def emit(self, payload: dict) -> None:
+        self._stream.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        self._stream.flush()
+
+
+def generate_run_id() -> str:
+    timestamp = datetime.now().strftime("%Y%m%dT%H%M%S")
+    return f"{timestamp}-{uuid.uuid4().hex[:8]}"
+
+
+def split_dataset_name(dataset: str) -> tuple[str | None, str]:
+    if "/" not in dataset:
+        return None, dataset
+    org, name = dataset.split("/", 1)
+    return org, name
+
+
+def resolve_dataset_ref(
+    config: JobConfig,
+    *,
+    org: str | None,
+    dataset: str | None,
+    split: str | None,
+) -> DatasetRef:
+    config_org = None
+    config_dataset = None
+    config_split = None
+
+    if isinstance(config, HarborJobConfig) and config.datasets:
+        dataset_config = config.datasets[0]
+        config_dataset = getattr(dataset_config, "name", None)
+        if config_dataset and "/" in config_dataset:
+            config_org, config_dataset = config_dataset.split("/", 1)
+        registry = getattr(dataset_config, "registry", None)
+        if isinstance(registry, OssRegistryInfo):
+            config_split = registry.split
+        config_split = config_split or getattr(dataset_config, "version", None)
+    elif isinstance(config, BashJobConfig):
+        env = config.environment.env
+        config_dataset = env.get("ROCK_DATASET")
+        config_split = env.get("ROCK_SPLIT")
+        if config_dataset and "/" in config_dataset:
+            config_org, config_dataset = config_dataset.split("/", 1)
+
+    selected_dataset = dataset or config_dataset
+    selected_org = org or config_org
+    if selected_dataset and "/" in selected_dataset:
+        embedded_org, embedded_dataset = selected_dataset.split("/", 1)
+        selected_org = org or embedded_org
+        selected_dataset = embedded_dataset
+
+    return DatasetRef(org=selected_org, dataset=selected_dataset, split=split or config_split)
+
+
+def resolve_oss_registry_info(config: JobConfig) -> OssRegistryInfo:
+    if isinstance(config, HarborJobConfig) and config.datasets:
+        registry = getattr(config.datasets[0], "registry", None)
+        if isinstance(registry, OssRegistryInfo):
+            return registry
+
+    mirror = config.environment.oss_mirror
+    if mirror and mirror.enabled:
+        return OssRegistryInfo(
+            oss_bucket=mirror.oss_bucket,
+            oss_endpoint=mirror.oss_endpoint,
+            oss_access_key_id=mirror.oss_access_key_id,
+            oss_access_key_secret=mirror.oss_access_key_secret,
+            oss_region=mirror.oss_region,
+        )
+
+    raise ValueError("dataset task enumeration requires a dataset registry or environment.oss_mirror")
+
+
+def get_config_task_ids(config: JobConfig) -> list[str]:
+    if isinstance(config, HarborJobConfig) and config.datasets:
+        return list(getattr(config.datasets[0], "task_names", None) or [])
+    if isinstance(config, BashJobConfig):
+        task = config.environment.env.get("TASK")
+        return [task] if task else []
+    return []
+
+
+def resolve_task_ids(
+    config: JobConfig,
+    *,
+    task: str | None,
+    tasks: str | None,
+    all_tasks: bool,
+    org: str | None,
+    dataset: str | None,
+    split: str | None,
+    limit: int | None,
+) -> tuple[str, DatasetRef, list[str]]:
+    explicit_count = sum(bool(v) for v in (task, tasks, all_tasks))
+    if explicit_count > 1:
+        raise ValueError("--task, --tasks and --all are mutually exclusive")
+
+    dataset_ref = resolve_dataset_ref(config, org=org, dataset=dataset, split=split)
+    if task:
+        return "single", dataset_ref, [task]
+    if tasks:
+        parsed = [item.strip() for item in tasks.split(",") if item.strip()]
+        if not parsed:
+            raise ValueError("--tasks must contain at least one task id")
+        return ("single" if len(parsed) == 1 else "multi"), dataset_ref, parsed[:limit] if limit else parsed
+    if all_tasks:
+        if not dataset_ref.org or not dataset_ref.dataset:
+            raise ValueError("--all requires dataset org/name from config or CLI args")
+        selected_split = dataset_ref.split or "test"
+        client = DatasetClient(resolve_oss_registry_info(config))
+        spec = client.list_dataset_tasks(dataset_ref.org, dataset_ref.dataset, selected_split)
+        if spec is None:
+            raise ValueError(f"Dataset split not found: {dataset_ref.org}/{dataset_ref.dataset}@{selected_split}")
+        task_ids = list(spec.task_ids)
+        if limit is not None:
+            task_ids = task_ids[:limit]
+        return "full", DatasetRef(dataset_ref.org, dataset_ref.dataset, selected_split), task_ids
+
+    config_tasks = get_config_task_ids(config)
+    if len(config_tasks) == 1:
+        return "single", dataset_ref, config_tasks
+    if len(config_tasks) > 1:
+        return "multi", dataset_ref, config_tasks[:limit] if limit else config_tasks
+    raise ValueError("fresh run requires an explicit task: use --task, --tasks, --all, or a config with one task")
+
+
+def flatten_trial_results(results: Sequence[TrialResult | list[TrialResult]]) -> list[TrialResult]:
+    flat: list[TrialResult] = []
+    for result in results:
+        if isinstance(result, list):
+            flat.extend(result)
+        else:
+            flat.append(result)
+    return flat
+
+
+def build_run_summary(*, task_ids: Sequence[str], trial_results: Sequence[TrialResult | list[TrialResult]]) -> RunScoreSummary:
+    by_task: dict[str, TrialResult] = {}
+    for result in flatten_trial_results(trial_results):
+        if result.task_name:
+            by_task[result.task_name] = result
+
+    completed = 0
+    failed = 0
+    scores: dict[str, float] = {}
+    for task_id in task_ids:
+        result = by_task.get(task_id)
+        if result is None:
+            failed += 1
+            continue
+        score = result.score if result.score is not None else 0.0
+        scores[task_id] = score
+        if result.status == "completed":
+            completed += 1
+        else:
+            failed += 1
+
+    total = len(task_ids)
+    total_score = sum(scores.values())
+    return RunScoreSummary(
+        completed=completed,
+        failed=failed,
+        skipped=0,
+        avg_score=total_score / total if total else 0.0,
+        total_score=total_score,
+        pass_rate=completed / total if total else 0.0,
+        scores=scores,
+    )
+
+
+def sync_namespace(config: JobConfig, namespace: str | None) -> None:
+    mirror = config.environment.oss_mirror
+    selected_namespace = namespace or config.namespace or (mirror.namespace if mirror else None)
+    if not selected_namespace:
+        return
+    config.namespace = selected_namespace
+    if hasattr(config.environment, "namespace"):
+        config.environment.namespace = selected_namespace
+    if mirror:
+        mirror.namespace = selected_namespace
+
+
+class _Callbacks:
+    def __init__(self, handler: UnifiedJobRunHandler, planned_job: PlannedJob, index: int):
+        self._handler = handler
+        self._planned_job = planned_job
+        self._index = index
+
+    def on_started(self, client: TrialClient) -> None:
+        self._handler.on_job_started(self._planned_job, client, self._index)
+
+    def on_done(self, client: TrialClient, result: TrialResult | list[TrialResult]) -> None:
+        self._handler.on_job_done(self._planned_job, client, result, self._index)
+
+
+class UnifiedJobRunHandler:
+    """CLI-level orchestration for single, multi, and full runs."""
+
+    def __init__(
+        self,
+        *,
+        mode: str,
+        task_ids: Sequence[str],
+        dataset_ref: DatasetRef,
+        run_id: str,
+        run_meta_repo: RunMetaRepository | None,
+        job_meta_repo: JobMetaRepository | None,
+        executor: JobExecutor,
+        progress: JsonlProgressReporter | NullProgressReporter,
+        resumed: bool = False,
+        base_run_meta: RunMeta | None = None,
+    ):
+        self.mode = mode
+        self.task_ids = list(task_ids)
+        self.dataset_ref = dataset_ref
+        self.run_id = run_id
+        self.run_meta_repo = run_meta_repo
+        self.job_meta_repo = job_meta_repo
+        self.executor = executor
+        self.progress = progress
+        self.resumed = resumed
+        self.base_run_meta = base_run_meta
+        self._completed = 0
+        self._passed = 0
+        self._failed = 0
+
+    async def run(self, config: JobConfig) -> RunResult:
+        started = datetime.now(timezone.utc)
+        planner = SingleTaskPlanner(run_id=self.run_id)
+        planned_jobs = []
+        existing_meta_by_task: dict[str, JobMeta] = {}
+        for task_id in self.task_ids:
+            planned = planner.plan(
+                config,
+                task=ResolvedTask(
+                    task_id=task_id,
+                    org=self.dataset_ref.org,
+                    dataset=self.dataset_ref.full_name,
+                    split=self.dataset_ref.split,
+                ),
+            )
+            existing_meta = self._get_recoverable_job_meta(task_id)
+            if existing_meta is not None:
+                planned.config.job_name = existing_meta.job_name
+                planned = PlannedJob(
+                    task_id=planned.task_id,
+                    job_name=existing_meta.job_name,
+                    config=planned.config,
+                    trial=planned.trial,
+                )
+                existing_meta_by_task[task_id] = existing_meta
+            planned_jobs.append(planned)
+        run_meta = self._make_run_meta(planned_jobs)
+        self._write_run_meta(run_meta)
+        for job in planned_jobs:
+            if job.task_id not in existing_meta_by_task:
+                self._mark_previous_attempt_unrecoverable(job.task_id)
+                self._write_job_meta(job, status="planned")
+
+        self.progress.emit(
+            {
+                "type": "run_started",
+                "run_id": self.run_id,
+                "mode": self.mode,
+                "total": len(self.task_ids),
+                "pending": len(self.task_ids),
+                "resumed": self.resumed,
+            }
+        )
+
+        semaphore = asyncio.Semaphore(self.executor._max_concurrent or len(planned_jobs) or 1)
+
+        async def run_one(index: int, job: PlannedJob):
+            async with semaphore:
+                existing_meta = existing_meta_by_task.get(job.task_id)
+                if existing_meta is not None:
+                    self.progress.emit(
+                        {
+                            "type": "job_recovered",
+                            "run_id": self.run_id,
+                            "task_id": job.task_id,
+                            "job_name": job.job_name,
+                            "sandbox_id": existing_meta.sandbox_id,
+                        }
+                    )
+                    result = await self.executor.wait_existing_job(job, existing_meta)
+                    client = SimpleNamespace(
+                        sandbox=SimpleNamespace(sandbox_id=existing_meta.sandbox_id),
+                        session=existing_meta.session,
+                        pid=existing_meta.pid,
+                    )
+                    self.on_job_done(job, client, result, index)
+                    return result
+                return await self.executor.run_job(job, callbacks=_Callbacks(self, job, index))
+
+        results = list(await asyncio.gather(*[run_one(i, job) for i, job in enumerate(planned_jobs)]))
+        summary = build_run_summary(task_ids=self.task_ids, trial_results=results)
+        run_meta.pending_tasks = 0
+        run_meta.summary = summary
+        run_meta.finished_at = datetime.now(timezone.utc).isoformat()
+        run_meta.updated_at = run_meta.finished_at
+        run_meta.status = "completed" if summary.failed == 0 else "failed" if summary.completed == 0 else "partial"
+        self._write_run_meta(run_meta)
+        duration_s = int((datetime.now(timezone.utc) - started).total_seconds())
+        self.progress.emit(
+            {
+                "type": "summary",
+                "run_id": self.run_id,
+                "status": run_meta.status,
+                "total": len(self.task_ids),
+                "passed": summary.completed,
+                "failed": summary.failed,
+                "pass_rate": summary.pass_rate,
+                "avg_score": summary.avg_score,
+                "duration_s": duration_s,
+            }
+        )
+        return RunResult(run_id=self.run_id, total=len(self.task_ids), failed=summary.failed, summary=summary)
+
+    def _make_run_meta(self, planned_jobs: Sequence[PlannedJob]) -> RunMeta:
+        now = datetime.now(timezone.utc).isoformat()
+        if self.base_run_meta is not None:
+            meta = self.base_run_meta.model_copy(deep=True)
+            meta.status = "running"
+            meta.pending_tasks = len(self.task_ids)
+            meta.finished_at = None
+            meta.updated_at = now
+        else:
+            meta = RunMeta(
+                run_id=self.run_id,
+                mode=self.mode,
+                status="planning",
+                dataset=self.dataset_ref.full_name,
+                split=self.dataset_ref.split,
+                total_tasks=len(self.task_ids),
+                pending_tasks=len(self.task_ids),
+                created_at=now,
+                updated_at=now,
+                started_at=now,
+            )
+        for job in planned_jobs:
+            meta.task_job_map[job.task_id] = job.job_name
+        return meta
+
+    def _write_run_meta(self, run_meta: RunMeta) -> None:
+        if self.run_meta_repo is not None:
+            self.run_meta_repo.write(run_meta)
+
+    def _get_recoverable_job_meta(self, task_id: str) -> JobMeta | None:
+        if not self.resumed or self.base_run_meta is None or self.job_meta_repo is None:
+            return None
+        job_name = self.base_run_meta.task_job_map.get(task_id)
+        if not job_name:
+            return None
+        meta = self.job_meta_repo.get(job_name)
+        if meta is None:
+            return None
+        if meta.status not in {"running", "sandbox_ready", "starting"}:
+            return None
+        if not meta.sandbox_id or not meta.session or meta.pid is None:
+            return None
+        return meta
+
+    def _mark_previous_attempt_unrecoverable(self, task_id: str) -> None:
+        if not self.resumed or self.base_run_meta is None or self.job_meta_repo is None:
+            return
+        old_job_name = self.base_run_meta.task_job_map.get(task_id)
+        if not old_job_name:
+            return
+        self.job_meta_repo.update_status(
+            old_job_name,
+            "unrecoverable",
+            status_reason="resume could not recover existing sandbox/process",
+            updated_at=datetime.now(timezone.utc).isoformat(),
+        )
+
+    def _write_job_meta(self, job: PlannedJob, *, status: str, **fields) -> None:
+        if self.job_meta_repo is None:
+            return
+        now = datetime.now(timezone.utc).isoformat()
+        meta = JobMeta(
+            job_name=job.job_name,
+            job_type="harbor" if isinstance(job.config, HarborJobConfig) else "bash",
+            run_id=self.run_id,
+            task_id=job.task_id,
+            status=status,
+            namespace=job.config.namespace,
+            experiment_id=job.config.experiment_id,
+            labels=job.config.labels,
+            env=job.config.environment.env,
+            created_at=now,
+            updated_at=now,
+            **fields,
+        )
+        self.job_meta_repo.write(meta)
+
+    def on_job_started(self, job: PlannedJob, client: TrialClient, index: int) -> None:
+        self._write_job_meta(
+            job,
+            status="running",
+            sandbox_id=getattr(client.sandbox, "sandbox_id", None),
+            session=client.session,
+            pid=client.pid,
+            started_at=datetime.now(timezone.utc).isoformat(),
+        )
+        self.progress.emit(
+            {
+                "type": "job_started",
+                "run_id": self.run_id,
+                "task_id": job.task_id,
+                "job_name": job.job_name,
+                "index": index,
+                "total": len(self.task_ids),
+                "sandbox_id": getattr(client.sandbox, "sandbox_id", None),
+            }
+        )
+
+    def on_job_done(
+        self,
+        job: PlannedJob,
+        client: TrialClient,
+        result: TrialResult | list[TrialResult],
+        index: int,
+    ) -> None:
+        primary = flatten_trial_results([result])[0]
+        if primary.status == "completed":
+            self._passed += 1
+        else:
+            self._failed += 1
+        self._completed += 1
+        error = None
+        if primary.exception_info:
+            error = primary.exception_info.exception_message or primary.exception_info.exception_type
+        self._write_job_meta(
+            job,
+            status=primary.status,
+            sandbox_id=getattr(client.sandbox, "sandbox_id", None),
+            session=client.session,
+            pid=client.pid,
+            finished_at=datetime.now(timezone.utc).isoformat(),
+            exit_code=primary.exit_code,
+            score=primary.score,
+            error=error,
+        )
+        self.progress.emit(
+            {
+                "type": "job_done",
+                "run_id": self.run_id,
+                "task_id": job.task_id,
+                "job_name": job.job_name,
+                "status": primary.status,
+                "score": primary.score,
+                "index": index,
+                "total": len(self.task_ids),
+                "sandbox_id": getattr(client.sandbox, "sandbox_id", None),
+                "error": error,
+            }
+        )
+        self.progress.emit(
+            {
+                "type": "progress",
+                "run_id": self.run_id,
+                "completed": self._completed,
+                "passed": self._passed,
+                "failed": self._failed,
+                "total": len(self.task_ids),
+            }
+        )

--- a/rock/sdk/job/__init__.py
+++ b/rock/sdk/job/__init__.py
@@ -24,4 +24,13 @@ __all__ = [
     "ScatterOperator",
     "AbstractTrial",
     "register_trial",
+    "JobViewer",
 ]
+
+
+def __getattr__(name: str):
+    if name == "JobViewer":
+        from rock.sdk.job.viewer import JobViewer
+
+        return JobViewer
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/rock/sdk/job/__init__.py
+++ b/rock/sdk/job/__init__.py
@@ -1,7 +1,7 @@
 # Auto-register BashTrial (safe: no bench dependency).
-# HarborTrial is registered by rock.sdk.bench.__init__ to avoid a circular
-# import when rock.sdk.job is triggered mid-bench-load.
+# HarborTrial is registered by rock.sdk.bench.__init__ to avoid circular imports.
 import rock.sdk.job.trial.bash  # noqa: F401
+
 from rock.sdk.job.api import Job
 from rock.sdk.job.config import BashJobConfig, JobConfig
 from rock.sdk.job.executor import JobClient, JobExecutor, TrialClient
@@ -22,6 +22,16 @@ __all__ = [
     "TrialClient",
     "Operator",
     "ScatterOperator",
+    "SingleTaskPlanner",
+    "ResolvedTask",
+    "PlannedJob",
+    "JobMeta",
+    "JobMetaRepository",
+    "RunMeta",
+    "RunJobRef",
+    "RunJobStatus",
+    "RunScoreSummary",
+    "RunMetaRepository",
     "AbstractTrial",
     "register_trial",
     "JobViewer",
@@ -33,4 +43,30 @@ def __getattr__(name: str):
         from rock.sdk.job.viewer import JobViewer
 
         return JobViewer
+    if name in {"SingleTaskPlanner", "ResolvedTask", "PlannedJob"}:
+        from rock.sdk.job.planner import PlannedJob, ResolvedTask, SingleTaskPlanner
+
+        return {
+            "SingleTaskPlanner": SingleTaskPlanner,
+            "ResolvedTask": ResolvedTask,
+            "PlannedJob": PlannedJob,
+        }[name]
+    if name in {"JobMeta", "RunMeta", "RunJobRef", "RunJobStatus", "RunScoreSummary"}:
+        from rock.sdk.job.meta import JobMeta, RunJobRef, RunJobStatus, RunMeta, RunScoreSummary
+
+        return {
+            "JobMeta": JobMeta,
+            "RunMeta": RunMeta,
+            "RunJobRef": RunJobRef,
+            "RunJobStatus": RunJobStatus,
+            "RunScoreSummary": RunScoreSummary,
+        }[name]
+    if name == "JobMetaRepository":
+        from rock.sdk.job.job_meta import JobMetaRepository
+
+        return JobMetaRepository
+    if name == "RunMetaRepository":
+        from rock.sdk.job.run_meta import RunMetaRepository
+
+        return RunMetaRepository
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/rock/sdk/job/api.py
+++ b/rock/sdk/job/api.py
@@ -1,13 +1,7 @@
-"""Job — thin user-facing facade over JobExecutor + Operator.
+"""Job facade over JobExecutor + Operator.
 
-Only 2 params (config + operator). Delegates everything to JobExecutor.
-
-Usage:
-    result = await Job(config).run()
-    # or
-    job = Job(config, operator=ScatterOperator(size=8))
-    await job.submit()
-    result = await job.wait()
+The facade intentionally keeps single-job semantics. Full-dataset orchestration
+belongs to the CLI layer.
 """
 
 from __future__ import annotations
@@ -26,15 +20,7 @@ if TYPE_CHECKING:
 
 
 class Job:
-    """Job Facade — the thin user-facing entry point.
-
-    Usage:
-        result = await Job(config).run()
-        # or
-        job = Job(config, operator=ScatterOperator(size=8))
-        await job.submit()
-        result = await job.wait()
-    """
+    """Thin user-facing entry point for one JobConfig."""
 
     def __init__(self, config: JobConfig, operator: Operator | None = None):
         self._config = config
@@ -65,20 +51,15 @@ class Job:
                 await tc.sandbox.arun(cmd=f"kill {tc.pid}", session=tc.session)
 
     def _build_result(self, raw_results: list[TrialResult | list[TrialResult]]) -> JobResult:
-        """Flatten list-returning collect() outputs into JobResult.trial_results.
-
-        Each element of ``raw_results`` is whatever one Trial's ``collect()``
-        returned — either a single TrialResult or a list. HarborTrial returns
-        a list (one entry per sub-trial); BashTrial returns a single result.
-        """
+        """Flatten list-returning collect() outputs into JobResult.trial_results."""
         flat: list[TrialResult] = []
-        for r in raw_results:
-            if isinstance(r, list):
-                flat.extend(r)
+        for result in raw_results:
+            if isinstance(result, list):
+                flat.extend(result)
             else:
-                flat.append(r)
+                flat.append(result)
+
         all_success = all(t.exception_info is None for t in flat)
-        # G5: surface first non-empty output / non-zero exit code from sub-trials
         raw_output = next((t.raw_output for t in flat if t.raw_output), "")
         exit_code = next((t.exit_code for t in flat if t.exit_code != 0), 0)
         return JobResult(

--- a/rock/sdk/job/executor.py
+++ b/rock/sdk/job/executor.py
@@ -1,26 +1,22 @@
-"""JobExecutor — orchestrates the full execution of Trials produced by an Operator.
-
-Flow:
-    submit(operator, config)  — apply operator to get TrialList, start all sandboxes
-                                in parallel, return JobClient (list of TrialClient)
-    wait(job_client)          — wait for all trials, collect results, return list[TrialResult]
-    run(operator, config)     — submit + wait
-"""
+"""JobExecutor drives Trials produced by an Operator."""
 
 from __future__ import annotations
 
 import asyncio
 import os
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from rock.actions import CreateBashSessionRequest
 from rock.logger import init_logger
 from rock.sdk.job.operator import Operator
-from rock.sdk.job.result import TrialResult
+from rock.sdk.job.result import ExceptionInfo, TrialResult
 from rock.sdk.sandbox.client import Sandbox
 
 if TYPE_CHECKING:
+    from rock.sdk.job.meta import JobMeta
+    from rock.sdk.job.planner import PlannedJob
     from rock.sdk.job.config import JobConfig
     from rock.sdk.job.trial.abstract import AbstractTrial
 
@@ -29,8 +25,6 @@ logger = init_logger(__name__)
 
 @dataclass
 class TrialClient:
-    """Handle for a single running trial."""
-
     sandbox: Sandbox
     session: str
     pid: int
@@ -39,62 +33,166 @@ class TrialClient:
 
 @dataclass
 class JobClient:
-    """Handle returned by JobExecutor.submit(). Holds multiple TrialClients."""
-
     trials: list[TrialClient]
 
 
+TrialDoneCallback = Callable[[TrialClient, TrialResult | list[TrialResult], int], None]
+TrialStartedCallback = Callable[[TrialClient, int], None]
+
+
 class JobExecutor:
-    """Execution engine: drives Operator to generate trials, runs in parallel, collects results."""
+    """Execution engine for job trials.
+
+    ``submit``/``wait`` preserve the historical single-job behavior.
+    ``run_job`` is the atomic primitive used by CLI run orchestration.
+    """
+
+    def __init__(self, max_concurrent: int | None = None):
+        if max_concurrent is not None and max_concurrent <= 0:
+            raise ValueError("max_concurrent must be positive or None")
+        self._max_concurrent = max_concurrent
 
     async def run(self, operator: Operator, config: JobConfig) -> list[TrialResult | list[TrialResult]]:
-        """Full lifecycle: submit + wait."""
         job_client = await self.submit(operator, config)
         return await self.wait(job_client)
 
+    async def run_job(
+        self,
+        job: PlannedJob,
+        *,
+        callbacks=None,
+    ) -> TrialResult | list[TrialResult]:
+        """Run a single planned job as an SDK atomic capability."""
+        client = None
+        try:
+            client = await self._do_submit(job.trial)
+            if callbacks and hasattr(callbacks, "on_started"):
+                callbacks.on_started(client)
+            result = await self._do_wait(client)
+            if callbacks and hasattr(callbacks, "on_done"):
+                callbacks.on_done(client, result)
+            return result
+        except Exception as exc:
+            logger.error("Job lifecycle failed: %s", exc, exc_info=True)
+            result = self._failure_result_for_trial(job.trial, exc)
+            if client is not None and callbacks and hasattr(callbacks, "on_done"):
+                callbacks.on_done(client, result)
+            return result
+
+    async def wait_existing_job(
+        self,
+        planned_job: PlannedJob,
+        job_meta: JobMeta,
+    ) -> TrialResult | list[TrialResult]:
+        """Reconnect to an existing sandbox/process and collect the result.
+
+        The CLI decides whether a job is recoverable; this method only performs
+        the atomic wait/collect operation from persisted metadata.
+        """
+        if not job_meta.sandbox_id or not job_meta.session or job_meta.pid is None:
+            raise ValueError("job_meta is missing sandbox_id/session/pid")
+        sandbox = Sandbox(planned_job.config.environment)
+        sandbox._sandbox_id = job_meta.sandbox_id
+        client = TrialClient(
+            sandbox=sandbox,
+            session=job_meta.session,
+            pid=job_meta.pid,
+            trial=planned_job.trial,
+        )
+        return await self._do_wait(client)
+
+    def prepare(self, operator: Operator, config: JobConfig) -> list[AbstractTrial]:
+        return operator.apply(config)
+
+    async def run_trials(
+        self,
+        trials: Sequence[AbstractTrial],
+        on_trial_started: TrialStartedCallback | None = None,
+        on_trial_done: TrialDoneCallback | None = None,
+    ) -> list[TrialResult | list[TrialResult]]:
+        """Run caller-provided trials with optional lifecycle concurrency control."""
+        if not trials:
+            return []
+
+        semaphore = asyncio.Semaphore(self._max_concurrent) if self._max_concurrent is not None else None
+
+        async def run_one(index: int, trial: AbstractTrial):
+            if semaphore is None:
+                return await self._run_trial_lifecycle(trial, index, on_trial_started, on_trial_done)
+            async with semaphore:
+                return await self._run_trial_lifecycle(trial, index, on_trial_started, on_trial_done)
+
+        return list(await asyncio.gather(*[run_one(i, trial) for i, trial in enumerate(trials)]))
+
     async def submit(self, operator: Operator, config: JobConfig) -> JobClient:
-        """Operator generates TrialList, start all sandboxes in parallel."""
-        trial_list = operator.apply(config)
+        trial_list = self.prepare(operator, config)
         if not trial_list:
             return JobClient(trials=[])
         trial_clients = await asyncio.gather(*[self._do_submit(t) for t in trial_list])
         return JobClient(trials=list(trial_clients))
 
-    async def wait(self, job_client: JobClient) -> list[TrialResult | list[TrialResult]]:
-        """Wait for all trials, collect results in parallel.
-
-        Each entry mirrors whatever the Trial's ``collect()`` returned
-        (single ``TrialResult`` or ``list[TrialResult]``). The Job layer
-        flattens lists into the final ``JobResult.trial_results``.
-        """
+    async def wait(
+        self,
+        job_client: JobClient,
+        on_trial_done: TrialDoneCallback | None = None,
+    ) -> list[TrialResult | list[TrialResult]]:
         if not job_client.trials:
             return []
-        return list(await asyncio.gather(*[self._do_wait(tc) for tc in job_client.trials]))
+        if on_trial_done is None:
+            return list(await asyncio.gather(*[self._do_wait(tc) for tc in job_client.trials]))
 
-    # ── Internal: per-trial submit/wait ──
+        async def wait_one(index: int, trial_client: TrialClient):
+            result = await self._do_wait(trial_client)
+            on_trial_done(trial_client, result, index)
+            return result
+
+        return list(await asyncio.gather(*[wait_one(i, tc) for i, tc in enumerate(job_client.trials)]))
+
+    async def _run_trial_lifecycle(
+        self,
+        trial: AbstractTrial,
+        index: int,
+        on_trial_started: TrialStartedCallback | None,
+        on_trial_done: TrialDoneCallback | None,
+    ) -> TrialResult | list[TrialResult]:
+        try:
+            client = await self._do_submit(trial)
+            if on_trial_started:
+                on_trial_started(client, index)
+            result = await self._do_wait(client)
+            if on_trial_done:
+                on_trial_done(client, result, index)
+            return result
+        except Exception as exc:
+            logger.error("Trial lifecycle failed: %s", exc, exc_info=True)
+            return self._failure_result_for_trial(trial, exc)
+
+    @staticmethod
+    def _failure_result_for_trial(trial: AbstractTrial, exc: Exception) -> TrialResult:
+        config = getattr(trial, "_config", None)
+        labels = getattr(config, "labels", {}) or {}
+        task_name = labels.get("rock_task_id") or getattr(config, "job_name", "") or ""
+        return TrialResult(
+            task_name=task_name,
+            exception_info=ExceptionInfo(
+                exception_type=type(exc).__name__,
+                exception_message=str(exc),
+            ),
+        )
 
     @staticmethod
     def _job_tmp_prefix(config: JobConfig) -> str:
-        """Prefix for per-job script/output files on sandbox.
-
-        Uses USER_DEFINED_LOGS (persistent under /data/logs/user-defined/...)
-        so that logs survive sandbox-internal /tmp sweeps and are inspectable
-        after a failure, matching the legacy bench/job.py behavior.
-        """
         from rock.sdk.bench.constants import USER_DEFINED_LOGS
 
         return f"{USER_DEFINED_LOGS}/rock_job_{config.job_name or 'default'}"
 
     async def _do_submit(self, trial: AbstractTrial) -> TrialClient:
-        """Start sandbox + execute script for a single trial."""
         config = trial._config
         sandbox = Sandbox(config.environment)
         await sandbox.start()
-        logger.info(f"Sandbox started: sandbox_id={sandbox.sandbox_id}, job_name={config.job_name}")
+        logger.info("Sandbox started: sandbox_id=%s, job_name=%s", sandbox.sandbox_id, config.job_name)
 
-        # G4: let trial backfill config from sandbox state before setup
         await trial.on_sandbox_ready(sandbox)
-
         await trial.setup(sandbox)
 
         session = f"rock-job-{config.job_name or 'default'}"
@@ -102,7 +200,6 @@ class JobExecutor:
         await sandbox.create_session(CreateBashSessionRequest(session=session, env_enable=True, env=env))
 
         script_content = trial.build()
-
         prefix = self._job_tmp_prefix(config)
         script_path = f"{prefix}.sh"
         await sandbox.write_file_by_path(script_content, script_path)
@@ -116,13 +213,10 @@ class JobExecutor:
         if error is not None:
             raise RuntimeError(f"Failed to start trial: {error.output}")
 
-        logger.info(f"Trial started: pid={pid}, job_name={config.job_name}")
+        logger.info("Trial started: pid=%s, job_name=%s", pid, config.job_name)
         return TrialClient(sandbox=sandbox, session=session, pid=pid, trial=trial)
 
     async def _do_wait(self, client: TrialClient) -> TrialResult | list[TrialResult]:
-        """Wait for a single trial to finish, call trial.collect()."""
-        from rock.sdk.job.result import ExceptionInfo
-
         config = client.trial._config
         success, message = await client.sandbox.wait_for_process_completion(
             pid=client.pid,
@@ -140,28 +234,26 @@ class JobExecutor:
         )
         exit_code = obs.exit_code if obs.exit_code is not None else 1
         if obs.output:
-            logger.info(f"Trial output (job={config.job_name}):\n{obs.output}")
+            logger.info("Trial output (job=%s):\n%s", config.job_name, obs.output)
         result = await client.trial.collect(client.sandbox, obs.output or "", exit_code)
-        # G5: populate raw_output / exit_code on every TrialResult so they surface in JobResult
         iter_results = result if isinstance(result, list) else [result]
-        for r in iter_results:
-            if not r.raw_output:
-                r.raw_output = obs.output or ""
-            if r.exit_code == 0 and exit_code != 0:
-                r.exit_code = exit_code
+        for trial_result in iter_results:
+            if not trial_result.raw_output:
+                trial_result.raw_output = obs.output or ""
+            if trial_result.exit_code == 0 and exit_code != 0:
+                trial_result.exit_code = exit_code
         if not success:
             fail_info = ExceptionInfo(
                 exception_type="ProcessTimeout",
                 exception_message=message or "process did not complete successfully",
             )
-            for r in iter_results:
-                if r.exception_info is None:
-                    r.exception_info = fail_info
+            for trial_result in iter_results:
+                if trial_result.exception_info is None:
+                    trial_result.exception_info = fail_info
         return result
 
     @staticmethod
     def _build_session_env(config: JobConfig) -> dict[str, str] | None:
-        """Merge OSS_* env vars from the process with config.env (config wins)."""
         oss_env = {k: v for k, v in os.environ.items() if k.startswith("OSS")}
         merged = {**oss_env, **config.environment.env}
         return merged or None

--- a/rock/sdk/job/job_meta.py
+++ b/rock/sdk/job/job_meta.py
@@ -1,0 +1,34 @@
+"""Repository wrapper for job-level metadata."""
+
+from __future__ import annotations
+
+from rock.sdk.job.meta import JobMeta
+from rock.sdk.job.viewer import JobViewer
+
+
+class JobMetaRepository:
+    """Stable SDK atomic interface for job metadata operations."""
+
+    def __init__(self, viewer: JobViewer):
+        self._viewer = viewer
+
+    def write(self, job_meta: JobMeta) -> None:
+        self._viewer.write_job_meta(job_meta)
+
+    def get(self, job_name: str) -> JobMeta | None:
+        return self._viewer.get_job_meta(job_name)
+
+    def update_status(self, job_name: str, status: str, **fields) -> None:
+        meta = self.get(job_name) or JobMeta(job_name=job_name)
+        meta.status = status
+        for key, value in fields.items():
+            if hasattr(meta, key):
+                setattr(meta, key, value)
+        self.write(meta)
+
+    def get_by_run_task(self, run_id: str, task_id: str) -> JobMeta | None:
+        for job_name in self._viewer.list_jobs():
+            meta = self.get(job_name)
+            if meta is not None and meta.run_id == run_id and meta.task_id == task_id:
+                return meta
+        return None

--- a/rock/sdk/job/meta.py
+++ b/rock/sdk/job/meta.py
@@ -25,14 +25,76 @@ class JobMeta(BaseModel):
     job_name: str = ""
     job_type: str = ""
     status: str = ""
+    run_id: str | None = None
+    task_id: str | None = None
+    attempt: int = 1
+    status_reason: str | None = None
     namespace: str | None = None
     experiment_id: str | None = None
     user_id: str | None = None
     image: str | None = None
     labels: dict[str, str] = Field(default_factory=dict)
+    env: dict[str, str] = Field(default_factory=dict)
+    sandbox_id: str | None = None
+    session: str | None = None
+    pid: int | None = None
+    tmp_file: str | None = None
+    script_path: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
     started_at: str | None = None
     finished_at: str | None = None
     exit_code: int | None = None
+    score: float | None = None
+    error: str | None = None
+
+
+class RunScoreSummary(BaseModel):
+    """Aggregated score summary for a full-dataset run."""
+
+    completed: int
+    failed: int
+    skipped: int
+    avg_score: float
+    total_score: float
+    pass_rate: float
+    scores: dict[str, float] = Field(default_factory=dict)
+
+
+class RunMeta(BaseModel):
+    """Run-level metadata for single, multi, and full modes."""
+
+    schema_version: str = "2"
+    run_id: str
+    mode: str = "full"
+    status: str
+    dataset: str | None = None
+    split: str | None = None
+    total_tasks: int
+    pending_tasks: int
+    created_at: str | None = None
+    updated_at: str | None = None
+    started_at: str | None = None
+    finished_at: str | None = None
+    status_reason: str | None = None
+    task_job_map: dict[str, str] = Field(default_factory=dict)
+    summary: RunScoreSummary | None = None
+
+
+class RunJobRef(BaseModel):
+    task_id: str
+    job_name: str
+
+
+class RunJobStatus(BaseModel):
+    task_id: str
+    job_name: str
+    status: str = "unknown"
+    sandbox_id: str | None = None
+    score: float | None = None
+    started_at: str | None = None
+    finished_at: str | None = None
+    error: str | None = None
 
 
 def render_meta_json(config: JobConfig, *, job_type: str, status: str = "running") -> str:

--- a/rock/sdk/job/meta.py
+++ b/rock/sdk/job/meta.py
@@ -1,9 +1,11 @@
 """Unified job metadata — written inside the sandbox, read by JobViewer.
 
-Both Harbor and Bash jobs write ``rock_meta.json`` to the job output
-directory. The existing OSS upload mechanisms (ossutil for Bash,
-Harbor's _oss_mirror_job_root_files for Harbor) automatically push it
-to ``artifacts/{namespace}/{experiment_id}/{job_name}/rock_meta.json``.
+Bash jobs write ``rock_meta.json`` via the wrapper script prologue/epilogue.
+The existing ossutil upload automatically pushes it to
+``artifacts/{namespace}/{experiment_id}/{job_name}/rock_meta.json``.
+
+Harbor jobs rely on Harbor's own result.json and OSS mirror mechanism;
+rock_meta.json is currently only generated for Bash jobs.
 """
 
 from __future__ import annotations

--- a/rock/sdk/job/meta.py
+++ b/rock/sdk/job/meta.py
@@ -1,0 +1,60 @@
+"""Unified job metadata — written inside the sandbox, read by JobViewer.
+
+Both Harbor and Bash jobs write ``rock_meta.json`` to the job output
+directory. The existing OSS upload mechanisms (ossutil for Bash,
+Harbor's _oss_mirror_job_root_files for Harbor) automatically push it
+to ``artifacts/{namespace}/{experiment_id}/{job_name}/rock_meta.json``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from rock.sdk.job.config import JobConfig
+
+
+class JobMeta(BaseModel):
+    """Unified job metadata — common format for Harbor and Bash jobs."""
+
+    schema_version: str = "1"
+    job_name: str = ""
+    job_type: str = ""
+    status: str = ""
+    namespace: str | None = None
+    experiment_id: str | None = None
+    user_id: str | None = None
+    image: str | None = None
+    labels: dict[str, str] = Field(default_factory=dict)
+    started_at: str | None = None
+    finished_at: str | None = None
+    exit_code: int | None = None
+
+
+def render_meta_json(config: JobConfig, *, job_type: str, status: str = "running") -> str:
+    """Render a rock_meta.json string from a JobConfig.
+
+    All fields are resolved at Python render time (no shell placeholders).
+    Shell-side timing and exit code are handled separately by the wrapper scripts.
+    """
+    user_id = getattr(config.environment, "user_id", None)
+    if not user_id:
+        import os
+
+        user_id = os.environ.get("ROCK_USER_ID")
+
+    image = getattr(config.environment, "image", None)
+
+    meta = JobMeta(
+        job_name=config.job_name or "",
+        job_type=job_type,
+        status=status,
+        namespace=config.namespace,
+        experiment_id=config.experiment_id,
+        user_id=user_id,
+        image=image,
+        labels=config.labels,
+    )
+    return meta.model_dump_json(indent=2)

--- a/rock/sdk/job/operator.py
+++ b/rock/sdk/job/operator.py
@@ -1,4 +1,4 @@
-"""Operator — generic algorithm that produces a TrialList from a JobConfig."""
+"""Operator primitives that produce Trial lists from a JobConfig."""
 
 from __future__ import annotations
 
@@ -13,11 +13,7 @@ if TYPE_CHECKING:
 
 
 class Operator(ABC):
-    """Operator base: apply(config) -> list[AbstractTrial].
-
-    Operators generate a TrialList from a config. They don't manage
-    sandbox lifecycle (JobExecutor does) — just decide what to run.
-    """
+    """Operator base: apply(config) -> list[AbstractTrial]."""
 
     @abstractmethod
     def apply(self, config: JobConfig) -> list[AbstractTrial]:
@@ -26,15 +22,7 @@ class Operator(ABC):
 
 
 class ScatterOperator(Operator):
-    """Scatter: create `size` identical Trial instances from config.
-
-    Analog of torch.distributed.scatter — same data/config distributed to N workers.
-
-    Usage:
-      ScatterOperator()           # size=1, single trial (default)
-      ScatterOperator(size=8)     # 8 parallel trials
-      ScatterOperator(size=0)     # empty list, no-op
-    """
+    """Create ``size`` identical Trial instances from config."""
 
     def __init__(self, size: int = 1):
         self.size = size

--- a/rock/sdk/job/planner.py
+++ b/rock/sdk/job/planner.py
@@ -1,0 +1,81 @@
+"""Single-task planning primitives for CLI run orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from rock.sdk.bench.models.job.config import HarborJobConfig, OssRegistryInfo, RegistryDatasetConfig
+from rock.sdk.job.config import BashJobConfig, JobConfig
+from rock.sdk.job.trial.abstract import AbstractTrial
+from rock.sdk.job.trial.registry import _create_trial
+
+
+@dataclass(frozen=True)
+class ResolvedTask:
+    task_id: str
+    dataset: str | None = None
+    split: str | None = None
+    org: str | None = None
+
+
+@dataclass(frozen=True)
+class PlannedJob:
+    task_id: str
+    job_name: str
+    config: JobConfig
+    trial: AbstractTrial
+
+
+class SingleTaskPlanner:
+    """Clone a JobConfig into one task-bound job/trial."""
+
+    def __init__(self, *, run_id: str):
+        self.run_id = run_id
+
+    def plan(self, config: JobConfig, *, task: ResolvedTask) -> PlannedJob:
+        cloned = config.model_copy(deep=True)
+        job_name = self._job_name(cloned, task)
+
+        cloned.job_name = job_name
+        cloned.labels["rock_run_id"] = self.run_id
+        cloned.labels["rock_task_id"] = task.task_id
+
+        if isinstance(cloned, HarborJobConfig):
+            self._apply_harbor_task(cloned, task)
+        elif isinstance(cloned, BashJobConfig):
+            self._apply_bash_task(cloned, task, job_name)
+        else:
+            raise TypeError(f"Unsupported JobConfig type: {type(config).__name__}")
+
+        trial = _create_trial(cloned)
+        return PlannedJob(task_id=task.task_id, job_name=job_name, config=cloned, trial=trial)
+
+    def _job_name(self, config: JobConfig, task: ResolvedTask) -> str:
+        dataset = task.dataset or getattr(config, "job_name", None) or "job"
+        dataset_short = dataset.rsplit("/", 1)[-1]
+        task_short = task.task_id.rsplit("/", 1)[-1]
+        return f"{dataset_short}_{task_short}_{self.run_id}"
+
+    @staticmethod
+    def _apply_harbor_task(config: HarborJobConfig, task: ResolvedTask) -> None:
+        if not config.datasets:
+            return
+        dataset_config = config.datasets[0]
+        dataset_config.task_names = [task.task_id]
+        if isinstance(dataset_config, RegistryDatasetConfig):
+            if task.dataset:
+                dataset_config.name = task.dataset if "/" in task.dataset or not task.org else f"{task.org}/{task.dataset}"
+            if isinstance(dataset_config.registry, OssRegistryInfo) and task.split:
+                dataset_config.registry.split = task.split
+                dataset_config.version = task.split
+
+    def _apply_bash_task(self, config: BashJobConfig, task: ResolvedTask, job_name: str) -> None:
+        env = config.environment.env
+        env["TASK"] = task.task_id
+        env["ROCK_TASK_ID"] = task.task_id
+        env["ROCK_RUN_ID"] = self.run_id
+        env["ROCK_JOB_NAME"] = job_name
+        if task.dataset:
+            env["ROCK_DATASET"] = task.dataset
+        if task.split:
+            env["ROCK_SPLIT"] = task.split

--- a/rock/sdk/job/planner.py
+++ b/rock/sdk/job/planner.py
@@ -29,8 +29,9 @@ class PlannedJob:
 class SingleTaskPlanner:
     """Clone a JobConfig into one task-bound job/trial."""
 
-    def __init__(self, *, run_id: str):
+    def __init__(self, *, run_id: str, preserve_job_name: bool = False):
         self.run_id = run_id
+        self.preserve_job_name = preserve_job_name
 
     def plan(self, config: JobConfig, *, task: ResolvedTask) -> PlannedJob:
         cloned = config.model_copy(deep=True)
@@ -51,6 +52,8 @@ class SingleTaskPlanner:
         return PlannedJob(task_id=task.task_id, job_name=job_name, config=cloned, trial=trial)
 
     def _job_name(self, config: JobConfig, task: ResolvedTask) -> str:
+        if self.preserve_job_name and config.job_name:
+            return config.job_name
         dataset = task.dataset or getattr(config, "job_name", None) or "job"
         dataset_short = dataset.rsplit("/", 1)[-1]
         task_short = task.task_id.rsplit("/", 1)[-1]

--- a/rock/sdk/job/run_meta.py
+++ b/rock/sdk/job/run_meta.py
@@ -1,0 +1,89 @@
+"""Repository wrapper for run metadata."""
+
+from __future__ import annotations
+
+from rock.sdk.job.meta import RunJobRef, RunJobStatus, RunMeta, RunScoreSummary
+from rock.sdk.job.viewer import JobViewer
+
+
+class RunMetaRepository:
+    """Stable SDK atomic interface for run metadata operations."""
+
+    def __init__(self, viewer: JobViewer):
+        self._viewer = viewer
+
+    @classmethod
+    def from_job_config(cls, config) -> RunMetaRepository:
+        oss_mirror = getattr(config.environment, "oss_mirror", None)
+        if oss_mirror is None or not oss_mirror.enabled:
+            raise ValueError("run metadata requires environment.oss_mirror.enabled=True")
+        if not oss_mirror.namespace and getattr(config, "namespace", None):
+            oss_mirror.namespace = config.namespace
+        if not oss_mirror.experiment_id and getattr(config, "experiment_id", None):
+            oss_mirror.experiment_id = config.experiment_id
+        return cls(JobViewer.from_oss_mirror(oss_mirror))
+
+    def write(self, run_meta: RunMeta) -> None:
+        self._viewer.write_run_meta(run_meta)
+
+    def get(self, run_id: str) -> RunMeta | None:
+        return self._viewer.get_run_meta(run_id)
+
+    def list(self, experiment_id: str | None = None) -> list[RunMeta]:
+        return self._viewer.list_runs()
+
+    def list_run_jobs(self, run_id: str) -> list[RunJobRef]:
+        run_meta = self.get(run_id)
+        if run_meta is None:
+            return []
+        return [
+            RunJobRef(task_id=task_id, job_name=job_name)
+            for task_id, job_name in sorted(run_meta.task_job_map.items())
+        ]
+
+    def get_run_job_statuses(self, run_id: str) -> list[RunJobStatus]:
+        statuses: list[RunJobStatus] = []
+        for ref in self.list_run_jobs(run_id):
+            meta = self._viewer.get_job_meta(ref.job_name)
+            trial_results = self._viewer.get_trial_results(ref.job_name)
+            score = None
+            status = "unknown"
+            error = None
+            if meta is not None:
+                status = meta.status or status
+                score = meta.score
+                error = meta.error
+            if trial_results:
+                first = next(iter(trial_results.values()))
+                status = getattr(first, "status", None) or status
+                score = getattr(first, "score", None)
+                exc = getattr(first, "exception_info", None)
+                if exc:
+                    error = getattr(exc, "exception_message", None) or getattr(exc, "exception_type", None)
+            statuses.append(
+                RunJobStatus(
+                    task_id=ref.task_id,
+                    job_name=ref.job_name,
+                    status=status,
+                    sandbox_id=getattr(meta, "sandbox_id", None) if meta is not None else None,
+                    score=score,
+                    started_at=getattr(meta, "started_at", None) if meta is not None else None,
+                    finished_at=getattr(meta, "finished_at", None) if meta is not None else None,
+                    error=error,
+                )
+            )
+        return statuses
+
+    def update_summary(self, run_id: str, summary: RunScoreSummary, status: str) -> None:
+        run_meta = self.get(run_id)
+        if run_meta is None:
+            raise ValueError(f"run_id not found: {run_id}")
+        run_meta.summary = summary
+        run_meta.status = status
+        self.write(run_meta)
+
+    def find_completed_tasks(self, run_id: str) -> set[str]:
+        return self._viewer.find_completed_tasks_in_run(run_id)
+
+    def resolve_run_id_for_resume(self) -> str | None:
+        return self._viewer.resolve_run_id_for_resume()

--- a/rock/sdk/job/trial/bash.py
+++ b/rock/sdk/job/trial/bash.py
@@ -88,20 +88,48 @@ class BashTrial(AbstractTrial):
             f"artifacts/{self._config.namespace}/{self._config.experiment_id}/{self._config.job_name}"
         )
 
+    def _render_meta_template(self, status_placeholder: str) -> str:
+        """Render a rock_meta.json template with placeholders for runtime values.
+
+        All config-derived fields are baked in at Python render time via json.dumps.
+        Runtime values use unique __ROCK_*__ placeholders that sed replaces later.
+        The result is always valid JSON (placeholders are quoted strings / integers).
+        """
+        user_id = getattr(self._config.environment, "user_id", None) or os.environ.get("ROCK_USER_ID")
+        image = getattr(self._config.environment, "image", None)
+        return (
+            "{\n"
+            '  "schema_version": "1",\n'
+            f'  "job_name": {json.dumps(self._config.job_name or "")},\n'
+            '  "job_type": "bash",\n'
+            f'  "status": "{status_placeholder}",\n'
+            f'  "namespace": {json.dumps(self._config.namespace)},\n'
+            f'  "experiment_id": {json.dumps(self._config.experiment_id)},\n'
+            f'  "user_id": {json.dumps(user_id)},\n'
+            f'  "image": {json.dumps(image)},\n'
+            f'  "labels": {json.dumps(self._config.labels)},\n'
+            '  "started_at": "__ROCK_STARTED__",\n'
+            '  "finished_at": "__ROCK_FINISHED__",\n'
+            '  "exit_code": __ROCK_EXIT_CODE__\n'
+            "}"
+        )
+
     def _render_wrapper(self, user_script: str, token: str | None = None) -> str:
         """Render the BashJob wrapper script.
 
         Structure: prologue (mkdir + meta running + initial upload) → user script
         (isolated in a single-quoted heredoc) → epilogue (meta final + upload) → exit
         with user's exit code.
+
+        All heredocs use single-quoted delimiters to prevent shell expansion.
+        Runtime values are injected via sed placeholder replacement.
         """
         if token is None:
             token = secrets.token_hex(4)  # 8-char hex
         eof = f"__ROCK_USER_SCRIPT_EOF_{token}__"
 
-        from rock.sdk.job.meta import render_meta_json
-
-        meta_running = render_meta_json(self._config, job_type="bash", status="running")
+        meta_running = self._render_meta_template("running")
+        meta_final = self._render_meta_template("__ROCK_STATUS__")
 
         return (
             "#!/bin/bash\n"
@@ -117,7 +145,8 @@ class BashTrial(AbstractTrial):
             f"cat > \"$ROCK_ARTIFACT_DIR/rock_meta.json\" << '__ROCK_META_EOF__'\n"
             f"{meta_running}\n"
             "__ROCK_META_EOF__\n"
-            'sed -i "s/null/$_rock_started_at/; 0,/null/s//null/" "$ROCK_ARTIFACT_DIR/rock_meta.json" 2>/dev/null || true\n'
+            'sed -i "s/__ROCK_STARTED__/$_rock_started_at/g; s/__ROCK_FINISHED__//g; s/__ROCK_EXIT_CODE__/0/g"'
+            ' "$ROCK_ARTIFACT_DIR/rock_meta.json" 2>/dev/null || true\n'
             "\n"
             'ossutil cp "$ROCK_ARTIFACT_DIR/" "oss://$OSS_BUCKET/$ROCK_OSS_PREFIX/" \\\n'
             "    --recursive -f >/dev/null 2>&1 || true\n"
@@ -132,22 +161,12 @@ class BashTrial(AbstractTrial):
             "_rock_finished_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)\n"
             '_rock_status=$( [ $_rock_user_rc -eq 0 ] && echo "completed" || echo "failed" )\n'
             "\n"
-            f'cat > "$ROCK_ARTIFACT_DIR/rock_meta.json" << __ROCK_META_EOF__\n'
-            "{\n"
-            '  "schema_version": "1",\n'
-            f'  "job_name": "{self._config.job_name or ""}",\n'
-            '  "job_type": "bash",\n'
-            '  "status": "$_rock_status",\n'
-            f'  "namespace": {json.dumps(self._config.namespace)},\n'
-            f'  "experiment_id": {json.dumps(self._config.experiment_id)},\n'
-            f'  "user_id": {json.dumps(getattr(self._config.environment, "user_id", None) or os.environ.get("ROCK_USER_ID"))},\n'
-            f'  "image": {json.dumps(getattr(self._config.environment, "image", None))},\n'
-            f'  "labels": {json.dumps(self._config.labels)},\n'
-            '  "started_at": "$_rock_started_at",\n'
-            '  "finished_at": "$_rock_finished_at",\n'
-            '  "exit_code": $_rock_user_rc\n'
-            "}\n"
+            f"cat > \"$ROCK_ARTIFACT_DIR/rock_meta.json\" << '__ROCK_META_EOF__'\n"
+            f"{meta_final}\n"
             "__ROCK_META_EOF__\n"
+            'sed -i "s/__ROCK_STATUS__/$_rock_status/g; s/__ROCK_STARTED__/$_rock_started_at/g;'
+            ' s/__ROCK_FINISHED__/$_rock_finished_at/g; s/__ROCK_EXIT_CODE__/$_rock_user_rc/g"'
+            ' "$ROCK_ARTIFACT_DIR/rock_meta.json"\n'
             "\n"
             'ossutil cp "$ROCK_ARTIFACT_DIR/" "oss://$OSS_BUCKET/$ROCK_OSS_PREFIX/" \\\n'
             "    --recursive -f \\\n"

--- a/rock/sdk/job/trial/bash.py
+++ b/rock/sdk/job/trial/bash.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import secrets
 from pathlib import Path
@@ -83,35 +84,41 @@ class BashTrial(AbstractTrial):
                 raise ValueError(f"oss_mirror.enabled=True but {env_key} is not resolvable")
 
         env["ROCK_ARTIFACT_DIR"] = env_vars.ROCK_BASH_JOB_ARTIFACT_DIR
-        env[
-            "ROCK_OSS_PREFIX"
-        ] = f"artifacts/{self._config.namespace}/{self._config.experiment_id}/{self._config.job_name}"
+        env["ROCK_OSS_PREFIX"] = (
+            f"artifacts/{self._config.namespace}/{self._config.experiment_id}/{self._config.job_name}"
+        )
 
-    @staticmethod
-    def _render_wrapper(user_script: str, token: str | None = None) -> str:
+    def _render_wrapper(self, user_script: str, token: str | None = None) -> str:
         """Render the BashJob wrapper script.
 
-        Structure: prologue (mkdir + touch + initial upload) → user script
-        (isolated in a single-quoted heredoc) → epilogue (final upload) → exit
+        Structure: prologue (mkdir + meta running + initial upload) → user script
+        (isolated in a single-quoted heredoc) → epilogue (meta final + upload) → exit
         with user's exit code.
-
-        When ``token`` is ``None`` a random 8-char hex is generated. Collision
-        probability is ~2^-32 and collisions also require the user script to
-        contain the terminator on its own line, which is not actively guarded
-        against — the risk is acceptable.
         """
         if token is None:
             token = secrets.token_hex(4)  # 8-char hex
         eof = f"__ROCK_USER_SCRIPT_EOF_{token}__"
+
+        from rock.sdk.job.meta import render_meta_json
+
+        meta_running = render_meta_json(self._config, job_type="bash", status="running")
+
         return (
             "#!/bin/bash\n"
             "# rock bash-job wrapper (generated, do not edit)\n"
             "# OSS credentials and paths come from session env; no secrets in this file.\n"
             "set +e\n"
             "\n"
-            "# -- prologue: prepare artifact dir and do an initial placeholder upload --\n"
+            "# -- prologue: prepare artifact dir, write meta, initial upload --\n"
+            "_rock_started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)\n"
             'mkdir -p "$ROCK_ARTIFACT_DIR"\n'
             'touch "$ROCK_ARTIFACT_DIR/.placeholder"\n'
+            "\n"
+            f"cat > \"$ROCK_ARTIFACT_DIR/rock_meta.json\" << '__ROCK_META_EOF__'\n"
+            f"{meta_running}\n"
+            "__ROCK_META_EOF__\n"
+            'sed -i "s/null/$_rock_started_at/; 0,/null/s//null/" "$ROCK_ARTIFACT_DIR/rock_meta.json" 2>/dev/null || true\n'
+            "\n"
             'ossutil cp "$ROCK_ARTIFACT_DIR/" "oss://$OSS_BUCKET/$ROCK_OSS_PREFIX/" \\\n'
             "    --recursive -f >/dev/null 2>&1 || true\n"
             "\n"
@@ -121,7 +128,27 @@ class BashTrial(AbstractTrial):
             f"{eof}\n"
             "_rock_user_rc=$?\n"
             "\n"
-            "# -- epilogue: final upload (failure is logged but does not change exit code) --\n"
+            "# -- epilogue: update meta to final status, then upload --\n"
+            "_rock_finished_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)\n"
+            '_rock_status=$( [ $_rock_user_rc -eq 0 ] && echo "completed" || echo "failed" )\n'
+            "\n"
+            f'cat > "$ROCK_ARTIFACT_DIR/rock_meta.json" << __ROCK_META_EOF__\n'
+            "{\n"
+            '  "schema_version": "1",\n'
+            f'  "job_name": "{self._config.job_name or ""}",\n'
+            '  "job_type": "bash",\n'
+            '  "status": "$_rock_status",\n'
+            f'  "namespace": {json.dumps(self._config.namespace)},\n'
+            f'  "experiment_id": {json.dumps(self._config.experiment_id)},\n'
+            f'  "user_id": {json.dumps(getattr(self._config.environment, "user_id", None) or os.environ.get("ROCK_USER_ID"))},\n'
+            f'  "image": {json.dumps(getattr(self._config.environment, "image", None))},\n'
+            f'  "labels": {json.dumps(self._config.labels)},\n'
+            '  "started_at": "$_rock_started_at",\n'
+            '  "finished_at": "$_rock_finished_at",\n'
+            '  "exit_code": $_rock_user_rc\n'
+            "}\n"
+            "__ROCK_META_EOF__\n"
+            "\n"
             'ossutil cp "$ROCK_ARTIFACT_DIR/" "oss://$OSS_BUCKET/$ROCK_OSS_PREFIX/" \\\n'
             "    --recursive -f \\\n"
             '    || echo "[rock] oss upload failed (rc=$?), ignored" >&2\n'

--- a/rock/sdk/job/trial/harbor.py
+++ b/rock/sdk/job/trial/harbor.py
@@ -21,6 +21,7 @@ from rock.sdk.job.trial.registry import register_trial
 logger = init_logger(__name__)
 
 _HARBOR_SCRIPT_TEMPLATE = r"""#!/bin/bash
+set -e
 
 # ── Detect and start dockerd ─────────────────────────────────────────
 if command -v docker &>/dev/null; then
@@ -39,17 +40,8 @@ fi
 # ── Ensure output directory exists ──────────────────────────────────
 mkdir -p {user_defined_dir}
 
-{meta_block}
-
 # ── Harbor run ───────────────────────────────────────────────────────
-set +e
 harbor jobs start -c {config_path}
-_rock_harbor_rc=$?
-set -e
-
-{meta_epilogue_block}
-
-exit $_rock_harbor_rc
 """
 
 
@@ -73,67 +65,13 @@ class HarborTrial(AbstractTrial):
         if sandbox.sandbox_id:
             labels.setdefault("rock_sandbox_id", sandbox.sandbox_id)
 
-    def _oss_mirror_enabled(self) -> bool:
-        mirror = getattr(self._config.environment, "oss_mirror", None)
-        return mirror is not None and mirror.enabled
 
     def build(self) -> str:
         config_path = f"{USER_DEFINED_LOGS}/rock_job_{self._config.job_name}.yaml"
-        meta_dir = f"{self._config.jobs_dir}/{self._config.job_name}"
-
-        if self._oss_mirror_enabled():
-            meta_block, meta_epilogue_block = self._build_meta_blocks(meta_dir)
-        else:
-            meta_block = ""
-            meta_epilogue_block = ""
-
         return _HARBOR_SCRIPT_TEMPLATE.format(
             config_path=config_path,
             user_defined_dir=USER_DEFINED_LOGS,
-            meta_block=meta_block,
-            meta_epilogue_block=meta_epilogue_block,
         )
-
-    def _build_meta_blocks(self, meta_dir: str) -> tuple[str, str]:
-        import os
-
-        from rock.sdk.job.meta import render_meta_json
-
-        meta_running = render_meta_json(self._config, job_type="harbor", status="running")
-
-        user_id = getattr(self._config.environment, "user_id", None) or os.environ.get("ROCK_USER_ID")
-        image = getattr(self._config.environment, "image", None)
-
-        prologue = (
-            f"mkdir -p {meta_dir}\n"
-            "_rock_started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)\n"
-            f"cat > \"{meta_dir}/rock_meta.json\" << '__ROCK_META_EOF__'\n"
-            f"{meta_running}\n"
-            "__ROCK_META_EOF__\n"
-        )
-
-        epilogue = (
-            "_rock_finished_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)\n"
-            '_rock_status=$( [ $_rock_harbor_rc -eq 0 ] && echo "completed" || echo "failed" )\n'
-            f'cat > "{meta_dir}/rock_meta.json" << __ROCK_META_EOF__\n'
-            "{\n"
-            '  "schema_version": "1",\n'
-            f'  "job_name": "{self._config.job_name or ""}",\n'
-            '  "job_type": "harbor",\n'
-            '  "status": "$_rock_status",\n'
-            f'  "namespace": {json.dumps(self._config.namespace)},\n'
-            f'  "experiment_id": {json.dumps(self._config.experiment_id)},\n'
-            f'  "user_id": {json.dumps(user_id)},\n'
-            f'  "image": {json.dumps(image)},\n'
-            f'  "labels": {json.dumps(self._config.labels)},\n'
-            '  "started_at": "$_rock_started_at",\n'
-            '  "finished_at": "$_rock_finished_at",\n'
-            '  "exit_code": $_rock_harbor_rc\n'
-            "}\n"
-            "__ROCK_META_EOF__\n"
-        )
-
-        return prologue, epilogue
 
     async def collect(self, sandbox, output: str, exit_code: int) -> list[TrialResult]:
         """Return all Harbor sub-trial results (one entry per ``result.json``).

--- a/rock/sdk/job/trial/harbor.py
+++ b/rock/sdk/job/trial/harbor.py
@@ -21,7 +21,6 @@ from rock.sdk.job.trial.registry import register_trial
 logger = init_logger(__name__)
 
 _HARBOR_SCRIPT_TEMPLATE = r"""#!/bin/bash
-set -e
 
 # ── Detect and start dockerd ─────────────────────────────────────────
 if command -v docker &>/dev/null; then
@@ -40,8 +39,17 @@ fi
 # ── Ensure output directory exists ──────────────────────────────────
 mkdir -p {user_defined_dir}
 
+{meta_block}
+
 # ── Harbor run ───────────────────────────────────────────────────────
+set +e
 harbor jobs start -c {config_path}
+_rock_harbor_rc=$?
+set -e
+
+{meta_epilogue_block}
+
+exit $_rock_harbor_rc
 """
 
 
@@ -65,12 +73,67 @@ class HarborTrial(AbstractTrial):
         if sandbox.sandbox_id:
             labels.setdefault("rock_sandbox_id", sandbox.sandbox_id)
 
+    def _oss_mirror_enabled(self) -> bool:
+        mirror = getattr(self._config.environment, "oss_mirror", None)
+        return mirror is not None and mirror.enabled
+
     def build(self) -> str:
         config_path = f"{USER_DEFINED_LOGS}/rock_job_{self._config.job_name}.yaml"
+        meta_dir = f"{self._config.jobs_dir}/{self._config.job_name}"
+
+        if self._oss_mirror_enabled():
+            meta_block, meta_epilogue_block = self._build_meta_blocks(meta_dir)
+        else:
+            meta_block = ""
+            meta_epilogue_block = ""
+
         return _HARBOR_SCRIPT_TEMPLATE.format(
             config_path=config_path,
             user_defined_dir=USER_DEFINED_LOGS,
+            meta_block=meta_block,
+            meta_epilogue_block=meta_epilogue_block,
         )
+
+    def _build_meta_blocks(self, meta_dir: str) -> tuple[str, str]:
+        import os
+
+        from rock.sdk.job.meta import render_meta_json
+
+        meta_running = render_meta_json(self._config, job_type="harbor", status="running")
+
+        user_id = getattr(self._config.environment, "user_id", None) or os.environ.get("ROCK_USER_ID")
+        image = getattr(self._config.environment, "image", None)
+
+        prologue = (
+            f"mkdir -p {meta_dir}\n"
+            "_rock_started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)\n"
+            f"cat > \"{meta_dir}/rock_meta.json\" << '__ROCK_META_EOF__'\n"
+            f"{meta_running}\n"
+            "__ROCK_META_EOF__\n"
+        )
+
+        epilogue = (
+            "_rock_finished_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)\n"
+            '_rock_status=$( [ $_rock_harbor_rc -eq 0 ] && echo "completed" || echo "failed" )\n'
+            f'cat > "{meta_dir}/rock_meta.json" << __ROCK_META_EOF__\n'
+            "{\n"
+            '  "schema_version": "1",\n'
+            f'  "job_name": "{self._config.job_name or ""}",\n'
+            '  "job_type": "harbor",\n'
+            '  "status": "$_rock_status",\n'
+            f'  "namespace": {json.dumps(self._config.namespace)},\n'
+            f'  "experiment_id": {json.dumps(self._config.experiment_id)},\n'
+            f'  "user_id": {json.dumps(user_id)},\n'
+            f'  "image": {json.dumps(image)},\n'
+            f'  "labels": {json.dumps(self._config.labels)},\n'
+            '  "started_at": "$_rock_started_at",\n'
+            '  "finished_at": "$_rock_finished_at",\n'
+            '  "exit_code": $_rock_harbor_rc\n'
+            "}\n"
+            "__ROCK_META_EOF__\n"
+        )
+
+        return prologue, epilogue
 
     async def collect(self, sandbox, output: str, exit_code: int) -> list[TrialResult]:
         """Return all Harbor sub-trial results (one entry per ``result.json``).

--- a/rock/sdk/job/viewer.py
+++ b/rock/sdk/job/viewer.py
@@ -349,13 +349,18 @@ class JobViewer:
         """Read rock_meta.json (unified metadata written by ROCK SDK)."""
         from rock.sdk.job.meta import JobMeta
 
-        data = self._read_json(f"{job_name}/rock_meta.json")
+        data = self._read_json(f"{job_name}/meta.json") or self._read_json(f"{job_name}/rock_meta.json")
         if data is None:
             return None
         try:
             return JobMeta.model_validate(data)
         except Exception:
             return None
+
+    def write_job_meta(self, job_meta) -> None:
+        key = self._oss_key(f"{job_meta.job_name}/meta.json")
+        body = job_meta.model_dump_json(indent=2)
+        self._bucket.put_object(key, body.encode("utf-8"))
 
     def get_exception(self, job_name: str, trial_name: str) -> str | None:
         return self._read_text(f"{job_name}/{trial_name}/exception.txt")
@@ -373,3 +378,75 @@ class JobViewer:
 
     def file_exists(self, path: str) -> bool:
         return self._bucket.object_exists(self._oss_key(path))
+
+    # ── Run metadata (full-dataset run support) ─────────────────────
+
+    def get_run_meta(self, run_id: str):
+        """Read _meta/run_{run_id}.json and return RunMeta or None."""
+        from rock.sdk.job.meta import RunMeta
+
+        data = self._read_json(f"_meta/run_{run_id}.json")
+        if data is None:
+            return None
+        try:
+            return RunMeta.model_validate(data)
+        except Exception:
+            return None
+
+    def write_run_meta(self, run_meta) -> None:
+        """Write RunMeta to OSS as _meta/run_{run_id}.json."""
+        key = self._oss_key(f"_meta/run_{run_meta.run_id}.json")
+        body = run_meta.model_dump_json(indent=2)
+        self._bucket.put_object(key, body)
+
+    def list_runs(self) -> list:
+        """List all runs under this experiment (read _meta/run_*.json files)."""
+        from rock.sdk.job.meta import RunMeta
+
+        meta_prefix = self._oss_key("_meta/")
+        runs = []
+        for obj in oss2.ObjectIterator(self._bucket, prefix=meta_prefix):
+            if obj.is_prefix():
+                continue
+            key = obj.key
+            if not key.endswith(".json") or "/run_" not in key:
+                continue
+            try:
+                result = self._bucket.get_object(key)
+                data = json.loads(result.read().decode("utf-8"))
+                runs.append(RunMeta.model_validate(data))
+            except Exception:
+                pass
+        return sorted(runs, key=lambda r: r.run_id)
+
+    def resolve_run_id_for_resume(self) -> str | None:
+        """Find the most recent incomplete run_id for resume.
+
+        Returns None if all runs are completed.
+        Raises ValueError if multiple incomplete runs exist.
+        """
+        runs = self.list_runs()
+        incomplete = [r for r in runs if r.status != "completed"]
+        if len(incomplete) == 0:
+            return None
+        if len(incomplete) == 1:
+            return incomplete[0].run_id
+        run_ids = [r.run_id for r in incomplete]
+        raise ValueError(f"Found multiple incomplete runs. Specify --run-id explicitly: {run_ids}")
+
+    def find_completed_tasks_in_run(self, run_id: str) -> set[str]:
+        """Find completed tasks within a specific run (does not cross-match other runs).
+
+        Reads the run's task_job_map, checks each job's trial results.
+        Only tasks with at least one successful trial (no exception_info) are considered completed.
+        """
+        run_meta = self.get_run_meta(run_id)
+        if run_meta is None:
+            return set()
+
+        completed = set()
+        for task_id, job_name in run_meta.task_job_map.items():
+            trial_results = self.get_trial_results(job_name)
+            if any(r.status == "completed" for r in trial_results.values()):
+                completed.add(task_id)
+        return completed

--- a/rock/sdk/job/viewer.py
+++ b/rock/sdk/job/viewer.py
@@ -1,0 +1,375 @@
+"""JobViewer — query agent job artifacts and status from OSS.
+
+Reads Harbor job results, trajectories, logs and artifact files that were
+persisted to OSS via the OSS mirror mechanism.
+
+OSS key layout:
+    artifacts/<namespace>/<experiment_id>/<job_name>/<trial_name>/...
+"""
+
+from __future__ import annotations
+
+import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import TYPE_CHECKING, Any
+
+import oss2
+from pydantic import BaseModel, Field
+
+from rock.sdk.bench.models.trial.result import HarborTrialResult
+
+if TYPE_CHECKING:
+    from rock.sdk.envhub.config import OssMirrorConfig
+
+RESERVED_JOB_DIR_NAMES = {"_meta"}
+
+# ---------------------------------------------------------------------------
+# Data models (lightweight, co-located to avoid unnecessary modules)
+# ---------------------------------------------------------------------------
+
+
+class VerifierOutput(BaseModel):
+    stdout: str | None = None
+    stderr: str | None = None
+    ctrf: str | None = None
+
+
+class ArtifactManifestEntry(BaseModel):
+    source: str
+    destination: str
+    type: str
+
+
+class FileInfo(BaseModel):
+    path: str
+    name: str
+    is_dir: bool
+    size: int | None = None
+
+
+class ArtifactsData(BaseModel):
+    files: list[FileInfo] = Field(default_factory=list)
+    manifest: list[ArtifactManifestEntry] | None = None
+
+
+class CommandLog(BaseModel):
+    index: int
+    content: str
+
+
+class AgentLogs(BaseModel):
+    oracle: str | None = None
+    setup: str | None = None
+    commands: list[CommandLog] = Field(default_factory=list)
+    summary: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# JobViewer
+# ---------------------------------------------------------------------------
+
+
+class JobViewer:
+    """Read agent job artifacts and status from OSS. Synchronous API.
+
+    OSS key: ``artifacts/<namespace>/<experiment_id>/<relative_path>``
+
+    Usage::
+
+        viewer = JobViewer.from_credentials(
+            oss_endpoint="https://oss-cn-hangzhou.aliyuncs.com",
+            oss_bucket="my-bucket",
+            access_key_id="...", access_key_secret="...",
+            namespace="my-ns", experiment_id="exp-001",
+        )
+        for job in viewer.list_jobs():
+            print(viewer.get_job_result(job))
+    """
+
+    def __init__(self, bucket: oss2.Bucket, namespace: str, experiment_id: str):
+        self._bucket = bucket
+        self._prefix = f"artifacts/{namespace}/{experiment_id}/"
+
+    # ── Factory methods ──────────────────────────────────────────────
+
+    @classmethod
+    def from_credentials(
+        cls,
+        *,
+        oss_endpoint: str,
+        oss_bucket: str,
+        access_key_id: str,
+        access_key_secret: str,
+        namespace: str,
+        experiment_id: str,
+        oss_region: str | None = None,
+    ) -> JobViewer:
+        auth = oss2.Auth(access_key_id, access_key_secret)
+        bucket = oss2.Bucket(auth, oss_endpoint, oss_bucket, region=oss_region)
+        return cls(bucket, namespace, experiment_id)
+
+    @classmethod
+    def from_oss_mirror(cls, oss_mirror: OssMirrorConfig) -> JobViewer:
+        if not oss_mirror.oss_endpoint or not oss_mirror.oss_bucket:
+            raise ValueError("OssMirrorConfig must have oss_endpoint and oss_bucket")
+        if not oss_mirror.namespace or not oss_mirror.experiment_id:
+            raise ValueError("OssMirrorConfig must have namespace and experiment_id")
+        return cls.from_credentials(
+            oss_endpoint=oss_mirror.oss_endpoint,
+            oss_bucket=oss_mirror.oss_bucket,
+            access_key_id=oss_mirror.oss_access_key_id or "",
+            access_key_secret=oss_mirror.oss_access_key_secret or "",
+            namespace=oss_mirror.namespace,
+            experiment_id=oss_mirror.experiment_id,
+            oss_region=oss_mirror.oss_region,
+        )
+
+    @classmethod
+    def from_admin(
+        cls,
+        *,
+        admin_base_url: str,
+        namespace: str,
+        experiment_id: str,
+        auth_token: str | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> JobViewer:
+        import httpx
+
+        api_prefix = "/apis/envs/sandbox/v1"
+        clean = admin_base_url.rstrip("/")
+        if not clean.endswith(api_prefix):
+            clean = f"{clean}{api_prefix}"
+        url = f"{clean}/get_token?account=primary"
+
+        headers = dict(extra_headers or {})
+        if auth_token:
+            headers["xrl-authorization"] = auth_token
+
+        resp = httpx.get(url, headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+        if data.get("status") != "Success":
+            raise RuntimeError(f"admin /get_token failed: {data.get('message')}")
+        sts = data["result"]
+
+        auth = oss2.StsAuth(sts["AccessKeyId"], sts["AccessKeySecret"], sts["SecurityToken"])
+        bucket = oss2.Bucket(auth, sts["Endpoint"], sts["Bucket"], region=sts.get("Region"))
+        return cls(bucket, namespace, experiment_id)
+
+    # ── Internal OSS operations ──────────────────────────────────────
+
+    def _oss_key(self, path: str) -> str:
+        return self._prefix + path
+
+    def _read_text(self, path: str) -> str | None:
+        try:
+            result = self._bucket.get_object(self._oss_key(path))
+            data = result.read()
+            return data.decode("utf-8")
+        except oss2.exceptions.NoSuchKey:
+            return None
+
+    def _read_bytes(self, path: str) -> bytes | None:
+        try:
+            result = self._bucket.get_object(self._oss_key(path))
+            return result.read()
+        except oss2.exceptions.NoSuchKey:
+            return None
+
+    def _read_json(self, path: str) -> dict[str, Any] | None:
+        text = self._read_text(path)
+        if text is None:
+            return None
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return None
+
+    def _list_dirs(self, prefix: str = "") -> list[str]:
+        oss_prefix = self._oss_key(prefix + "/") if prefix else self._prefix
+        result: list[str] = []
+        for obj in oss2.ObjectIterator(self._bucket, prefix=oss_prefix, delimiter="/"):
+            if obj.is_prefix():
+                dir_name = obj.key[len(oss_prefix) :].rstrip("/")
+                if dir_name:
+                    result.append(dir_name)
+        return result
+
+    def _read_texts_batch(self, paths: list[str]) -> dict[str, str | None]:
+        if not paths:
+            return {}
+        results: dict[str, str | None] = {}
+        max_workers = min(len(paths), 32)
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            future_to_path = {executor.submit(self._read_text, p): p for p in paths}
+            for future in as_completed(future_to_path):
+                path = future_to_path[future]
+                try:
+                    results[path] = future.result()
+                except Exception:
+                    results[path] = None
+        return results
+
+    def _find_dirs_with_file(self, prefix: str, filename: str) -> list[str]:
+        dirs = self._list_dirs(prefix)
+        if not dirs:
+            return []
+        base = f"{prefix}/" if prefix else ""
+        max_workers = min(len(dirs), 32)
+        results: list[str] = []
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            future_to_dir = {
+                executor.submit(self._bucket.object_exists, self._oss_key(f"{base}{d}/{filename}")): d for d in dirs
+            }
+            for future in as_completed(future_to_dir):
+                d = future_to_dir[future]
+                try:
+                    if future.result():
+                        results.append(d)
+                except Exception:
+                    pass
+        return sorted(results)
+
+    def _exists(self, path: str) -> bool:
+        if self._bucket.object_exists(self._oss_key(path)):
+            return True
+        for _ in oss2.ObjectIterator(self._bucket, prefix=self._oss_key(path) + "/", max_keys=1):
+            return True
+        return False
+
+    # ── Job operations ───────────────────────────────────────────────
+
+    def list_jobs(self) -> list[str]:
+        return sorted(d for d in self._list_dirs() if d not in RESERVED_JOB_DIR_NAMES)
+
+    def get_job_result(self, job_name: str) -> dict[str, Any] | None:
+        return self._read_json(f"{job_name}/result.json")
+
+    def get_job_config(self, job_name: str) -> dict[str, Any] | None:
+        return self._read_json(f"{job_name}/config.json")
+
+    def get_job_summary(self, job_name: str) -> str | None:
+        return self._read_text(f"{job_name}/summary.md")
+
+    # ── Trial operations ─────────────────────────────────────────────
+
+    def list_trials(self, job_name: str) -> list[str]:
+        return self._find_dirs_with_file(job_name, "result.json")
+
+    def get_trial_result(self, job_name: str, trial_name: str) -> HarborTrialResult | None:
+        data = self._read_json(f"{job_name}/{trial_name}/result.json")
+        if data is None:
+            return None
+        try:
+            return HarborTrialResult.from_harbor_json(data)
+        except Exception:
+            return None
+
+    def get_trial_results(self, job_name: str) -> dict[str, HarborTrialResult]:
+        all_dirs = self._list_dirs(job_name)
+        if not all_dirs:
+            return {}
+        paths = [f"{job_name}/{d}/result.json" for d in all_dirs]
+        contents = self._read_texts_batch(paths)
+        results: dict[str, HarborTrialResult] = {}
+        for d, p in zip(all_dirs, paths):
+            text = contents.get(p)
+            if text:
+                try:
+                    data = json.loads(text)
+                    results[d] = HarborTrialResult.from_harbor_json(data)
+                except Exception:
+                    pass
+        return results
+
+    def get_trial_config(self, job_name: str, trial_name: str) -> dict[str, Any] | None:
+        return self._read_json(f"{job_name}/{trial_name}/config.json")
+
+    # ── Artifacts and logs ───────────────────────────────────────────
+
+    def get_trajectory(self, job_name: str, trial_name: str) -> dict[str, Any] | None:
+        return self._read_json(f"{job_name}/{trial_name}/agent/trajectory.json")
+
+    def get_verifier_output(self, job_name: str, trial_name: str) -> VerifierOutput:
+        base = f"{job_name}/{trial_name}/verifier"
+        return VerifierOutput(
+            stdout=self._read_text(f"{base}/test-stdout.txt"),
+            stderr=self._read_text(f"{base}/test-stderr.txt"),
+            ctrf=self._read_text(f"{base}/ctrf.json"),
+        )
+
+    def list_artifacts(self, job_name: str, trial_name: str) -> ArtifactsData:
+        base = f"{job_name}/{trial_name}/artifacts"
+        manifest = None
+        manifest_text = self._read_text(f"{base}/manifest.json")
+        if manifest_text:
+            try:
+                raw = json.loads(manifest_text)
+                manifest = [ArtifactManifestEntry(**e) for e in raw] if isinstance(raw, list) else None
+            except (json.JSONDecodeError, Exception):
+                manifest = None
+
+        oss_prefix = self._oss_key(base + "/")
+        files: list[FileInfo] = []
+        for obj in oss2.ObjectIterator(self._bucket, prefix=oss_prefix):
+            if obj.is_prefix():
+                continue
+            relative = obj.key[len(oss_prefix) :]
+            if not relative or relative == "manifest.json":
+                continue
+            name = relative.rsplit("/", 1)[-1]
+            files.append(FileInfo(path=relative, name=name, is_dir=False, size=obj.size))
+        return ArtifactsData(files=files, manifest=manifest)
+
+    def get_agent_logs(self, job_name: str, trial_name: str) -> AgentLogs:
+        base = f"{job_name}/{trial_name}"
+        agent_base = f"{base}/agent"
+
+        all_dirs = self._list_dirs(agent_base)
+        cmd_dirs = sorted(
+            [d for d in all_dirs if d.startswith("command-")],
+            key=lambda d: int(d.split("-", 1)[1]) if d.split("-", 1)[1].isdigit() else 0,
+        )
+
+        commands: list[CommandLog] = []
+        for d in cmd_dirs:
+            content = self._read_text(f"{agent_base}/{d}/stdout.txt")
+            idx = d.split("-", 1)[1]
+            commands.append(CommandLog(index=int(idx) if idx.isdigit() else 0, content=content or ""))
+
+        return AgentLogs(
+            oracle=self._read_text(f"{agent_base}/oracle.txt"),
+            setup=self._read_text(f"{agent_base}/setup/stdout.txt"),
+            commands=commands,
+            summary=self._read_text(f"{base}/summary.md"),
+        )
+
+    def get_job_meta(self, job_name: str):
+        """Read rock_meta.json (unified metadata written by ROCK SDK)."""
+        from rock.sdk.job.meta import JobMeta
+
+        data = self._read_json(f"{job_name}/rock_meta.json")
+        if data is None:
+            return None
+        try:
+            return JobMeta.model_validate(data)
+        except Exception:
+            return None
+
+    def get_exception(self, job_name: str, trial_name: str) -> str | None:
+        return self._read_text(f"{job_name}/{trial_name}/exception.txt")
+
+    def get_trial_log(self, job_name: str, trial_name: str) -> str | None:
+        return self._read_text(f"{job_name}/{trial_name}/trial.log")
+
+    # ── Generic file operations ──────────────────────────────────────
+
+    def read_file(self, path: str) -> str | None:
+        return self._read_text(path)
+
+    def read_file_bytes(self, path: str) -> bytes | None:
+        return self._read_bytes(path)
+
+    def file_exists(self, path: str) -> bool:
+        return self._bucket.object_exists(self._oss_key(path))

--- a/tests/unit/cli/command/test_job.py
+++ b/tests/unit/cli/command/test_job.py
@@ -45,22 +45,87 @@ def test_run_parser_supports_single_multi_full_and_resume():
     assert ns.resume == "run-1"
 
 
-def test_run_query_parsers_use_run_centric_commands():
+def test_run_query_parsers_use_explicit_command_names():
     parser = _build_parser()
-    runs = parser.parse_args(["job", "runs", "--job-config", "foo.yaml", "--output", "json"])
-    assert runs.job_command == "runs"
+    runs = parser.parse_args(["job", "run-list", "--job-config", "foo.yaml", "--output", "json"])
+    assert runs.job_command == "run-list"
     assert runs.job_config == "foo.yaml"
     assert runs.output == "json"
 
-    status = parser.parse_args(["job", "status", "--run-id", "run-1", "--job-config", "foo.yaml", "--jobs"])
-    assert status.job_command == "status"
+    status = parser.parse_args(["job", "run-status", "--run-id", "run-1", "--job-config", "foo.yaml", "--jobs"])
+    assert status.job_command == "run-status"
     assert status.run_id == "run-1"
     assert status.jobs is True
 
-    show = parser.parse_args(["job", "show", "--run-id", "run-1", "--task-id", "t1", "--job-config", "foo.yaml"])
-    assert show.job_command == "show"
+    job_list = parser.parse_args(["job", "job-list", "--namespace", "ns", "--experiment-id", "exp"])
+    assert job_list.job_command == "job-list"
+
+    show = parser.parse_args(["job", "job-show", "--run-id", "run-1", "--task-id", "t1", "--job-config", "foo.yaml"])
+    assert show.job_command == "job-show"
     assert show.run_id == "run-1"
     assert show.task_id == "t1"
+
+    trial_list = parser.parse_args(["job", "trial-list", "job-1", "--namespace", "ns", "--experiment-id", "exp"])
+    assert trial_list.job_command == "trial-list"
+    assert trial_list.job_name == "job-1"
+
+    trial_show = parser.parse_args(["job", "trial-show", "job-1", "trial-1", "--namespace", "ns", "--experiment-id", "exp"])
+    assert trial_show.job_command == "trial-show"
+    assert trial_show.job_name == "job-1"
+    assert trial_show.trial_name == "trial-1"
+
+
+def test_old_query_subcommands_are_removed():
+    parser = _build_parser()
+    for subcommand in ["runs", "status", "list", "show", "trials", "trial"]:
+        with pytest.raises(SystemExit):
+            parser.parse_args(["job", subcommand])
+
+
+def test_job_help_uses_self_describing_query_command_summaries(capsys):
+    parser = _build_parser()
+
+    with pytest.raises(SystemExit) as excinfo:
+        parser.parse_args(["job", "--help"])
+
+    assert excinfo.value.code == 0
+    out = capsys.readouterr().out
+    assert "run-list" in out
+    assert "List historical job runs from run metadata" in out
+    assert "run-status" in out
+    assert "Show summary and task/job status for one run" in out
+    assert "job-list" in out
+    assert "List job artifact directories in an experiment" in out
+    assert "job-show" in out
+    assert "Show one job artifact by job name or run/task id" in out
+    assert "trial-list" in out
+    assert "List trial results under one job artifact" in out
+    assert "trial-show" in out
+    assert "Show one trial result and verifier details" in out
+
+
+def test_query_subcommand_help_explains_locators_and_identifiers(capsys):
+    parser = _build_parser()
+
+    with pytest.raises(SystemExit) as excinfo:
+        parser.parse_args(["job", "job-show", "--help"])
+
+    assert excinfo.value.code == 0
+    out = capsys.readouterr().out
+    assert "Show one job artifact by job name or run/task id" in out
+    assert "YAML config used to locate OSS artifacts" in out
+    assert "Run id from rock job run or run-list" in out
+    assert "Task id inside the run; use with --run-id" in out
+    assert "Job artifact name" in out
+
+    with pytest.raises(SystemExit) as excinfo:
+        parser.parse_args(["job", "trial-show", "--help"])
+
+    assert excinfo.value.code == 0
+    out = capsys.readouterr().out
+    assert "Show one trial result and verifier details" in out
+    assert "Job artifact name" in out
+    assert "Trial name under the job artifact" in out
 
 
 class TestRunValidation:
@@ -139,7 +204,7 @@ class TestRunEndToEnd:
 
 
 class TestRunQueries:
-    def test_runs_prints_run_meta(self, monkeypatch, capsys):
+    def test_run_list_prints_run_meta(self, monkeypatch, capsys):
         from rock.sdk.job.meta import RunMeta, RunScoreSummary
 
         viewer = MagicMock()
@@ -157,7 +222,7 @@ class TestRunQueries:
         ]
         monkeypatch.setattr(JobCommand, "_build_viewer_from_locator", lambda self, args: viewer)
         parser = _build_parser()
-        ns = parser.parse_args(["job", "runs", "--job-config", "foo.yaml"])
+        ns = parser.parse_args(["job", "run-list", "--job-config", "foo.yaml"])
 
         asyncio.run(JobCommand().arun(ns))
 
@@ -166,7 +231,7 @@ class TestRunQueries:
         assert "full" in out
         assert "org/ds" in out
 
-    def test_status_prints_jobs(self, monkeypatch, capsys):
+    def test_run_status_prints_jobs(self, monkeypatch, capsys):
         from rock.sdk.job.meta import RunJobStatus, RunMeta
 
         viewer = MagicMock()
@@ -184,7 +249,7 @@ class TestRunQueries:
         monkeypatch.setattr(JobCommand, "_build_viewer_from_locator", lambda self, args: viewer)
         monkeypatch.setattr("rock.sdk.job.run_meta.RunMetaRepository", FakeRepo)
         parser = _build_parser()
-        ns = parser.parse_args(["job", "status", "--run-id", "run-1", "--job-config", "foo.yaml", "--jobs"])
+        ns = parser.parse_args(["job", "run-status", "--run-id", "run-1", "--job-config", "foo.yaml", "--jobs"])
 
         asyncio.run(JobCommand().arun(ns))
 

--- a/tests/unit/cli/command/test_job.py
+++ b/tests/unit/cli/command/test_job.py
@@ -1,14 +1,8 @@
-"""Unit tests for rock.cli.command.job.JobCommand.
-
-All tests in this file are fast: no Docker, Ray, or network. We drive the
-sub-parser end-to-end with argparse so mutual-exclusion and error messages
-match what users see at the terminal.
-"""
-
 from __future__ import annotations
 
 import argparse
 import asyncio
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -16,656 +10,185 @@ from rock.cli.command.job import JobCommand
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    """Build a top-level parser with `job` subcommand wired in, same as the CLI."""
     top = argparse.ArgumentParser(prog="rock")
     subparsers = top.add_subparsers(dest="command")
     asyncio.run(JobCommand.add_parser_to(subparsers))
     return top
 
 
-def test_parser_builds():
-    """Smoke: the parser builds without error and exposes --job_config / --script."""
-    parser = _build_parser()
-    ns = parser.parse_args(["job", "run", "--job_config", "foo.yaml"])
-    assert ns.command == "job"
-    assert ns.job_command == "run"
-    assert ns.job_config == "foo.yaml"
-    assert ns.script is None
-    assert ns.script_content is None
-
-
-def test_top_level_config_does_not_collide_with_job_config():
-    """Regression: `rock --config cli.ini job run --job_config foo.yaml` keeps
-    both values separate — the top-level --config (INI loader) and the sub-parser's
-    --job_config (YAML) must not overwrite each other.
-    """
-    top = argparse.ArgumentParser(prog="rock")
-    top.add_argument("--config", help="top-level CLI config (INI)")
-    subparsers = top.add_subparsers(dest="command")
-    asyncio.run(JobCommand.add_parser_to(subparsers))
-
-    ns = top.parse_args(["--config", "cli.ini", "job", "run", "--job_config", "bash.yaml"])
-    assert ns.config == "cli.ini"
-    assert ns.job_config == "bash.yaml"
-
-
 def test_job_config_hyphen_alias():
-    """Both --job_config and --job-config should work (argparse accepts the alias)."""
     parser = _build_parser()
-    ns = parser.parse_args(["job", "run", "--job-config", "foo.yaml"])
+    ns = parser.parse_args(["job", "run", "--job-config", "foo.yaml", "--task", "t1"])
     assert ns.job_config == "foo.yaml"
+    assert ns.task == "t1"
 
 
-class TestFailHelper:
-    def test_fail_exits_with_code_2_and_usage(self, capsys):
-        """_fail() must print usage + msg and exit code 2 (argparse convention)."""
-        from rock.cli.command.job import _fail
-
-        parser = argparse.ArgumentParser(prog="rock job run")
-        parser.add_argument("--config")
-
-        with pytest.raises(SystemExit) as excinfo:
-            _fail(parser, "boom")
-
-        assert excinfo.value.code == 2
-        err = capsys.readouterr().err
-        assert "usage:" in err
-        assert "boom" in err
-        assert "rock job run --help" in err  # always appended
-
-    def test_fail_includes_hint_when_given(self, capsys):
-        from rock.cli.command.job import _fail
-
-        parser = argparse.ArgumentParser(prog="rock job run")
-
-        with pytest.raises(SystemExit):
-            _fail(parser, "boom", hint="try this: X")
-
-        err = capsys.readouterr().err
-        assert "boom" in err
-        assert "try this: X" in err
-
-    def test_fail_no_hint_still_appends_help_pointer(self, capsys):
-        from rock.cli.command.job import _fail
-
-        parser = argparse.ArgumentParser(prog="rock job run")
-
-        with pytest.raises(SystemExit):
-            _fail(parser, "boom")
-
-        err = capsys.readouterr().err
-        assert "rock job run --help" in err
+def test_run_all_subcommand_is_removed():
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["job", "run-all", "--job-config", "foo.yaml"])
 
 
-class TestRunParserStash:
-    def test_run_parser_stashed_on_class_after_add_parser_to(self):
-        """After add_parser_to runs, JobCommand._run_parser must point to the 'run' sub-parser."""
-        # Reset to isolate from other tests
-        JobCommand._run_parser = None
+def test_run_parser_supports_single_multi_full_and_resume():
+    parser = _build_parser()
+    ns = parser.parse_args(["job", "run", "--job-config", "foo.yaml", "--tasks", "t1,t2", "--concurrency", "3"])
+    assert ns.job_command == "run"
+    assert ns.tasks == "t1,t2"
+    assert ns.concurrency == 3
 
-        top = argparse.ArgumentParser(prog="rock")
-        subparsers = top.add_subparsers(dest="command")
-        asyncio.run(JobCommand.add_parser_to(subparsers))
+    ns = parser.parse_args(["job", "run", "--job-config", "foo.yaml", "--all", "--limit", "2", "--jsonl"])
+    assert ns.all is True
+    assert ns.limit == 2
+    assert ns.jsonl is True
 
-        assert JobCommand._run_parser is not None
-        assert isinstance(JobCommand._run_parser, argparse.ArgumentParser)
-        # Sanity: it is the parser that knows about --config (stored as job_config)
-        actions = {a.dest for a in JobCommand._run_parser._actions}
-        assert "job_config" in actions
-        assert "script" in actions
+    ns = parser.parse_args(["job", "run", "--resume", "run-1", "--job-config", "foo.yaml"])
+    assert ns.resume == "run-1"
 
 
-class TestJobRunValidation:
+def test_run_query_parsers_use_run_centric_commands():
+    parser = _build_parser()
+    runs = parser.parse_args(["job", "runs", "--job-config", "foo.yaml", "--output", "json"])
+    assert runs.job_command == "runs"
+    assert runs.job_config == "foo.yaml"
+    assert runs.output == "json"
+
+    status = parser.parse_args(["job", "status", "--run-id", "run-1", "--job-config", "foo.yaml", "--jobs"])
+    assert status.job_command == "status"
+    assert status.run_id == "run-1"
+    assert status.jobs is True
+
+    show = parser.parse_args(["job", "show", "--run-id", "run-1", "--task-id", "t1", "--job-config", "foo.yaml"])
+    assert show.job_command == "show"
+    assert show.run_id == "run-1"
+    assert show.task_id == "t1"
+
+
+class TestRunValidation:
     @pytest.fixture(autouse=True)
     def _parser(self):
-        """Rebuild the parser for each test so _run_parser is populated and fresh."""
-        JobCommand._run_parser = None
-        top = argparse.ArgumentParser(prog="rock")
-        subparsers = top.add_subparsers(dest="command")
-        asyncio.run(JobCommand.add_parser_to(subparsers))
-        self.top = top
-        yield
+        self.top = _build_parser()
 
     def _run(self, argv):
-        """Parse argv and invoke JobCommand.arun; SystemExit bubbles up."""
         ns = self.top.parse_args(argv)
-        cmd = JobCommand()
-        asyncio.run(cmd.arun(ns))
+        asyncio.run(JobCommand().arun(ns))
 
-    def test_missing_both_config_and_script_errors(self, capsys):
-        """With neither --config nor --script*, must exit 2 with helpful message."""
+    def test_missing_definition_for_fresh_run_errors(self, capsys):
         with pytest.raises(SystemExit) as excinfo:
-            self._run(["job", "run"])
-
+            self._run(["job", "run", "--task", "t1"])
         assert excinfo.value.code == 2
-        err = capsys.readouterr().err
-        assert "Missing job definition" in err
-        assert "--job_config job.yaml" in err  # example in hint
-        assert "--script" in err
-        assert "rock job run --help" in err
+        assert "Missing job definition" in capsys.readouterr().err
 
-    def test_config_and_script_mutually_exclusive(self, capsys, tmp_path):
-        """--job_config together with --script must error with mutex hint."""
-        yaml_path = tmp_path / "job.yaml"
-        yaml_path.write_text("script_path: ./run.sh\n")
-
+    def test_script_requires_explicit_task(self, capsys):
         with pytest.raises(SystemExit) as excinfo:
-            self._run(["job", "run", "--job_config", str(yaml_path), "--script", "run.sh"])
-
+            self._run(["job", "run", "--script-content", "echo hi"])
         assert excinfo.value.code == 2
-        err = capsys.readouterr().err
-        assert "mutually exclusive" in err
-        assert "YAML mode" in err
-        assert "flags mode" in err
+        assert "fresh run requires an explicit task" in capsys.readouterr().err
 
-    def test_config_and_script_content_mutually_exclusive(self, capsys, tmp_path):
-        yaml_path = tmp_path / "job.yaml"
-        yaml_path.write_text("script_path: ./run.sh\n")
-
+    def test_task_selection_arguments_are_mutually_exclusive(self, capsys):
         with pytest.raises(SystemExit) as excinfo:
-            self._run(["job", "run", "--job_config", str(yaml_path), "--script-content", "echo hi"])
-
+            self._run(["job", "run", "--script-content", "echo hi", "--task", "t1", "--all"])
         assert excinfo.value.code == 2
-        err = capsys.readouterr().err
-        assert "mutually exclusive" in err
 
-    def test_script_and_script_content_mutually_exclusive(self, capsys):
-        with pytest.raises(SystemExit) as excinfo:
-            self._run(["job", "run", "--script", "run.sh", "--script-content", "echo hi"])
-
-        assert excinfo.value.code == 2
-        err = capsys.readouterr().err
-        assert "--script and --script-content are mutually exclusive" in err
-
-    def test_type_harbor_requires_config(self, capsys):
-        with pytest.raises(SystemExit) as excinfo:
-            self._run(["job", "run", "--type", "harbor", "--script", "run.sh"])
-
-        assert excinfo.value.code == 2
-        err = capsys.readouterr().err
-        assert "--type harbor requires --job_config" in err
-        assert "cannot be expressed purely via CLI flags" in err
-
-    def test_type_default_is_none(self):
-        """--type should default to None; 'bash' is implied only when mode is flags."""
-        ns = self.top.parse_args(["job", "run", "--script", "run.sh"])
-        assert ns.type is None
-
-
-class TestConfigFromFlags:
-    def _args(self, **overrides):
-        """Build an argparse.Namespace matching the run sub-parser defaults, then overlay overrides."""
-        JobCommand._run_parser = None
-        top = argparse.ArgumentParser(prog="rock")
-        subparsers = top.add_subparsers(dest="command")
-        asyncio.run(JobCommand.add_parser_to(subparsers))
-        argv = ["job", "run", "--script", "dummy.sh"]
-        ns = top.parse_args(argv)
-        for k, v in overrides.items():
-            setattr(ns, k, v)
-        return ns
-
-    def test_inline_script_content_with_env_and_uploads(self):
-        ns = self._args(
-            script=None,
-            script_content="echo hi",
-            image="python:3.11",
-            memory="8g",
-            cpus=4.0,
-            env=["FOO=bar", "BAZ=qux"],
-            local_path="/tmp/workspace",
-            target_path="/root/job",
-            timeout=1800,
-        )
-        config = JobCommand()._config_from_flags(ns)
-
+    def test_resume_rejects_task_selection(self, monkeypatch, capsys):
         from rock.sdk.job.config import BashJobConfig
+        from rock.sdk.job.meta import RunMeta
 
-        assert isinstance(config, BashJobConfig)
-        assert config.script == "echo hi"
-        assert config.script_path is None
-        assert config.timeout == 1800
-        env = config.environment
-        assert env.image == "python:3.11"
-        assert env.memory == "8g"
-        assert env.cpus == 4.0
-        assert env.env == {"FOO": "bar", "BAZ": "qux"}
-        assert env.uploads == [("/tmp/workspace", "/root/job")]
+        config = BashJobConfig(script="echo hi", environment={"oss_mirror": {"enabled": True, "namespace": "ns", "experiment_id": "exp", "oss_bucket": "b", "oss_endpoint": "e"}})
 
-    def test_script_path_mode_no_env_no_uploads(self):
-        ns = self._args(script="run.sh", script_content=None, env=None, local_path=None)
-        config = JobCommand()._config_from_flags(ns)
+        class FakeRepo:
+            _viewer = MagicMock()
 
-        assert config.script_path == "run.sh"
-        assert config.script is None
-        assert config.environment.env == {}
-        assert config.environment.uploads == []
+            def get(self, run_id):
+                return RunMeta(run_id=run_id, mode="single", status="running", total_tasks=1, pending_tasks=1)
 
+            def find_completed_tasks(self, run_id):
+                return set()
 
-class TestConfigFromYaml:
-    def _setup(self):
-        JobCommand._run_parser = None
-        top = argparse.ArgumentParser(prog="rock")
-        subparsers = top.add_subparsers(dest="command")
-        asyncio.run(JobCommand.add_parser_to(subparsers))
-        return top
-
-    def _make_args(self, top, argv):
-        return top.parse_args(argv)
-
-    def test_loads_bash_yaml_autodetected(self, tmp_path):
-        top = self._setup()
-        yaml_path = tmp_path / "bash.yaml"
-        yaml_path.write_text("script_path: ./run.sh\ntimeout: 1800\nenvironment:\n  image: python:3.11\n")
-        ns = self._make_args(top, ["job", "run", "--job_config", str(yaml_path)])
-        config = JobCommand()._config_from_yaml(JobCommand._run_parser, ns)
-
-        from rock.sdk.job.config import BashJobConfig
-
-        assert isinstance(config, BashJobConfig)
-        assert config.script_path == "./run.sh"
-        assert config.timeout == 1800
-        assert config.environment.image == "python:3.11"
-
-    def test_missing_file_errors_via_parser(self, tmp_path, capsys):
-        top = self._setup()
-        missing = tmp_path / "nope.yaml"
-        ns = self._make_args(top, ["job", "run", "--job_config", str(missing)])
+        monkeypatch.setattr(JobCommand, "_config_from_yaml", lambda self, parser, args: config)
+        monkeypatch.setattr("rock.sdk.job.run_meta.RunMetaRepository.from_job_config", classmethod(lambda cls, cfg: FakeRepo()))
 
         with pytest.raises(SystemExit) as excinfo:
-            JobCommand()._config_from_yaml(JobCommand._run_parser, ns)
-
+            self._run(["job", "run", "--resume", "run-1", "--job-config", "foo.yaml", "--task", "t1"])
         assert excinfo.value.code == 2
-        err = capsys.readouterr().err
-        assert "--job_config path does not exist" in err
-
-    def test_invalid_yaml_surfaces_from_yaml_error(self, tmp_path, capsys):
-        top = self._setup()
-        yaml_path = tmp_path / "weird.yaml"
-        yaml_path.write_text("totally_unknown_field: 1\n")
-        ns = self._make_args(top, ["job", "run", "--job_config", str(yaml_path)])
-
-        with pytest.raises(SystemExit) as excinfo:
-            JobCommand()._config_from_yaml(JobCommand._run_parser, ns)
-
-        assert excinfo.value.code == 2
-        err = capsys.readouterr().err
-        assert "Failed to load --job_config" in err
-        assert "YAML does not match any known job type" in err
-
-    def test_type_bash_matches_yaml(self, tmp_path):
-        top = self._setup()
-        yaml_path = tmp_path / "bash.yaml"
-        yaml_path.write_text("script_path: ./run.sh\n")
-        ns = self._make_args(top, ["job", "run", "--type", "bash", "--job_config", str(yaml_path)])
-        config = JobCommand()._config_from_yaml(JobCommand._run_parser, ns)
-
-        from rock.sdk.job.config import BashJobConfig
-
-        assert isinstance(config, BashJobConfig)
-
-    def test_type_harbor_mismatch_against_bash_yaml(self, tmp_path, capsys):
-        top = self._setup()
-        yaml_path = tmp_path / "bash.yaml"
-        yaml_path.write_text("script_path: ./run.sh\n")
-        ns = self._make_args(top, ["job", "run", "--type", "harbor", "--job_config", str(yaml_path)])
-
-        with pytest.raises(SystemExit) as excinfo:
-            JobCommand()._config_from_yaml(JobCommand._run_parser, ns)
-
-        assert excinfo.value.code == 2
-        err = capsys.readouterr().err
-        assert "--type harbor does not match YAML (detected as bash)" in err
+        assert "resume cannot be combined" in capsys.readouterr().err
 
 
-class TestApplyOverrides:
-    def _setup(self):
-        JobCommand._run_parser = None
-        top = argparse.ArgumentParser(prog="rock")
-        subparsers = top.add_subparsers(dest="command")
-        asyncio.run(JobCommand.add_parser_to(subparsers))
-        return top
-
-    def test_override_image_memory_cpus_on_bash_config(self):
-        from rock.sdk.bench.models.trial.config import RockEnvironmentConfig
-        from rock.sdk.job.config import BashJobConfig
-
-        top = self._setup()
-        config = BashJobConfig(
-            script="echo hi",
-            environment=RockEnvironmentConfig(image="python:3.10", memory="2g", cpus=1),
-            timeout=7200,
-        )
-        ns = top.parse_args(
-            [
-                "job",
-                "run",
-                "--job_config",
-                "unused.yaml",
-                "--image",
-                "python:3.12",
-                "--memory",
-                "16g",
-                "--cpus",
-                "8",
-                "--timeout",
-                "900",
-            ]
-        )
-        JobCommand()._apply_overrides(config, ns)
-
-        assert config.environment.image == "python:3.12"
-        assert config.environment.memory == "16g"
-        assert config.environment.cpus == 8.0
-        assert config.timeout == 900
-
-    def test_env_overrides_append_and_overwrite(self):
-        from rock.sdk.bench.models.trial.config import RockEnvironmentConfig
-        from rock.sdk.job.config import BashJobConfig
-
-        top = self._setup()
-        config = BashJobConfig(
-            script="echo hi",
-            environment=RockEnvironmentConfig(env={"FOO": "old", "KEEP": "1"}),
-        )
-        ns = top.parse_args(
-            [
-                "job",
-                "run",
-                "--job_config",
-                "unused.yaml",
-                "--env",
-                "FOO=new",
-                "--env",
-                "NEW=2",
-            ]
-        )
-        JobCommand()._apply_overrides(config, ns)
-
-        assert config.environment.env == {"FOO": "new", "KEEP": "1", "NEW": "2"}
-
-    def test_uploads_appended(self):
-        from rock.sdk.bench.models.trial.config import RockEnvironmentConfig
-        from rock.sdk.job.config import BashJobConfig
-
-        top = self._setup()
-        config = BashJobConfig(
-            script="echo hi",
-            environment=RockEnvironmentConfig(uploads=[("/a", "/b")]),
-        )
-        ns = top.parse_args(
-            [
-                "job",
-                "run",
-                "--job_config",
-                "unused.yaml",
-                "--local-path",
-                "/src",
-                "--target-path",
-                "/dst",
-            ]
-        )
-        JobCommand()._apply_overrides(config, ns)
-
-        assert config.environment.uploads == [("/a", "/b"), ("/src", "/dst")]
-
-    def test_parser_timeout_default_is_none(self):
-        """--timeout should default to None so YAML timeout is not unconditionally overridden."""
-        top = self._setup()
-        ns = top.parse_args(["job", "run", "--script", "run.sh"])
-        assert ns.timeout is None
-
-    def test_parser_description_mentions_two_modes(self):
-        self._setup()  # populates JobCommand._run_parser
-        desc = JobCommand._run_parser.description or ""
-        assert "YAML mode" in desc
-        assert "flags mode" in desc
-
-    def test_no_overrides_leaves_config_untouched(self):
-        from rock.sdk.bench.models.trial.config import RockEnvironmentConfig
-        from rock.sdk.job.config import BashJobConfig
-
-        top = self._setup()
-        config = BashJobConfig(
-            script="echo hi",
-            environment=RockEnvironmentConfig(image="python:3.10", env={"X": "1"}),
-            timeout=1234,
-        )
-        ns = top.parse_args(["job", "run", "--job_config", "unused.yaml"])
-        # Force timeout to None so this test is robust regardless of the parser's
-        # current default (Task 11 flips it to None permanently).
-        ns.timeout = None
-        JobCommand()._apply_overrides(config, ns)
-
-        assert config.environment.image == "python:3.10"
-        assert config.environment.env == {"X": "1"}
-        assert config.timeout == 1234
-
-
-class TestJobRunEndToEnd:
-    """End-to-end-ish tests for _job_run, mocking only Job.run."""
-
-    def _setup(self):
-        JobCommand._run_parser = None
-        top = argparse.ArgumentParser(prog="rock")
-        subparsers = top.add_subparsers(dest="command")
-        asyncio.run(JobCommand.add_parser_to(subparsers))
-        return top
-
-    def test_flags_mode_builds_bash_config_and_runs_job(self, monkeypatch):
-        """A --script invocation should produce a BashJobConfig and call Job(config).run()."""
-        from unittest.mock import MagicMock
-
+class TestRunEndToEnd:
+    def test_flags_mode_builds_bash_config_and_uses_unified_handler(self, monkeypatch):
         from rock.sdk.job.config import BashJobConfig
 
         captured = {}
 
-        class FakeJob:
-            def __init__(self, cfg):
+        class FakeHandler:
+            def __init__(self, **kwargs):
+                captured["kwargs"] = kwargs
+
+            async def run(self, cfg):
                 captured["cfg"] = cfg
+                return type("R", (), {"failed": 0, "run_id": "run-1"})()
 
-            async def run(self):
-                result = MagicMock()
-                result.status = "COMPLETED"
-                result.trial_results = []
-                return result
+        monkeypatch.setattr("rock.cli.job_run.UnifiedJobRunHandler", FakeHandler)
 
-        monkeypatch.setattr("rock.sdk.job.Job", FakeJob)
-
-        top = self._setup()
-        ns = top.parse_args(
-            [
-                "job",
-                "run",
-                "--script",
-                "run.sh",
-                "--image",
-                "python:3.11",
-                "--env",
-                "A=1",
-            ]
-        )
+        parser = _build_parser()
+        ns = parser.parse_args(["job", "run", "--script-content", "echo hi", "--task", "task-1"])
         asyncio.run(JobCommand().arun(ns))
 
-        cfg = captured["cfg"]
-        assert isinstance(cfg, BashJobConfig)
-        assert cfg.script_path == "run.sh"
-        assert cfg.environment.image == "python:3.11"
-        assert cfg.environment.env == {"A": "1"}
+        assert isinstance(captured["cfg"], BashJobConfig)
+        assert captured["kwargs"]["mode"] == "single"
+        assert captured["kwargs"]["task_ids"] == ["task-1"]
 
-    def test_yaml_mode_with_override_image(self, monkeypatch, tmp_path):
-        from unittest.mock import MagicMock
 
-        from rock.sdk.job.config import BashJobConfig
+class TestRunQueries:
+    def test_runs_prints_run_meta(self, monkeypatch, capsys):
+        from rock.sdk.job.meta import RunMeta, RunScoreSummary
 
-        yaml_path = tmp_path / "bash.yaml"
-        yaml_path.write_text("script_path: ./run.sh\nenvironment:\n  image: python:3.10\n")
+        viewer = MagicMock()
+        viewer.list_runs.return_value = [
+            RunMeta(
+                run_id="run-1",
+                mode="full",
+                dataset="org/ds",
+                split="test",
+                total_tasks=2,
+                pending_tasks=0,
+                status="completed",
+                summary=RunScoreSummary(completed=2, failed=0, skipped=0, avg_score=1.0, total_score=2.0, pass_rate=1.0),
+            )
+        ]
+        monkeypatch.setattr(JobCommand, "_build_viewer_from_locator", lambda self, args: viewer)
+        parser = _build_parser()
+        ns = parser.parse_args(["job", "runs", "--job-config", "foo.yaml"])
 
-        captured = {}
-
-        class FakeJob:
-            def __init__(self, cfg):
-                captured["cfg"] = cfg
-
-            async def run(self):
-                r = MagicMock()
-                r.status = "COMPLETED"
-                r.trial_results = []
-                return r
-
-        monkeypatch.setattr("rock.sdk.job.Job", FakeJob)
-
-        top = self._setup()
-        ns = top.parse_args(
-            [
-                "job",
-                "run",
-                "--job_config",
-                str(yaml_path),
-                "--image",
-                "python:3.12",
-            ]
-        )
         asyncio.run(JobCommand().arun(ns))
 
-        cfg = captured["cfg"]
-        assert isinstance(cfg, BashJobConfig)
-        assert cfg.script_path == "./run.sh"
-        assert cfg.environment.image == "python:3.12"  # override applied
-
-
-class TestYamlSourceOfTruth:
-    """Regression: YAML-loaded fields (base_url, cluster) must survive when the
-    user doesn't pass the corresponding CLI flag, even though main.py would
-    otherwise backfill args.base_url from the ~/.rock/config.ini default.
-    """
-
-    def _setup(self):
-        JobCommand._run_parser = None
-        top = argparse.ArgumentParser(prog="rock")
-        # Mirror the top-level flags declared in rock/cli/main.py so we can
-        # drive load_config_from_file() as main.py does.
-        top.add_argument("--config")
-        top.add_argument("--base-url")
-        top.add_argument("--auth-token")
-        top.add_argument("--cluster")
-        top.add_argument("--extra-header", action="append", dest="extra_headers_list")
-        subparsers = top.add_subparsers(dest="command")
-        asyncio.run(JobCommand.add_parser_to(subparsers))
-        return top
-
-    def test_load_config_from_file_skips_backfill_for_job(self, tmp_path, monkeypatch):
-        """load_config_from_file must NOT backfill base_url/cluster/auth_token
-        when the command is `job` — the YAML is the source of truth.
-        """
-        from rock.cli import main as main_mod
-
-        top = self._setup()
-        ns = top.parse_args(["job", "run", "--job_config", "unused.yaml"])
-        # Pretend the INI file would return http://ini.example.com as base_url
-        fake_cli_config = type(
-            "CLI", (), {"base_url": "http://ini.example.com", "extra_headers": {"cluster": "ini-cluster"}}
-        )()
-        monkeypatch.setattr(
-            main_mod, "ConfigManager", lambda _path: type("M", (), {"get_config": lambda self: fake_cli_config})()
-        )
-
-        main_mod.load_config_from_file(ns)
-
-        # Backfill should have been skipped for `job`
-        assert ns.base_url is None
-        assert ns.cluster is None
-        assert ns.auth_token is None
-
-    def test_load_config_from_file_backfills_for_non_job(self, tmp_path, monkeypatch):
-        """Non-job commands still get the backfill behavior."""
-        from rock.cli import main as main_mod
-
-        # Build a parser with a non-job subcommand
-        top = argparse.ArgumentParser(prog="rock")
-        top.add_argument("--config")
-        top.add_argument("--base-url")
-        top.add_argument("--auth-token")
-        top.add_argument("--cluster")
-        top.add_argument("--extra-header", action="append", dest="extra_headers_list")
-        subparsers = top.add_subparsers(dest="command")
-        subparsers.add_parser("sandbox")
-        ns = top.parse_args(["sandbox"])
-
-        fake_cli_config = type(
-            "CLI", (), {"base_url": "http://ini.example.com", "extra_headers": {"cluster": "ini-cluster"}}
-        )()
-        monkeypatch.setattr(
-            main_mod, "ConfigManager", lambda _path: type("M", (), {"get_config": lambda self: fake_cli_config})()
-        )
-
-        main_mod.load_config_from_file(ns)
-
-        assert ns.base_url == "http://ini.example.com"
-        assert ns.cluster == "ini-cluster"
-
-    def test_yaml_base_url_overridden_when_user_passes_flag(self, tmp_path, monkeypatch):
-        """When user explicitly passes --base-url, it should override YAML."""
-        from unittest.mock import MagicMock
-
-        yaml_path = tmp_path / "bash.yaml"
-        yaml_path.write_text("script_path: ./run.sh\nenvironment:\n  base_url: http://xrl.alibaba-inc.com\n")
-
-        captured = {}
-
-        class FakeJob:
-            def __init__(self, cfg):
-                captured["cfg"] = cfg
-
-            async def run(self):
-                r = MagicMock()
-                r.status = "COMPLETED"
-                r.trial_results = []
-                return r
-
-        monkeypatch.setattr("rock.sdk.job.Job", FakeJob)
-
-        top = self._setup()
-        ns = top.parse_args(
-            [
-                "job",
-                "run",
-                "--job_config",
-                str(yaml_path),
-                "--base-url",
-                "http://explicit.example.com",
-            ]
-        )
-        asyncio.run(JobCommand().arun(ns))
-
-        cfg = captured["cfg"]
-        assert cfg.environment.base_url == "http://explicit.example.com"
-
-
-class TestArun:
-    """Tests for JobCommand.arun dispatch (not _job_run)."""
-
-    def test_unknown_job_command_logs_error(self):
-        from unittest.mock import patch
-
-        ns = argparse.Namespace(job_command="weird")
-        with patch("rock.cli.command.job.logger") as mock_logger:
-            asyncio.run(JobCommand().arun(ns))
-            mock_logger.error.assert_called()
-
-
-class TestHelpOutput:
-    def test_help_output_mentions_both_modes(self, capsys):
-        top = argparse.ArgumentParser(prog="rock")
-        subparsers = top.add_subparsers(dest="command")
-        asyncio.run(JobCommand.add_parser_to(subparsers))
-
-        with pytest.raises(SystemExit) as excinfo:
-            top.parse_args(["job", "run", "--help"])
-
-        assert excinfo.value.code == 0
         out = capsys.readouterr().out
-        assert "YAML mode" in out
-        assert "flags mode" in out
-        assert "--job_config" in out
-        assert "--script" in out
+        assert "run-1" in out
+        assert "full" in out
+        assert "org/ds" in out
+
+    def test_status_prints_jobs(self, monkeypatch, capsys):
+        from rock.sdk.job.meta import RunJobStatus, RunMeta
+
+        viewer = MagicMock()
+
+        class FakeRepo:
+            def __init__(self, _viewer):
+                pass
+
+            def get(self, run_id):
+                return RunMeta(run_id=run_id, mode="multi", status="partial", total_tasks=1, pending_tasks=0)
+
+            def get_run_job_statuses(self, run_id):
+                return [RunJobStatus(task_id="t1", job_name="j1", status="completed", score=1.0)]
+
+        monkeypatch.setattr(JobCommand, "_build_viewer_from_locator", lambda self, args: viewer)
+        monkeypatch.setattr("rock.sdk.job.run_meta.RunMetaRepository", FakeRepo)
+        parser = _build_parser()
+        ns = parser.parse_args(["job", "status", "--run-id", "run-1", "--job-config", "foo.yaml", "--jobs"])
+
+        asyncio.run(JobCommand().arun(ns))
+
+        out = capsys.readouterr().out
+        assert "Run: run-1" in out
+        assert "t1" in out
+        assert "completed" in out

--- a/tests/unit/cli/test_job_run.py
+++ b/tests/unit/cli/test_job_run.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import json
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from rock.sdk.bench.models.job.config import HarborJobConfig, OssRegistryInfo, RegistryDatasetConfig
+from rock.sdk.envhub.config import OssMirrorConfig
+from rock.sdk.envhub.datasets.models import DatasetSpec
+from rock.sdk.job.config import BashJobConfig
+from rock.sdk.job.meta import RunScoreSummary
+from rock.sdk.job.result import ExceptionInfo, TrialResult
+
+
+def test_resolve_task_ids_filters_full_dataset_with_limit(monkeypatch):
+    from rock.cli.job_run import resolve_task_ids
+
+    client = MagicMock()
+    client.list_dataset_tasks.return_value = DatasetSpec(id="alibaba/bench", split="test", task_ids=["t1", "t2", "t3"])
+    monkeypatch.setattr("rock.cli.job_run.DatasetClient", lambda registry: client)
+    config = HarborJobConfig(
+        experiment_id="exp",
+        datasets=[RegistryDatasetConfig(name="alibaba/bench", registry=OssRegistryInfo(split="test"))],
+    )
+
+    mode, ref, tasks = resolve_task_ids(
+        config,
+        task=None,
+        tasks=None,
+        all_tasks=True,
+        org=None,
+        dataset=None,
+        split=None,
+        limit=2,
+    )
+
+    assert mode == "full"
+    assert ref.full_name == "alibaba/bench"
+    assert tasks == ["t1", "t2"]
+
+
+def test_resolve_task_ids_supports_bash_task_from_environment():
+    from rock.cli.job_run import resolve_task_ids
+
+    config = BashJobConfig(script="echo hi", environment={"env": {"TASK": "task-1"}})
+
+    mode, _ref, tasks = resolve_task_ids(
+        config,
+        task=None,
+        tasks=None,
+        all_tasks=False,
+        org=None,
+        dataset=None,
+        split=None,
+        limit=None,
+    )
+
+    assert mode == "single"
+    assert tasks == ["task-1"]
+
+
+def test_sync_namespace_uses_oss_mirror_namespace_when_cli_namespace_is_omitted():
+    from rock.cli.job_run import sync_namespace
+
+    config = BashJobConfig(
+        script="echo hi",
+        environment={"oss_mirror": OssMirrorConfig(enabled=True, namespace="ns", oss_bucket="b", oss_endpoint="e")},
+    )
+
+    sync_namespace(config, None)
+
+    assert config.namespace == "ns"
+    assert config.environment.oss_mirror.namespace == "ns"
+
+
+def test_build_run_summary_from_trial_results():
+    from rock.cli.job_run import build_run_summary
+
+    summary = build_run_summary(
+        task_ids=["t1", "t2"],
+        trial_results=[
+            TrialResult(task_name="t1"),
+            TrialResult(task_name="t2", exception_info=ExceptionInfo(exception_type="Error")),
+        ],
+    )
+
+    assert summary.completed == 1
+    assert summary.failed == 1
+    assert summary.pass_rate == pytest.approx(0.5)
+
+
+def test_jsonl_progress_reporter_emits_json_lines():
+    from rock.cli.job_run import JsonlProgressReporter
+
+    stream = StringIO()
+    reporter = JsonlProgressReporter(stream)
+
+    reporter.emit({"type": "run_started", "run_id": "run-1"})
+    reporter.emit({"type": "summary", "summary": RunScoreSummary(completed=1, failed=0, skipped=0, avg_score=1.0, total_score=1.0, pass_rate=1.0).model_dump()})
+
+    lines = [json.loads(line) for line in stream.getvalue().splitlines()]
+    assert lines[0] == {"type": "run_started", "run_id": "run-1"}
+    assert lines[1]["type"] == "summary"
+
+
+async def test_unified_handler_writes_run_meta_and_runs_each_task():
+    from rock.cli.job_run import DatasetRef, NullProgressReporter, UnifiedJobRunHandler
+    from rock.sdk.job.planner import PlannedJob
+
+    writes = []
+
+    class FakeRunRepo:
+        def write(self, meta):
+            writes.append(meta.model_copy(deep=True))
+
+    class FakeExecutor:
+        _max_concurrent = 1
+
+        async def run_job(self, job, callbacks=None):
+            client = SimpleNamespace(sandbox=SimpleNamespace(sandbox_id="sb"), session="s", pid=1)
+            if callbacks:
+                callbacks.on_started(client)
+            result = TrialResult(task_name=job.task_id)
+            if callbacks:
+                callbacks.on_done(client, result)
+            return result
+
+    config = BashJobConfig(job_name="job", script="echo hi")
+    result = await UnifiedJobRunHandler(
+        mode="multi",
+        task_ids=["t1", "t2"],
+        dataset_ref=DatasetRef(org=None, dataset=None, split=None),
+        run_id="run-1",
+        run_meta_repo=FakeRunRepo(),
+        job_meta_repo=None,
+        executor=FakeExecutor(),
+        progress=NullProgressReporter(),
+    ).run(config)
+
+    assert result.failed == 0
+    assert writes[0].status == "planning"
+    assert writes[-1].status == "completed"
+    assert writes[-1].task_job_map == {"t1": "job_t1_run-1", "t2": "job_t2_run-1"}
+
+
+async def test_unified_handler_resume_recovers_running_job_meta_before_new_sandbox():
+    from rock.cli.job_run import DatasetRef, NullProgressReporter, UnifiedJobRunHandler
+    from rock.sdk.job.meta import JobMeta, RunMeta
+
+    existing = JobMeta(
+        job_name="old-job",
+        run_id="run-1",
+        task_id="t1",
+        status="running",
+        sandbox_id="sb-1",
+        session="session-1",
+        pid=42,
+    )
+
+    class FakeRunRepo:
+        def write(self, meta):
+            pass
+
+    class FakeJobRepo:
+        def get(self, job_name):
+            assert job_name == "old-job"
+            return existing
+
+        def write(self, meta):
+            pass
+
+        def update_status(self, *args, **kwargs):
+            raise AssertionError("recoverable job should not be marked unrecoverable")
+
+    class FakeExecutor:
+        _max_concurrent = 1
+
+        async def run_job(self, job, callbacks=None):
+            raise AssertionError("recoverable job should not start a new sandbox")
+
+        async def wait_existing_job(self, job, meta):
+            assert job.job_name == "old-job"
+            assert meta is existing
+            return TrialResult(task_name="t1")
+
+    result = await UnifiedJobRunHandler(
+        mode="single",
+        task_ids=["t1"],
+        dataset_ref=DatasetRef(org=None, dataset=None, split=None),
+        run_id="run-1",
+        run_meta_repo=FakeRunRepo(),
+        job_meta_repo=FakeJobRepo(),
+        executor=FakeExecutor(),
+        progress=NullProgressReporter(),
+        resumed=True,
+        base_run_meta=RunMeta(
+            run_id="run-1",
+            mode="single",
+            status="running",
+            total_tasks=1,
+            pending_tasks=1,
+            task_job_map={"t1": "old-job"},
+        ),
+    ).run(BashJobConfig(job_name="job", script="echo hi"))
+
+    assert result.failed == 0

--- a/tests/unit/cli/test_job_run.py
+++ b/tests/unit/cli/test_job_run.py
@@ -146,6 +146,39 @@ async def test_unified_handler_writes_run_meta_and_runs_each_task():
     assert writes[-1].task_job_map == {"t1": "job_t1_run-1", "t2": "job_t2_run-1"}
 
 
+async def test_unified_handler_preserves_yaml_job_name_for_single_task():
+    from rock.cli.job_run import DatasetRef, NullProgressReporter, UnifiedJobRunHandler
+
+    seen_job_names = []
+
+    class FakeExecutor:
+        _max_concurrent = 1
+
+        async def run_job(self, job, callbacks=None):
+            seen_job_names.append(job.job_name)
+            client = SimpleNamespace(sandbox=SimpleNamespace(sandbox_id="sb"), session="s", pid=1)
+            if callbacks:
+                callbacks.on_started(client)
+            result = TrialResult(task_name=job.task_id)
+            if callbacks:
+                callbacks.on_done(client, result)
+            return result
+
+    result = await UnifiedJobRunHandler(
+        mode="single",
+        task_ids=["t1"],
+        dataset_ref=DatasetRef(org=None, dataset=None, split=None),
+        run_id="run-1",
+        run_meta_repo=None,
+        job_meta_repo=None,
+        executor=FakeExecutor(),
+        progress=NullProgressReporter(),
+    ).run(BashJobConfig(job_name="yaml-job", script="echo hi"))
+
+    assert result.failed == 0
+    assert seen_job_names == ["yaml-job"]
+
+
 async def test_unified_handler_resume_recovers_running_job_meta_before_new_sandbox():
     from rock.cli.job_run import DatasetRef, NullProgressReporter, UnifiedJobRunHandler
     from rock.sdk.job.meta import JobMeta, RunMeta

--- a/tests/unit/sdk/job/test_executor_concurrent.py
+++ b/tests/unit/sdk/job/test_executor_concurrent.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from rock.sdk.job.executor import JobExecutor
+from rock.sdk.job.planner import PlannedJob
+from rock.sdk.job.result import TrialResult
+
+
+class DummyTrial:
+    def __init__(self, name: str):
+        self._config = SimpleNamespace(job_name=name, labels={"rock_task_id": name})
+
+
+class TestJobExecutorRunTrials:
+    async def test_run_trials_respects_max_concurrent_for_submit_and_wait_lifecycle(self):
+        executor = JobExecutor(max_concurrent=2)
+        active = 0
+        max_active = 0
+
+        async def fake_submit(trial):
+            nonlocal active, max_active
+            active += 1
+            max_active = max(max_active, active)
+            await asyncio.sleep(0.01)
+            return SimpleNamespace(trial=trial)
+
+        async def fake_wait(client):
+            nonlocal active
+            await asyncio.sleep(0.01)
+            active -= 1
+            return TrialResult(task_name=client.trial._config.job_name)
+
+        executor._do_submit = fake_submit
+        executor._do_wait = fake_wait
+
+        results = await executor.run_trials([DummyTrial(f"t{i}") for i in range(5)])
+
+        assert [r.task_name for r in results] == ["t0", "t1", "t2", "t3", "t4"]
+        assert max_active <= 2
+
+    async def test_run_trials_converts_lifecycle_exception_to_failed_trial_result(self):
+        executor = JobExecutor(max_concurrent=1)
+        trial = DummyTrial("task-1")
+
+        async def fake_submit(_trial):
+            raise RuntimeError("sandbox boom")
+
+        executor._do_submit = fake_submit
+
+        results = await executor.run_trials([trial])
+
+        assert len(results) == 1
+        assert results[0].task_name == "task-1"
+        assert results[0].status == "failed"
+        assert results[0].exception_info.exception_type == "RuntimeError"
+        assert "sandbox boom" in results[0].exception_info.exception_message
+
+
+class TestJobExecutorRunJob:
+    async def test_run_job_calls_done_callback_when_wait_fails_after_start(self):
+        executor = JobExecutor()
+        trial = DummyTrial("task-1")
+        client = SimpleNamespace(trial=trial, sandbox=SimpleNamespace(sandbox_id="sb-1"), session="s", pid=1)
+        done_results = []
+
+        async def fake_submit(_trial):
+            return client
+
+        async def fake_wait(_client):
+            raise RuntimeError("No trial results found")
+
+        class Callbacks:
+            def on_started(self, _client):
+                pass
+
+            def on_done(self, _client, result):
+                done_results.append(result)
+
+        executor._do_submit = fake_submit
+        executor._do_wait = fake_wait
+
+        result = await executor.run_job(
+            PlannedJob(task_id="task-1", job_name="job-1", config=SimpleNamespace(), trial=trial),
+            callbacks=Callbacks(),
+        )
+
+        assert result.status == "failed"
+        assert result.exception_info.exception_message == "No trial results found"
+        assert len(done_results) == 1
+        assert done_results[0].status == "failed"

--- a/tests/unit/sdk/job/test_meta.py
+++ b/tests/unit/sdk/job/test_meta.py
@@ -71,6 +71,17 @@ class TestJobMeta:
 # ---------------------------------------------------------------------------
 
 
+class TestMetaModuleDocstring:
+    def test_docstring_does_not_claim_harbor_writes_meta(self):
+        """P1-3: meta.py docstring must not claim Harbor writes rock_meta.json."""
+        import rock.sdk.job.meta as meta_module
+
+        docstring = meta_module.__doc__ or ""
+        assert "Both Harbor and Bash" not in docstring, (
+            "docstring incorrectly claims both job types write rock_meta.json"
+        )
+
+
 class TestRenderMetaJson:
     def test_bash_running(self):
         from rock.sdk.job.config import BashJobConfig
@@ -205,6 +216,96 @@ class TestBashTrialMetaIntegration:
         trial = BashTrial(config)
         script = trial.build()
         assert "rock_meta.json" not in script
+
+    def test_epilogue_heredoc_is_quoted(self):
+        """P1-1: epilogue heredoc must use single-quoted delimiter to prevent
+        shell expansion of $() in config values."""
+        from rock.sdk.job.trial.bash import BashTrial
+
+        config = self._build_bash_config()
+        trial = BashTrial(config)
+        trial._ossutil_ready = True
+        script = trial.build()
+        # Both prologue and epilogue heredocs must be single-quoted
+        meta_writes = [line for line in script.splitlines() if "rock_meta.json" in line and "cat >" in line]
+        for line in meta_writes:
+            assert "'__ROCK_META_EOF__'" in line or "<<" not in line, (
+                f"heredoc delimiter must be single-quoted to prevent shell expansion: {line}"
+            )
+
+    def test_epilogue_no_shell_variable_expansion_in_heredoc(self):
+        """P1-1: config fields with $() must not be shell-executed."""
+        from rock.sdk.job.trial.bash import BashTrial
+
+        config = self._build_bash_config()
+        config.job_name = "safe-job"
+        trial = BashTrial(config)
+        trial._ossutil_ready = True
+        script = trial.build()
+        # The epilogue heredoc body should NOT contain raw $-prefixed
+        # values from config (those should go through sed placeholders)
+        heredoc_sections = script.split("__ROCK_META_EOF__")
+        for section in heredoc_sections:
+            if '"status":' in section and '"exit_code":' in section:
+                # This is an epilogue heredoc body — must not have
+                # unquoted shell vars like $_rock_status directly
+                assert "$_rock_status" not in section, (
+                    "epilogue heredoc body must use placeholders, not raw shell variables"
+                )
+
+    def test_prologue_no_sed_null_replacement(self):
+        """P1-2: prologue must not use sed to replace 'null' — it produces
+        invalid JSON and can match null in other fields."""
+        from rock.sdk.job.trial.bash import BashTrial
+
+        config = self._build_bash_config()
+        trial = BashTrial(config)
+        trial._ossutil_ready = True
+        script = trial.build()
+        assert 's/null/' not in script, "must not use sed to replace literal 'null'"
+
+    def test_meta_produces_valid_json_after_sed(self):
+        """P1-2: heredoc body + sed substitution must produce valid JSON
+        (no unquoted time strings, no bare null replacement)."""
+        import re
+
+        from rock.sdk.job.trial.bash import BashTrial
+
+        config = self._build_bash_config()
+        trial = BashTrial(config)
+        trial._ossutil_ready = True
+        script = trial.build()
+        heredoc_bodies = re.findall(
+            r"<< *'__ROCK_META_EOF__'\n(.*?)__ROCK_META_EOF__", script, re.DOTALL
+        )
+        assert len(heredoc_bodies) >= 2, "should have at least prologue + epilogue heredocs"
+        for body in heredoc_bodies:
+            # Simulate sed: replace placeholders with realistic values
+            simulated = (
+                body.replace("__ROCK_STATUS__", "completed")
+                .replace("__ROCK_STARTED__", "2024-01-01T10:00:00Z")
+                .replace("__ROCK_FINISHED__", "2024-01-01T12:00:00Z")
+                .replace("__ROCK_EXIT_CODE__", "0")
+            )
+            data = json.loads(simulated)
+            assert data["schema_version"] == "1"
+            assert data["job_type"] == "bash"
+
+    def test_epilogue_uses_sed_for_runtime_values(self):
+        """P1-1/P1-2 fix: runtime values (status, timestamps, exit_code)
+        must be injected via sed after a quoted heredoc, not inside it."""
+        from rock.sdk.job.trial.bash import BashTrial
+
+        config = self._build_bash_config()
+        trial = BashTrial(config)
+        trial._ossutil_ready = True
+        script = trial.build()
+        # The script should contain sed commands that replace placeholders
+        assert "__ROCK_STATUS__" in script
+        assert "__ROCK_STARTED__" in script
+        assert "__ROCK_FINISHED__" in script
+        assert "__ROCK_EXIT_CODE__" in script
+        assert "sed" in script
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/sdk/job/test_meta.py
+++ b/tests/unit/sdk/job/test_meta.py
@@ -1,0 +1,329 @@
+"""Tests for rock.sdk.job.meta — JobMeta model, render_meta_json, and trial integration.
+
+TDD: written first (RED), then implementation (GREEN).
+"""
+
+from __future__ import annotations
+
+import json
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import oss2
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: Model tests
+# ---------------------------------------------------------------------------
+
+
+class TestJobMeta:
+    def test_defaults(self):
+        from rock.sdk.job.meta import JobMeta
+
+        m = JobMeta()
+        assert m.schema_version == "1"
+        assert m.job_name == ""
+        assert m.job_type == ""
+        assert m.status == ""
+        assert m.namespace is None
+        assert m.experiment_id is None
+        assert m.user_id is None
+        assert m.image is None
+        assert m.labels == {}
+        assert m.started_at is None
+        assert m.finished_at is None
+        assert m.exit_code is None
+
+    def test_with_values(self):
+        from rock.sdk.job.meta import JobMeta
+
+        m = JobMeta(
+            job_name="swe-bench_abc",
+            job_type="harbor",
+            status="completed",
+            namespace="ns",
+            experiment_id="exp",
+            user_id="alice",
+            image="python:3.11",
+            labels={"env": "test"},
+            started_at="2024-01-01T10:00:00Z",
+            finished_at="2024-01-01T12:00:00Z",
+            exit_code=0,
+        )
+        assert m.job_type == "harbor"
+        assert m.status == "completed"
+        assert m.exit_code == 0
+
+    def test_serialization_roundtrip(self):
+        from rock.sdk.job.meta import JobMeta
+
+        m = JobMeta(job_name="test", job_type="bash", status="failed", exit_code=1)
+        data = json.loads(m.model_dump_json())
+        m2 = JobMeta.model_validate(data)
+        assert m2.job_name == "test"
+        assert m2.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: render_meta_json tests
+# ---------------------------------------------------------------------------
+
+
+class TestRenderMetaJson:
+    def test_bash_running(self):
+        from rock.sdk.job.config import BashJobConfig
+        from rock.sdk.job.meta import render_meta_json
+
+        config = BashJobConfig(job_name="job1", namespace="ns", experiment_id="exp")
+        text = render_meta_json(config, job_type="bash", status="running")
+        data = json.loads(text)
+        assert data["job_name"] == "job1"
+        assert data["job_type"] == "bash"
+        assert data["status"] == "running"
+        assert data["namespace"] == "ns"
+        assert data["experiment_id"] == "exp"
+
+    def test_harbor_running(self):
+        from rock.sdk.bench.models.job.config import HarborJobConfig
+        from rock.sdk.job.meta import render_meta_json
+
+        config = HarborJobConfig(
+            job_name="harbor-job",
+            namespace="ns",
+            experiment_id="exp",
+        )
+        text = render_meta_json(config, job_type="harbor", status="running")
+        data = json.loads(text)
+        assert data["job_type"] == "harbor"
+
+    def test_includes_user_id(self):
+        from rock.sdk.job.config import BashJobConfig
+        from rock.sdk.job.meta import render_meta_json
+
+        config = BashJobConfig(job_name="j")
+        config.environment.user_id = "bob"
+        text = render_meta_json(config, job_type="bash", status="running")
+        data = json.loads(text)
+        assert data["user_id"] == "bob"
+
+    def test_includes_labels(self):
+        from rock.sdk.job.config import BashJobConfig
+        from rock.sdk.job.meta import render_meta_json
+
+        config = BashJobConfig(job_name="j", labels={"team": "ml", "env": "prod"})
+        text = render_meta_json(config, job_type="bash", status="running")
+        data = json.loads(text)
+        assert data["labels"] == {"team": "ml", "env": "prod"}
+
+    def test_includes_image(self):
+        from rock.sdk.job.config import BashJobConfig
+        from rock.sdk.job.meta import render_meta_json
+
+        config = BashJobConfig(job_name="j")
+        config.environment.image = "ubuntu:22.04"
+        text = render_meta_json(config, job_type="bash", status="running")
+        data = json.loads(text)
+        assert data["image"] == "ubuntu:22.04"
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: BashTrial meta integration
+# ---------------------------------------------------------------------------
+
+
+class TestBashTrialMetaIntegration:
+    def _build_bash_config(self):
+        from rock.sdk.bench.models.trial.config import RockEnvironmentConfig
+        from rock.sdk.envhub.config import OssMirrorConfig
+        from rock.sdk.job.config import BashJobConfig
+
+        return BashJobConfig(
+            job_name="bash-job-1",
+            namespace="ns",
+            experiment_id="exp",
+            script="echo hello",
+            environment=RockEnvironmentConfig(
+                oss_mirror=OssMirrorConfig(
+                    enabled=True,
+                    oss_bucket="bucket",
+                    oss_access_key_id="ak",
+                    oss_access_key_secret="sk",
+                    oss_endpoint="https://oss.example.com",
+                    oss_region="cn-hangzhou",
+                    namespace="ns",
+                    experiment_id="exp",
+                ),
+            ),
+        )
+
+    def test_wrapper_contains_meta_prologue(self):
+        from rock.sdk.job.trial.bash import BashTrial
+
+        config = self._build_bash_config()
+        trial = BashTrial(config)
+        trial._ossutil_ready = True
+        script = trial.build()
+        assert "rock_meta.json" in script
+        assert '"status": "running"' in script
+
+    def test_wrapper_contains_meta_epilogue(self):
+        from rock.sdk.job.trial.bash import BashTrial
+
+        config = self._build_bash_config()
+        trial = BashTrial(config)
+        trial._ossutil_ready = True
+        script = trial.build()
+        assert "_rock_status" in script
+        parts = script.split("rock_meta.json")
+        assert len(parts) >= 3, "rock_meta.json should appear at least twice (prologue + epilogue)"
+
+    def test_meta_contains_job_name(self):
+        from rock.sdk.job.trial.bash import BashTrial
+
+        config = self._build_bash_config()
+        trial = BashTrial(config)
+        trial._ossutil_ready = True
+        script = trial.build()
+        assert '"job_name": "bash-job-1"' in script
+
+    def test_meta_contains_job_type_bash(self):
+        from rock.sdk.job.trial.bash import BashTrial
+
+        config = self._build_bash_config()
+        trial = BashTrial(config)
+        trial._ossutil_ready = True
+        script = trial.build()
+        assert '"job_type": "bash"' in script
+
+    def test_no_meta_when_mirror_disabled(self):
+        from rock.sdk.job.config import BashJobConfig
+        from rock.sdk.job.trial.bash import BashTrial
+
+        config = BashJobConfig(job_name="j", script="echo hi")
+        trial = BashTrial(config)
+        script = trial.build()
+        assert "rock_meta.json" not in script
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: HarborTrial meta integration
+# ---------------------------------------------------------------------------
+
+
+class TestHarborTrialMetaIntegration:
+    def _build_harbor_config(self):
+        from rock.sdk.bench.models.trial.config import RockEnvironmentConfig
+        from rock.sdk.envhub.config import OssMirrorConfig
+        from rock.sdk.bench.models.job.config import HarborJobConfig
+
+        return HarborJobConfig(
+            job_name="harbor-job-1",
+            namespace="ns",
+            experiment_id="exp",
+            environment=RockEnvironmentConfig(
+                oss_mirror=OssMirrorConfig(
+                    enabled=True,
+                    oss_bucket="bucket",
+                    oss_access_key_id="ak",
+                    oss_access_key_secret="sk",
+                    oss_endpoint="https://oss.example.com",
+                    oss_region="cn-hangzhou",
+                    namespace="ns",
+                    experiment_id="exp",
+                ),
+            ),
+        )
+
+    def test_script_contains_meta_prologue(self):
+        from rock.sdk.job.trial.harbor import HarborTrial
+
+        config = self._build_harbor_config()
+        trial = HarborTrial(config)
+        script = trial.build()
+        assert "rock_meta.json" in script
+        assert '"status": "running"' in script
+
+    def test_script_contains_meta_epilogue(self):
+        from rock.sdk.job.trial.harbor import HarborTrial
+
+        config = self._build_harbor_config()
+        trial = HarborTrial(config)
+        script = trial.build()
+        assert "_rock_status" in script
+
+    def test_meta_contains_job_type_harbor(self):
+        from rock.sdk.job.trial.harbor import HarborTrial
+
+        config = self._build_harbor_config()
+        trial = HarborTrial(config)
+        script = trial.build()
+        assert '"job_type": "harbor"' in script
+
+    def test_no_meta_when_mirror_disabled(self):
+        from rock.sdk.bench.models.job.config import HarborJobConfig
+
+        config = HarborJobConfig(job_name="j", namespace="ns", experiment_id="exp")
+        from rock.sdk.job.trial.harbor import HarborTrial
+
+        trial = HarborTrial(config)
+        script = trial.build()
+        assert "rock_meta.json" not in script
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: JobViewer read meta
+# ---------------------------------------------------------------------------
+
+
+def _make_oss_object(data: bytes):
+    obj = BytesIO(data)
+    return obj
+
+
+class TestJobViewerReadMeta:
+    @pytest.fixture
+    def viewer(self):
+        from rock.sdk.job.viewer import JobViewer
+
+        bucket = MagicMock()
+        return JobViewer(bucket, namespace="ns", experiment_id="exp"), bucket
+
+    def test_get_job_meta_found(self, viewer):
+        from rock.sdk.job.meta import JobMeta
+
+        v, bucket = viewer
+        meta_json = JobMeta(
+            job_name="j1", job_type="bash", status="completed", exit_code=0
+        ).model_dump_json()
+        bucket.get_object.return_value = _make_oss_object(meta_json.encode())
+        meta = v.get_job_meta("j1")
+        assert meta is not None
+        assert meta.job_name == "j1"
+        assert meta.status == "completed"
+
+    def test_get_job_meta_not_found(self, viewer):
+        v, bucket = viewer
+        bucket.get_object.side_effect = oss2.exceptions.NoSuchKey(404, {}, b"", {"Code": "NoSuchKey"})
+        meta = v.get_job_meta("nonexistent")
+        assert meta is None
+
+    def test_get_job_meta_running(self, viewer):
+        from rock.sdk.job.meta import JobMeta
+
+        v, bucket = viewer
+        meta_json = JobMeta(
+            job_name="j1", job_type="harbor", status="running",
+            started_at="2024-01-01T10:00:00Z",
+        ).model_dump_json()
+        bucket.get_object.return_value = _make_oss_object(meta_json.encode())
+        meta = v.get_job_meta("j1")
+        assert meta.status == "running"
+        assert meta.finished_at is None
+
+    def test_get_job_meta_invalid_json(self, viewer):
+        v, bucket = viewer
+        bucket.get_object.return_value = _make_oss_object(b"not valid json")
+        meta = v.get_job_meta("j1")
+        assert meta is None

--- a/tests/unit/sdk/job/test_meta.py
+++ b/tests/unit/sdk/job/test_meta.py
@@ -410,3 +410,124 @@ class TestJobViewerReadMeta:
         bucket.get_object.return_value = _make_oss_object(b"not valid json")
         meta = v.get_job_meta("j1")
         assert meta is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 6: RunMeta and RunScoreSummary models
+# ---------------------------------------------------------------------------
+
+
+class TestRunScoreSummary:
+    def test_defaults(self):
+        from rock.sdk.job.meta import RunScoreSummary
+
+        s = RunScoreSummary(completed=10, failed=2, skipped=0, avg_score=0.5, total_score=5.0, pass_rate=0.83)
+        assert s.completed == 10
+        assert s.failed == 2
+        assert s.skipped == 0
+        assert s.avg_score == 0.5
+        assert s.total_score == 5.0
+        assert s.pass_rate == 0.83
+        assert s.scores == {}
+
+    def test_with_scores(self):
+        from rock.sdk.job.meta import RunScoreSummary
+
+        s = RunScoreSummary(
+            completed=2, failed=0, skipped=0, avg_score=0.75, total_score=1.5, pass_rate=1.0,
+            scores={"task_a": 1.0, "task_b": 0.5},
+        )
+        assert s.scores == {"task_a": 1.0, "task_b": 0.5}
+
+    def test_serialization_roundtrip(self):
+        from rock.sdk.job.meta import RunScoreSummary
+
+        s = RunScoreSummary(
+            completed=5, failed=1, skipped=2, avg_score=0.6, total_score=3.0, pass_rate=0.625,
+            scores={"t1": 1.0, "t2": 0.0},
+        )
+        data = json.loads(s.model_dump_json())
+        s2 = RunScoreSummary.model_validate(data)
+        assert s2.completed == 5
+        assert s2.scores == {"t1": 1.0, "t2": 0.0}
+
+
+class TestRunMeta:
+    def test_required_fields(self):
+        from rock.sdk.job.meta import RunMeta
+
+        m = RunMeta(
+            run_id="20260706T143052-a1b2c3d4",
+            dataset="alibaba/aone-bench",
+            split="test",
+            total_tasks=100,
+            pending_tasks=100,
+            started_at="2026-07-06T14:30:52Z",
+            status="running",
+            task_job_map={"task_001": "aone-bench_task_001_20260706T143052-a1b2c3d4"},
+        )
+        assert m.run_id == "20260706T143052-a1b2c3d4"
+        assert m.dataset == "alibaba/aone-bench"
+        assert m.split == "test"
+        assert m.total_tasks == 100
+        assert m.pending_tasks == 100
+        assert m.status == "running"
+        assert m.finished_at is None
+        assert m.summary is None
+
+    def test_completed_with_summary(self):
+        from rock.sdk.job.meta import RunMeta, RunScoreSummary
+
+        m = RunMeta(
+            run_id="20260706T143052-a1b2c3d4",
+            dataset="alibaba/aone-bench",
+            split="test",
+            total_tasks=100,
+            pending_tasks=100,
+            started_at="2026-07-06T14:30:52Z",
+            finished_at="2026-07-06T18:00:00Z",
+            status="completed",
+            task_job_map={"task_001": "job_001"},
+            summary=RunScoreSummary(
+                completed=80, failed=20, skipped=0, avg_score=0.42, total_score=33.6, pass_rate=0.8,
+            ),
+        )
+        assert m.status == "completed"
+        assert m.summary.avg_score == 0.42
+
+    def test_serialization_roundtrip(self):
+        from rock.sdk.job.meta import RunMeta
+
+        m = RunMeta(
+            run_id="20260706T143052-a1b2c3d4",
+            dataset="org/ds",
+            split="test",
+            total_tasks=50,
+            pending_tasks=50,
+            started_at="2026-07-06T14:30:52Z",
+            status="running",
+            task_job_map={"t1": "j1", "t2": "j2"},
+        )
+        data = json.loads(m.model_dump_json())
+        m2 = RunMeta.model_validate(data)
+        assert m2.run_id == "20260706T143052-a1b2c3d4"
+        assert m2.task_job_map == {"t1": "j1", "t2": "j2"}
+
+    def test_run_id_format(self):
+        """run_id should follow {YYYYMMDD}T{HHmmss}-{8hex} format."""
+        import re
+
+        from rock.sdk.job.meta import RunMeta
+
+        m = RunMeta(
+            run_id="20260706T143052-a1b2c3d4",
+            dataset="org/ds",
+            split="test",
+            total_tasks=10,
+            pending_tasks=10,
+            started_at="2026-07-06T14:30:52Z",
+            status="running",
+            task_job_map={},
+        )
+        pattern = r"^\d{8}T\d{6}-[0-9a-f]{8}$"
+        assert re.match(pattern, m.run_id)

--- a/tests/unit/sdk/job/test_meta.py
+++ b/tests/unit/sdk/job/test_meta.py
@@ -236,40 +236,22 @@ class TestHarborTrialMetaIntegration:
             ),
         )
 
-    def test_script_contains_meta_prologue(self):
+    def test_script_does_not_contain_meta(self):
+        """Harbor's rock_meta.json is written by Harbor itself, not by the wrapper script."""
         from rock.sdk.job.trial.harbor import HarborTrial
 
         config = self._build_harbor_config()
-        trial = HarborTrial(config)
-        script = trial.build()
-        assert "rock_meta.json" in script
-        assert '"status": "running"' in script
-
-    def test_script_contains_meta_epilogue(self):
-        from rock.sdk.job.trial.harbor import HarborTrial
-
-        config = self._build_harbor_config()
-        trial = HarborTrial(config)
-        script = trial.build()
-        assert "_rock_status" in script
-
-    def test_meta_contains_job_type_harbor(self):
-        from rock.sdk.job.trial.harbor import HarborTrial
-
-        config = self._build_harbor_config()
-        trial = HarborTrial(config)
-        script = trial.build()
-        assert '"job_type": "harbor"' in script
-
-    def test_no_meta_when_mirror_disabled(self):
-        from rock.sdk.bench.models.job.config import HarborJobConfig
-
-        config = HarborJobConfig(job_name="j", namespace="ns", experiment_id="exp")
-        from rock.sdk.job.trial.harbor import HarborTrial
-
         trial = HarborTrial(config)
         script = trial.build()
         assert "rock_meta.json" not in script
+
+    def test_script_contains_harbor_start(self):
+        from rock.sdk.job.trial.harbor import HarborTrial
+
+        config = self._build_harbor_config()
+        trial = HarborTrial(config)
+        script = trial.build()
+        assert "harbor jobs start" in script
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/sdk/job/test_operator.py
+++ b/tests/unit/sdk/job/test_operator.py
@@ -50,6 +50,13 @@ class TestScatterOperator:
         assert all(isinstance(t, BashTrial) for t in trials)
 
 
+class TestUnsupportedDatasetOperator:
+    def test_dataset_operator_is_not_a_job_sdk_entrypoint(self):
+        import rock.sdk.job.operator as operator_module
+
+        assert not hasattr(operator_module, "DatasetOperator")
+
+
 class TestCustomOperator:
     def test_custom_subclass_can_override_apply(self):
         class FixedOperator(Operator):

--- a/tests/unit/sdk/job/test_planner.py
+++ b/tests/unit/sdk/job/test_planner.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+
+from rock.sdk.bench.models.job.config import HarborJobConfig, OssRegistryInfo, RegistryDatasetConfig
+from rock.sdk.job.config import BashJobConfig
+
+
+def make_harbor_config() -> HarborJobConfig:
+    return HarborJobConfig(
+        experiment_id="exp-1",
+        job_name="template",
+        labels={"keep": "yes"},
+        datasets=[
+            RegistryDatasetConfig(
+                name="old/bench",
+                registry=OssRegistryInfo(split="dev"),
+            )
+        ],
+    )
+
+
+class TestSingleTaskPlanner:
+    def test_plan_clones_harbor_config_for_single_task_without_mutating_template(self):
+        from rock.sdk.job.planner import ResolvedTask, SingleTaskPlanner
+        from rock.sdk.job.trial.harbor import HarborTrial
+
+        template = make_harbor_config()
+        planner = SingleTaskPlanner(run_id="run-123")
+
+        planned = planner.plan(
+            template,
+            task=ResolvedTask(task_id="task-001", org="alibaba", dataset="alibaba/aone-bench", split="test"),
+        )
+
+        assert planned.task_id == "task-001"
+        assert planned.config is not template
+        assert planned.config.datasets[0].name == "alibaba/aone-bench"
+        assert planned.config.datasets[0].task_names == ["task-001"]
+        assert planned.config.datasets[0].registry.split == "test"
+        assert planned.config.datasets[0].version == "test"
+        assert planned.config.job_name == "aone-bench_task-001_run-123"
+        assert planned.config.labels["rock_run_id"] == "run-123"
+        assert planned.config.labels["rock_task_id"] == "task-001"
+        assert planned.config.labels["keep"] == "yes"
+        assert isinstance(planned.trial, HarborTrial)
+
+        assert template.datasets[0].name == "old/bench"
+        assert template.datasets[0].task_names is None
+        assert template.labels == {"keep": "yes"}
+
+    def test_plan_clones_bash_config_and_injects_task_env(self):
+        from rock.sdk.job.planner import ResolvedTask, SingleTaskPlanner
+        from rock.sdk.job.trial.bash import BashTrial
+
+        template = BashJobConfig(script="echo $TASK", environment={"env": {"TASK": "old", "KEEP": "1"}})
+        planner = SingleTaskPlanner(run_id="run-123")
+
+        planned = planner.plan(template, task=ResolvedTask(task_id="task-001", dataset="bench", split="test"))
+
+        assert planned.config is not template
+        assert planned.config.environment.env["TASK"] == "task-001"
+        assert planned.config.environment.env["ROCK_TASK_ID"] == "task-001"
+        assert planned.config.environment.env["ROCK_RUN_ID"] == "run-123"
+        assert planned.config.environment.env["ROCK_JOB_NAME"] == "bench_task-001_run-123"
+        assert planned.config.environment.env["ROCK_DATASET"] == "bench"
+        assert planned.config.environment.env["ROCK_SPLIT"] == "test"
+        assert template.environment.env["TASK"] == "old"
+        assert isinstance(planned.trial, BashTrial)

--- a/tests/unit/sdk/job/test_planner.py
+++ b/tests/unit/sdk/job/test_planner.py
@@ -67,3 +67,15 @@ class TestSingleTaskPlanner:
         assert planned.config.environment.env["ROCK_SPLIT"] == "test"
         assert template.environment.env["TASK"] == "old"
         assert isinstance(planned.trial, BashTrial)
+
+    def test_plan_preserves_config_job_name_when_requested(self):
+        from rock.sdk.job.planner import ResolvedTask, SingleTaskPlanner
+
+        template = BashJobConfig(job_name="yaml-job", script="echo $TASK")
+        planner = SingleTaskPlanner(run_id="run-123", preserve_job_name=True)
+
+        planned = planner.plan(template, task=ResolvedTask(task_id="task-001", dataset="bench", split="test"))
+
+        assert planned.job_name == "yaml-job"
+        assert planned.config.job_name == "yaml-job"
+        assert planned.config.environment.env["ROCK_JOB_NAME"] == "yaml-job"

--- a/tests/unit/sdk/job/test_run_meta_repository.py
+++ b/tests/unit/sdk/job/test_run_meta_repository.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from rock.sdk.job.meta import RunMeta
+
+
+def make_run_meta(run_id: str = "run-1") -> RunMeta:
+    return RunMeta(
+        run_id=run_id,
+        dataset="org/dataset",
+        split="test",
+        total_tasks=2,
+        pending_tasks=2,
+        started_at="2026-07-09T00:00:00Z",
+        status="running",
+        task_job_map={"t1": "j1", "t2": "j2"},
+    )
+
+
+class TestRunMetaRepository:
+    def test_delegates_write_get_list_and_completed_tasks_to_viewer(self):
+        from rock.sdk.job.run_meta import RunMetaRepository
+
+        viewer = MagicMock()
+        meta = make_run_meta()
+        viewer.get_run_meta.return_value = meta
+        viewer.list_runs.return_value = [meta]
+        viewer.find_completed_tasks_in_run.return_value = {"t1"}
+
+        repo = RunMetaRepository(viewer)
+
+        repo.write(meta)
+        assert repo.get("run-1") == meta
+        assert repo.list() == [meta]
+        assert repo.find_completed_tasks("run-1") == {"t1"}
+
+        viewer.write_run_meta.assert_called_once_with(meta)
+        viewer.get_run_meta.assert_called_once_with("run-1")
+        viewer.list_runs.assert_called_once_with()
+        viewer.find_completed_tasks_in_run.assert_called_once_with("run-1")
+
+    def test_resolve_run_id_for_resume_delegates_to_viewer(self):
+        from rock.sdk.job.run_meta import RunMetaRepository
+
+        viewer = MagicMock()
+        viewer.resolve_run_id_for_resume.return_value = "run-1"
+
+        assert RunMetaRepository(viewer).resolve_run_id_for_resume() == "run-1"
+
+    def test_from_job_config_uses_oss_mirror(self):
+        from rock.sdk.bench.models.job.config import HarborJobConfig
+        from rock.sdk.envhub.config import OssMirrorConfig
+        from rock.sdk.job.run_meta import RunMetaRepository
+
+        config = HarborJobConfig(
+            experiment_id="exp-1",
+            namespace="ns-1",
+            environment={
+                "oss_mirror": OssMirrorConfig(
+                    enabled=True,
+                    oss_bucket="bucket",
+                    oss_endpoint="endpoint",
+                    oss_access_key_id="ak",
+                    oss_access_key_secret="sk",
+                )
+            },
+        )
+        viewer = MagicMock()
+
+        with patch("rock.sdk.job.run_meta.JobViewer.from_oss_mirror", return_value=viewer) as factory:
+            repo = RunMetaRepository.from_job_config(config)
+
+        assert repo._viewer is viewer
+        factory.assert_called_once_with(config.environment.oss_mirror)
+
+    def test_from_job_config_backfills_oss_mirror_identity_from_config(self):
+        from rock.sdk.bench.models.job.config import HarborJobConfig
+        from rock.sdk.envhub.config import OssMirrorConfig
+        from rock.sdk.job.run_meta import RunMetaRepository
+
+        config = HarborJobConfig(
+            experiment_id="exp-1",
+            namespace="ns-from-sandbox",
+            environment={
+                "oss_mirror": OssMirrorConfig(
+                    enabled=True,
+                    oss_bucket="bucket",
+                    oss_endpoint="endpoint",
+                )
+            },
+        )
+        config.environment.oss_mirror.namespace = None
+        config.environment.oss_mirror.experiment_id = None
+
+        with patch("rock.sdk.job.run_meta.JobViewer.from_oss_mirror") as factory:
+            RunMetaRepository.from_job_config(config)
+
+        assert config.environment.oss_mirror.namespace == "ns-from-sandbox"
+        assert config.environment.oss_mirror.experiment_id == "exp-1"
+        factory.assert_called_once_with(config.environment.oss_mirror)

--- a/tests/unit/sdk/job/test_trial_bash.py
+++ b/tests/unit/sdk/job/test_trial_bash.py
@@ -300,8 +300,13 @@ class TestBashTrialOssMirror:
 
 
 class TestRenderWrapper:
-    def test_wrapper_contains_prologue_and_epilogue(self):
-        wrapper = BashTrial._render_wrapper("echo hi", token="deadbeef")
+    @pytest.fixture
+    def trial(self):
+        config = BashJobConfig(job_name="test-job", script="echo hi", namespace="ns", experiment_id="exp")
+        return BashTrial(config)
+
+    def test_wrapper_contains_prologue_and_epilogue(self, trial):
+        wrapper = trial._render_wrapper("echo hi", token="deadbeef")
 
         # prologue
         assert 'mkdir -p "$ROCK_ARTIFACT_DIR"' in wrapper
@@ -321,9 +326,9 @@ class TestRenderWrapper:
         assert "--recursive -f" in wrapper
         assert "exit $_rock_user_rc" in wrapper
 
-    def test_wrapper_uses_oss_env_variables(self):
+    def test_wrapper_uses_oss_env_variables(self, trial):
         """Wrapper reads paths/bucket from env only; no plaintext credentials."""
-        wrapper = BashTrial._render_wrapper("echo hi", token="deadbeef")
+        wrapper = trial._render_wrapper("echo hi", token="deadbeef")
 
         # env-var references present
         assert '"oss://$OSS_BUCKET/$ROCK_OSS_PREFIX/"' in wrapper
@@ -331,25 +336,23 @@ class TestRenderWrapper:
         assert "--access-key-id" not in wrapper
         assert "--access-key-secret" not in wrapper
 
-    def test_wrapper_empty_user_script(self):
-        wrapper = BashTrial._render_wrapper("", token="deadbeef")
+    def test_wrapper_empty_user_script(self, trial):
+        wrapper = trial._render_wrapper("", token="deadbeef")
         assert "__ROCK_USER_SCRIPT_EOF_deadbeef__" in wrapper
         # prologue/epilogue still present
         assert "ossutil cp" in wrapper
 
-    def test_wrapper_preserves_user_script_verbatim(self):
+    def test_wrapper_preserves_user_script_verbatim(self, trial):
         """Single-quoted heredoc keeps $VAR, backticks, $() unexpanded."""
-        from rock.sdk.job.trial.bash import BashTrial
-
         user = 'echo "$HOME $(date) `whoami`"'
-        wrapper = BashTrial._render_wrapper(user, token="deadbeef")
+        wrapper = trial._render_wrapper(user, token="deadbeef")
         assert user in wrapper
 
-    def test_wrapper_auto_generates_token_when_omitted(self):
+    def test_wrapper_auto_generates_token_when_omitted(self, trial):
         """Without an explicit token, secrets.token_hex(4) is used."""
         import re as _re
 
-        wrapper = BashTrial._render_wrapper("echo hi")
+        wrapper = trial._render_wrapper("echo hi")
         match = _re.search(r"__ROCK_USER_SCRIPT_EOF_([0-9a-f]{8})__", wrapper)
         assert match is not None, "wrapper should contain auto-generated 8-char hex token"
 

--- a/tests/unit/sdk/job/test_viewer.py
+++ b/tests/unit/sdk/job/test_viewer.py
@@ -1,0 +1,534 @@
+"""Tests for rock.sdk.job.viewer — JobViewer and data models.
+
+TDD: these tests are written first (RED), then the implementation (GREEN).
+"""
+
+from __future__ import annotations
+
+import json
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import oss2
+import pytest
+
+from rock.sdk.job.viewer import (
+    AgentLogs,
+    ArtifactsData,
+    ArtifactManifestEntry,
+    CommandLog,
+    FileInfo,
+    JobViewer,
+    VerifierOutput,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+NAMESPACE = "test-ns"
+EXPERIMENT_ID = "exp-001"
+PREFIX = f"artifacts/{NAMESPACE}/{EXPERIMENT_ID}/"
+
+
+def _make_oss_object(data: bytes):
+    """Simulate oss2 get_object result (a readable stream)."""
+    obj = BytesIO(data)
+    obj.read = obj.read
+    return obj
+
+
+def _make_oss_iterator_item(key: str, *, is_prefix: bool = False, size: int = 0):
+    """Simulate an item returned by oss2.ObjectIterator."""
+    item = MagicMock()
+    item.key = key
+    item.is_prefix = MagicMock(return_value=is_prefix)
+    item.size = size
+    return item
+
+
+@pytest.fixture
+def mock_bucket():
+    return MagicMock()
+
+
+@pytest.fixture
+def viewer(mock_bucket):
+    return JobViewer(mock_bucket, namespace=NAMESPACE, experiment_id=EXPERIMENT_ID)
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: Data model tests
+# ---------------------------------------------------------------------------
+
+
+class TestVerifierOutput:
+    def test_defaults(self):
+        v = VerifierOutput()
+        assert v.stdout is None
+        assert v.stderr is None
+        assert v.ctrf is None
+
+    def test_with_values(self):
+        v = VerifierOutput(stdout="ok", stderr="warn", ctrf='{"results":[]}')
+        assert v.stdout == "ok"
+        assert v.stderr == "warn"
+        assert v.ctrf == '{"results":[]}'
+
+
+class TestAgentLogs:
+    def test_defaults(self):
+        logs = AgentLogs()
+        assert logs.oracle is None
+        assert logs.setup is None
+        assert logs.commands == []
+        assert logs.summary is None
+
+    def test_with_commands(self):
+        logs = AgentLogs(
+            oracle="oracle text",
+            setup="setup text",
+            commands=[CommandLog(index=0, content="cmd0"), CommandLog(index=1, content="cmd1")],
+            summary="summary text",
+        )
+        assert len(logs.commands) == 2
+        assert logs.commands[0].index == 0
+        assert logs.commands[1].content == "cmd1"
+
+
+class TestFileInfo:
+    def test_file(self):
+        f = FileInfo(path="patch.diff", name="patch.diff", is_dir=False, size=1024)
+        assert not f.is_dir
+        assert f.size == 1024
+
+    def test_directory(self):
+        f = FileInfo(path="agent", name="agent", is_dir=True)
+        assert f.is_dir
+        assert f.size is None
+
+
+class TestArtifactsData:
+    def test_empty(self):
+        a = ArtifactsData()
+        assert a.files == []
+        assert a.manifest is None
+
+    def test_with_manifest(self):
+        a = ArtifactsData(
+            files=[FileInfo(path="f.txt", name="f.txt", is_dir=False, size=10)],
+            manifest=[ArtifactManifestEntry(source="/src", destination="dst", type="file")],
+        )
+        assert len(a.files) == 1
+        assert len(a.manifest) == 1
+        assert a.manifest[0].source == "/src"
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Internal OSS operation tests
+# ---------------------------------------------------------------------------
+
+
+class TestJobViewerInternal:
+    def test_oss_key_prefix(self, viewer):
+        assert viewer._prefix == PREFIX
+        assert viewer._oss_key("job1/result.json") == f"{PREFIX}job1/result.json"
+
+    def test_read_text_found(self, viewer, mock_bucket):
+        mock_bucket.get_object.return_value = _make_oss_object(b'{"status":"ok"}')
+        result = viewer._read_text("job1/result.json")
+        assert result == '{"status":"ok"}'
+        mock_bucket.get_object.assert_called_once_with(f"{PREFIX}job1/result.json")
+
+    def test_read_text_not_found(self, viewer, mock_bucket):
+        mock_bucket.get_object.side_effect = oss2.exceptions.NoSuchKey(404, {}, b"", {"Code": "NoSuchKey"})
+        result = viewer._read_text("nonexistent.json")
+        assert result is None
+
+    def test_read_bytes_found(self, viewer, mock_bucket):
+        mock_bucket.get_object.return_value = _make_oss_object(b"\x89PNG")
+        result = viewer._read_bytes("img.png")
+        assert result == b"\x89PNG"
+
+    def test_read_bytes_not_found(self, viewer, mock_bucket):
+        mock_bucket.get_object.side_effect = oss2.exceptions.NoSuchKey(404, {}, b"", {"Code": "NoSuchKey"})
+        result = viewer._read_bytes("nonexistent.png")
+        assert result is None
+
+    def test_list_dirs(self, viewer, mock_bucket):
+        items = [
+            _make_oss_iterator_item(f"{PREFIX}job-a/", is_prefix=True),
+            _make_oss_iterator_item(f"{PREFIX}job-b/", is_prefix=True),
+        ]
+        with patch("oss2.ObjectIterator", return_value=iter(items)):
+            dirs = viewer._list_dirs()
+        assert sorted(dirs) == ["job-a", "job-b"]
+
+    def test_list_dirs_with_prefix(self, viewer, mock_bucket):
+        items = [
+            _make_oss_iterator_item(f"{PREFIX}job1/trial-a/", is_prefix=True),
+            _make_oss_iterator_item(f"{PREFIX}job1/trial-b/", is_prefix=True),
+        ]
+        with patch("oss2.ObjectIterator", return_value=iter(items)):
+            dirs = viewer._list_dirs("job1")
+        assert sorted(dirs) == ["trial-a", "trial-b"]
+
+    def test_exists_file(self, viewer, mock_bucket):
+        mock_bucket.object_exists.return_value = True
+        assert viewer._exists("job1/result.json") is True
+
+    def test_exists_directory(self, viewer, mock_bucket):
+        mock_bucket.object_exists.return_value = False
+        items = [_make_oss_iterator_item(f"{PREFIX}job1/trial-a/result.json")]
+        with patch("oss2.ObjectIterator", return_value=iter(items)):
+            assert viewer._exists("job1") is True
+
+    def test_not_exists(self, viewer, mock_bucket):
+        mock_bucket.object_exists.return_value = False
+        with patch("oss2.ObjectIterator", return_value=iter([])):
+            assert viewer._exists("nonexistent") is False
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: Job operation tests
+# ---------------------------------------------------------------------------
+
+SAMPLE_JOB_RESULT = {
+    "id": "abc123",
+    "started_at": "2024-01-01T10:00:00Z",
+    "finished_at": "2024-01-01T12:00:00Z",
+    "n_total_trials": 10,
+}
+
+SAMPLE_JOB_CONFIG = {
+    "job_name": "swe-bench_abc",
+    "namespace": "test-ns",
+    "experiment_id": "exp-001",
+}
+
+
+class TestJobViewerJobs:
+    def test_list_jobs(self, viewer, mock_bucket):
+        items = [
+            _make_oss_iterator_item(f"{PREFIX}job-a/", is_prefix=True),
+            _make_oss_iterator_item(f"{PREFIX}job-b/", is_prefix=True),
+        ]
+        with patch("oss2.ObjectIterator", return_value=iter(items)):
+            jobs = viewer.list_jobs()
+        assert "job-a" in jobs
+        assert "job-b" in jobs
+
+    def test_list_jobs_excludes_meta(self, viewer, mock_bucket):
+        items = [
+            _make_oss_iterator_item(f"{PREFIX}_meta/", is_prefix=True),
+            _make_oss_iterator_item(f"{PREFIX}job-a/", is_prefix=True),
+        ]
+        with patch("oss2.ObjectIterator", return_value=iter(items)):
+            jobs = viewer.list_jobs()
+        assert "_meta" not in jobs
+        assert "job-a" in jobs
+
+    def test_get_job_result_found(self, viewer, mock_bucket):
+        mock_bucket.get_object.return_value = _make_oss_object(json.dumps(SAMPLE_JOB_RESULT).encode())
+        result = viewer.get_job_result("job-a")
+        assert result is not None
+        assert result["id"] == "abc123"
+        assert result["n_total_trials"] == 10
+
+    def test_get_job_result_not_found(self, viewer, mock_bucket):
+        mock_bucket.get_object.side_effect = oss2.exceptions.NoSuchKey(404, {}, b"", {"Code": "NoSuchKey"})
+        result = viewer.get_job_result("nonexistent")
+        assert result is None
+
+    def test_get_job_config(self, viewer, mock_bucket):
+        mock_bucket.get_object.return_value = _make_oss_object(json.dumps(SAMPLE_JOB_CONFIG).encode())
+        config = viewer.get_job_config("job-a")
+        assert config["job_name"] == "swe-bench_abc"
+
+    def test_get_job_summary(self, viewer, mock_bucket):
+        mock_bucket.get_object.return_value = _make_oss_object(b"# Summary\nAll passed.")
+        summary = viewer.get_job_summary("job-a")
+        assert summary == "# Summary\nAll passed."
+
+    def test_get_job_summary_not_found(self, viewer, mock_bucket):
+        mock_bucket.get_object.side_effect = oss2.exceptions.NoSuchKey(404, {}, b"", {"Code": "NoSuchKey"})
+        assert viewer.get_job_summary("job-a") is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: Trial operation tests
+# ---------------------------------------------------------------------------
+
+SAMPLE_TRIAL_RESULT = {
+    "task_name": "django__django-12345",
+    "trial_name": "trial-001",
+    "source": "swe-bench",
+    "agent_info": {"name": "my-agent", "version": "1.0", "model_info": {"name": "claude-sonnet", "provider": "anthropic"}},
+    "verifier_result": {"rewards": {"reward": 1.0}},
+    "exception_info": None,
+    "started_at": "2024-01-01T10:00:00Z",
+    "finished_at": "2024-01-01T10:02:00Z",
+}
+
+
+class TestJobViewerTrials:
+    def test_list_trials(self, viewer, mock_bucket):
+        dir_items = [
+            _make_oss_iterator_item(f"{PREFIX}job-a/trial-001/", is_prefix=True),
+            _make_oss_iterator_item(f"{PREFIX}job-a/trial-002/", is_prefix=True),
+            _make_oss_iterator_item(f"{PREFIX}job-a/no-result/", is_prefix=True),
+        ]
+        mock_bucket.object_exists.side_effect = lambda key: "no-result" not in key
+        with patch("oss2.ObjectIterator", return_value=iter(dir_items)):
+            trials = viewer.list_trials("job-a")
+        assert "trial-001" in trials
+        assert "trial-002" in trials
+        assert "no-result" not in trials
+
+    def test_get_trial_result_parses_harbor_format(self, viewer, mock_bucket):
+        mock_bucket.get_object.return_value = _make_oss_object(json.dumps(SAMPLE_TRIAL_RESULT).encode())
+        result = viewer.get_trial_result("job-a", "trial-001")
+        assert result is not None
+        assert result.task_name == "django__django-12345"
+        assert result.score == 1.0
+        assert result.agent_info.name == "my-agent"
+        assert result.agent_info.model_info.name == "claude-sonnet"
+
+    def test_get_trial_result_not_found(self, viewer, mock_bucket):
+        mock_bucket.get_object.side_effect = oss2.exceptions.NoSuchKey(404, {}, b"", {"Code": "NoSuchKey"})
+        result = viewer.get_trial_result("job-a", "nonexistent")
+        assert result is None
+
+    def test_get_trial_results_batch(self, viewer, mock_bucket):
+        dir_items = [
+            _make_oss_iterator_item(f"{PREFIX}job-a/trial-001/", is_prefix=True),
+            _make_oss_iterator_item(f"{PREFIX}job-a/trial-002/", is_prefix=True),
+        ]
+        mock_bucket.get_object.return_value = _make_oss_object(json.dumps(SAMPLE_TRIAL_RESULT).encode())
+        with patch("oss2.ObjectIterator", return_value=iter(dir_items)):
+            results = viewer.get_trial_results("job-a")
+        assert len(results) >= 1
+
+    def test_get_trial_config(self, viewer, mock_bucket):
+        trial_config = {"agent": {"name": "my-agent"}, "environment": {"type": "docker"}}
+        mock_bucket.get_object.return_value = _make_oss_object(json.dumps(trial_config).encode())
+        config = viewer.get_trial_config("job-a", "trial-001")
+        assert config["agent"]["name"] == "my-agent"
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: Artifact and log tests
+# ---------------------------------------------------------------------------
+
+
+class TestJobViewerArtifacts:
+    def test_get_trajectory(self, viewer, mock_bucket):
+        traj = {"schema_version": "1.0", "steps": [{"step_id": 0}]}
+        mock_bucket.get_object.return_value = _make_oss_object(json.dumps(traj).encode())
+        result = viewer.get_trajectory("job-a", "trial-001")
+        assert result is not None
+        assert result["schema_version"] == "1.0"
+        assert len(result["steps"]) == 1
+
+    def test_get_trajectory_not_found(self, viewer, mock_bucket):
+        mock_bucket.get_object.side_effect = oss2.exceptions.NoSuchKey(404, {}, b"", {"Code": "NoSuchKey"})
+        result = viewer.get_trajectory("job-a", "trial-001")
+        assert result is None
+
+    def test_get_verifier_output(self, viewer, mock_bucket):
+        def fake_get_object(key):
+            if "test-stdout.txt" in key:
+                return _make_oss_object(b"PASS")
+            if "test-stderr.txt" in key:
+                return _make_oss_object(b"warn")
+            if "ctrf.json" in key:
+                return _make_oss_object(b'{"results":[]}')
+            raise oss2.exceptions.NoSuchKey(404, {}, b"", {"Code": "NoSuchKey"})
+
+        mock_bucket.get_object.side_effect = fake_get_object
+        output = viewer.get_verifier_output("job-a", "trial-001")
+        assert isinstance(output, VerifierOutput)
+        assert output.stdout == "PASS"
+        assert output.stderr == "warn"
+        assert output.ctrf == '{"results":[]}'
+
+    def test_get_verifier_output_empty(self, viewer, mock_bucket):
+        mock_bucket.get_object.side_effect = oss2.exceptions.NoSuchKey(404, {}, b"", {"Code": "NoSuchKey"})
+        output = viewer.get_verifier_output("job-a", "trial-001")
+        assert output.stdout is None
+        assert output.stderr is None
+        assert output.ctrf is None
+
+    def test_get_agent_logs(self, viewer, mock_bucket):
+        def fake_get_object(key):
+            if "oracle.txt" in key:
+                return _make_oss_object(b"oracle content")
+            if "setup/stdout.txt" in key:
+                return _make_oss_object(b"setup content")
+            if "summary.md" in key:
+                return _make_oss_object(b"summary content")
+            raise oss2.exceptions.NoSuchKey(404, {}, b"", {"Code": "NoSuchKey"})
+
+        mock_bucket.get_object.side_effect = fake_get_object
+        with patch("oss2.ObjectIterator", return_value=iter([])):
+            logs = viewer.get_agent_logs("job-a", "trial-001")
+        assert isinstance(logs, AgentLogs)
+        assert logs.oracle == "oracle content"
+        assert logs.setup == "setup content"
+        assert logs.summary == "summary content"
+
+    def test_get_exception(self, viewer, mock_bucket):
+        mock_bucket.get_object.return_value = _make_oss_object(b"TimeoutError: agent timed out")
+        result = viewer.get_exception("job-a", "trial-001")
+        assert result == "TimeoutError: agent timed out"
+
+    def test_get_exception_not_found(self, viewer, mock_bucket):
+        mock_bucket.get_object.side_effect = oss2.exceptions.NoSuchKey(404, {}, b"", {"Code": "NoSuchKey"})
+        assert viewer.get_exception("job-a", "trial-001") is None
+
+    def test_get_trial_log(self, viewer, mock_bucket):
+        mock_bucket.get_object.return_value = _make_oss_object(b"[INFO] Trial started")
+        result = viewer.get_trial_log("job-a", "trial-001")
+        assert "Trial started" in result
+
+    def test_get_trial_log_not_found(self, viewer, mock_bucket):
+        mock_bucket.get_object.side_effect = oss2.exceptions.NoSuchKey(404, {}, b"", {"Code": "NoSuchKey"})
+        assert viewer.get_trial_log("job-a", "trial-001") is None
+
+
+# ---------------------------------------------------------------------------
+# Phase 6: Factory method tests
+# ---------------------------------------------------------------------------
+
+
+class TestJobViewerFactories:
+    @patch("oss2.Bucket")
+    @patch("oss2.Auth")
+    def test_from_credentials(self, mock_auth_cls, mock_bucket_cls):
+        viewer = JobViewer.from_credentials(
+            oss_endpoint="https://oss.example.com",
+            oss_bucket="my-bucket",
+            access_key_id="AK",
+            access_key_secret="SK",
+            namespace="ns",
+            experiment_id="exp",
+        )
+        mock_auth_cls.assert_called_once_with("AK", "SK")
+        mock_bucket_cls.assert_called_once()
+        assert viewer._prefix == "artifacts/ns/exp/"
+
+    @patch("oss2.Bucket")
+    @patch("oss2.Auth")
+    def test_from_oss_mirror(self, mock_auth_cls, mock_bucket_cls):
+        from rock.sdk.envhub.config import OssMirrorConfig
+
+        mirror = OssMirrorConfig(
+            enabled=True,
+            oss_bucket="bucket",
+            namespace="ns",
+            experiment_id="exp",
+            oss_access_key_id="AK",
+            oss_access_key_secret="SK",
+            oss_region="cn-hangzhou",
+            oss_endpoint="https://oss.example.com",
+        )
+        viewer = JobViewer.from_oss_mirror(mirror)
+        assert viewer._prefix == "artifacts/ns/exp/"
+
+    def test_from_oss_mirror_missing_fields(self):
+        from rock.sdk.envhub.config import OssMirrorConfig
+
+        mirror = OssMirrorConfig(enabled=True)
+        with pytest.raises(Exception):
+            JobViewer.from_oss_mirror(mirror)
+
+    @patch("httpx.get")
+    @patch("oss2.Bucket")
+    @patch("oss2.StsAuth")
+    def test_from_admin(self, mock_sts_auth_cls, mock_bucket_cls, mock_httpx_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "status": "Success",
+            "result": {
+                "AccessKeyId": "tmp-ak",
+                "AccessKeySecret": "tmp-sk",
+                "SecurityToken": "token",
+                "Endpoint": "https://oss.example.com",
+                "Bucket": "bucket",
+                "Region": "cn-hangzhou",
+            },
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_httpx_get.return_value = mock_resp
+
+        viewer = JobViewer.from_admin(
+            admin_base_url="https://admin.example.com",
+            namespace="ns",
+            experiment_id="exp",
+        )
+        mock_sts_auth_cls.assert_called_once_with("tmp-ak", "tmp-sk", "token")
+        assert viewer._prefix == "artifacts/ns/exp/"
+
+    @patch("httpx.get")
+    def test_from_admin_auth_failure(self, mock_httpx_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"status": "Failed", "message": "unauthorized"}
+        mock_resp.raise_for_status = MagicMock()
+        mock_httpx_get.return_value = mock_resp
+
+        with pytest.raises(RuntimeError, match="unauthorized"):
+            JobViewer.from_admin(
+                admin_base_url="https://admin.example.com",
+                namespace="ns",
+                experiment_id="exp",
+            )
+
+    @patch("httpx.get")
+    @patch("oss2.Bucket")
+    @patch("oss2.StsAuth")
+    def test_from_admin_url_normalization(self, mock_sts_auth_cls, mock_bucket_cls, mock_httpx_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "status": "Success",
+            "result": {
+                "AccessKeyId": "ak",
+                "AccessKeySecret": "sk",
+                "SecurityToken": "t",
+                "Endpoint": "https://oss.example.com",
+                "Bucket": "b",
+            },
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_httpx_get.return_value = mock_resp
+
+        JobViewer.from_admin(
+            admin_base_url="https://admin.example.com/apis/envs/sandbox/v1",
+            namespace="ns",
+            experiment_id="exp",
+        )
+        call_url = mock_httpx_get.call_args[0][0]
+        assert call_url == "https://admin.example.com/apis/envs/sandbox/v1/get_token?account=primary"
+        assert "/apis/envs/sandbox/v1/apis/" not in call_url
+
+
+# ---------------------------------------------------------------------------
+# Phase bonus: Generic file operations
+# ---------------------------------------------------------------------------
+
+
+class TestJobViewerFileOps:
+    def test_read_file(self, viewer, mock_bucket):
+        mock_bucket.get_object.return_value = _make_oss_object(b"hello")
+        assert viewer.read_file("some/path.txt") == "hello"
+
+    def test_read_file_bytes(self, viewer, mock_bucket):
+        mock_bucket.get_object.return_value = _make_oss_object(b"\x00\x01\x02")
+        assert viewer.read_file_bytes("bin.dat") == b"\x00\x01\x02"
+
+    def test_file_exists_true(self, viewer, mock_bucket):
+        mock_bucket.object_exists.return_value = True
+        assert viewer.file_exists("some/file") is True
+
+    def test_file_exists_false(self, viewer, mock_bucket):
+        mock_bucket.object_exists.return_value = False
+        assert viewer.file_exists("nonexistent") is False

--- a/tests/unit/sdk/job/test_viewer.py
+++ b/tests/unit/sdk/job/test_viewer.py
@@ -532,3 +532,168 @@ class TestJobViewerFileOps:
     def test_file_exists_false(self, viewer, mock_bucket):
         mock_bucket.object_exists.return_value = False
         assert viewer.file_exists("nonexistent") is False
+
+
+# ---------------------------------------------------------------------------
+# Run metadata tests (full-dataset run support)
+# ---------------------------------------------------------------------------
+
+
+class TestJobViewerRunMeta:
+    @pytest.fixture
+    def viewer(self):
+        bucket = MagicMock()
+        return JobViewer(bucket, namespace=NAMESPACE, experiment_id=EXPERIMENT_ID), bucket
+
+    def test_get_run_meta_found(self, viewer):
+        from rock.sdk.job.meta import RunMeta
+
+        v, bucket = viewer
+        meta = RunMeta(
+            run_id="20260706T143052-a1b2c3d4",
+            dataset="alibaba/aone-bench", split="test",
+            total_tasks=100, pending_tasks=100,
+            started_at="2026-07-06T14:30:52Z", status="running",
+            task_job_map={"task-001": "j1"},
+        )
+        bucket.get_object.return_value = _make_oss_object(meta.model_dump_json().encode())
+        result = v.get_run_meta("20260706T143052-a1b2c3d4")
+        assert result is not None
+        assert result.run_id == "20260706T143052-a1b2c3d4"
+        assert result.status == "running"
+        bucket.get_object.assert_called_once_with(f"artifacts/{NAMESPACE}/{EXPERIMENT_ID}/_meta/run_20260706T143052-a1b2c3d4.json")
+
+    def test_get_run_meta_not_found(self, viewer):
+        v, bucket = viewer
+        bucket.get_object.side_effect = oss2.exceptions.NoSuchKey(404, {}, b"", {"Code": "NoSuchKey"})
+        result = v.get_run_meta("nonexistent")
+        assert result is None
+
+    def test_write_run_meta(self, viewer):
+        from rock.sdk.job.meta import RunMeta
+
+        v, bucket = viewer
+        meta = RunMeta(
+            run_id="20260706T143052-a1b2c3d4",
+            dataset="alibaba/aone-bench", split="test",
+            total_tasks=50, pending_tasks=50,
+            started_at="2026-07-06T14:30:52Z", status="running",
+            task_job_map={"t1": "j1"},
+        )
+        v.write_run_meta(meta)
+        bucket.put_object.assert_called_once()
+        key = bucket.put_object.call_args[0][0]
+        assert key == f"artifacts/{NAMESPACE}/{EXPERIMENT_ID}/_meta/run_20260706T143052-a1b2c3d4.json"
+        body = bucket.put_object.call_args[0][1]
+        data = json.loads(body)
+        assert data["run_id"] == "20260706T143052-a1b2c3d4"
+
+    def test_list_runs(self, viewer):
+        from rock.sdk.job.meta import RunMeta
+
+        v, bucket = viewer
+        meta1 = RunMeta(
+            run_id="20260706T100000-aaaaaaaa", dataset="d", split="test",
+            total_tasks=10, pending_tasks=10, started_at="2026-07-06T10:00:00Z",
+            status="completed", task_job_map={},
+        )
+        meta2 = RunMeta(
+            run_id="20260706T120000-bbbbbbbb", dataset="d", split="test",
+            total_tasks=10, pending_tasks=5, started_at="2026-07-06T12:00:00Z",
+            status="running", task_job_map={},
+        )
+        prefix = f"artifacts/{NAMESPACE}/{EXPERIMENT_ID}/_meta/"
+
+        mock_obj1 = MagicMock()
+        mock_obj1.key = f"{prefix}run_20260706T100000-aaaaaaaa.json"
+        mock_obj1.is_prefix.return_value = False
+        mock_obj2 = MagicMock()
+        mock_obj2.key = f"{prefix}run_20260706T120000-bbbbbbbb.json"
+        mock_obj2.is_prefix.return_value = False
+
+        with patch("oss2.ObjectIterator", return_value=iter([mock_obj1, mock_obj2])):
+            def get_object_side_effect(key):
+                if "aaaaaaaa" in key:
+                    return _make_oss_object(meta1.model_dump_json().encode())
+                return _make_oss_object(meta2.model_dump_json().encode())
+
+            bucket.get_object.side_effect = get_object_side_effect
+            runs = v.list_runs()
+
+        assert len(runs) == 2
+        assert runs[0].run_id == "20260706T100000-aaaaaaaa"
+
+    def test_resolve_run_id_for_resume_single_incomplete(self, viewer):
+        from rock.sdk.job.meta import RunMeta
+
+        v, bucket = viewer
+        meta1 = RunMeta(
+            run_id="20260706T100000-aaaaaaaa", dataset="d", split="test",
+            total_tasks=10, pending_tasks=10, started_at="t", status="completed", task_job_map={},
+        )
+        meta2 = RunMeta(
+            run_id="20260706T120000-bbbbbbbb", dataset="d", split="test",
+            total_tasks=10, pending_tasks=5, started_at="t", status="running", task_job_map={},
+        )
+        with patch.object(v, "list_runs", return_value=[meta1, meta2]):
+            result = v.resolve_run_id_for_resume()
+        assert result == "20260706T120000-bbbbbbbb"
+
+    def test_resolve_run_id_for_resume_none_incomplete(self, viewer):
+        from rock.sdk.job.meta import RunMeta
+
+        v, bucket = viewer
+        meta1 = RunMeta(
+            run_id="r1", dataset="d", split="test",
+            total_tasks=10, pending_tasks=10, started_at="t", status="completed", task_job_map={},
+        )
+        with patch.object(v, "list_runs", return_value=[meta1]):
+            result = v.resolve_run_id_for_resume()
+        assert result is None
+
+    def test_resolve_run_id_for_resume_multiple_incomplete_raises(self, viewer):
+        from rock.sdk.job.meta import RunMeta
+
+        v, bucket = viewer
+        meta1 = RunMeta(
+            run_id="r1", dataset="d", split="test",
+            total_tasks=10, pending_tasks=10, started_at="t", status="running", task_job_map={},
+        )
+        meta2 = RunMeta(
+            run_id="r2", dataset="d", split="test",
+            total_tasks=10, pending_tasks=5, started_at="t", status="running", task_job_map={},
+        )
+        with patch.object(v, "list_runs", return_value=[meta1, meta2]):
+            with pytest.raises(ValueError, match="multiple"):
+                v.resolve_run_id_for_resume()
+
+    def test_find_completed_tasks_in_run(self, viewer):
+        from rock.sdk.job.meta import RunMeta
+
+        v, bucket = viewer
+        meta = RunMeta(
+            run_id="r1", dataset="d", split="test",
+            total_tasks=3, pending_tasks=3, started_at="t", status="running",
+            task_job_map={"task-001": "j1", "task-002": "j2", "task-003": "j3"},
+        )
+        with patch.object(v, "get_run_meta", return_value=meta):
+            # j1 has completed trial, j2 has failed trial, j3 has no trial
+            def mock_get_trial_results(job_name):
+                from rock.sdk.bench.models.trial.result import HarborTrialResult
+
+                if job_name == "j1":
+                    return {"trial1": HarborTrialResult(task_name="task-001")}
+                elif job_name == "j2":
+                    from rock.sdk.job.result import ExceptionInfo
+                    return {"trial1": HarborTrialResult(
+                        task_name="task-002",
+                        exception_info=ExceptionInfo(exception_type="Timeout", exception_message="timeout"),
+                    )}
+                return {}
+
+            with patch.object(v, "get_trial_results", side_effect=mock_get_trial_results):
+                completed = v.find_completed_tasks_in_run("r1")
+
+        assert completed == {"task-001"}
+        assert "task-002" not in completed
+        assert "task-003" not in completed


### PR DESCRIPTION
## Summary

- Extend `rock job run` into a unified entrypoint for single-task, multi-task, and full dataset execution via `--task`, `--tasks`, and `--all`
- Add CLI-level orchestration in `rock.cli.job_run` for task planning, run/job metadata writes, concurrency control, JSONL progress events, and score summaries
- Keep the SDK focused on atomic primitives: task-bound planning, single-job execution, run/job metadata repositories, and reconnecting to existing sandbox jobs
- Add `--resume <run_id>` support that skips completed tasks, reconnects to still-running sandbox jobs when metadata contains `sandbox_id/session/pid`, and marks unrecoverable attempts before rerun
- Add run-level query support with `rock job runs`, `rock job status --run-id`, and run-aware `rock job show`
- Support both Harbor and Bash task binding while keeping one task per sandbox at the SDK execution layer

## Validation

- [x] `uv run pytest tests/unit/sdk/job/test_planner.py tests/unit/sdk/job/test_run_meta_repository.py tests/unit/sdk/job/test_executor_concurrent.py tests/unit/cli/command/test_job.py tests/unit/cli/test_job_run.py` — 26 passed
- [x] `uv run pytest tests/unit/sdk/job/test_meta.py tests/unit/sdk/job/test_viewer.py tests/unit/sdk/job/test_executor.py tests/unit/sdk/job/test_job.py tests/unit/sdk/job/test_config.py` — 208 passed
- [x] Built wheel from `feat/job-run-all`: `dist/rl_rock-1.10.1.dev2-py3-none-any.whl`
- [x] Verified wheel metadata consistency: filename, `.dist-info`, and `METADATA Version` are all `1.10.1.dev2`


Closes #1231