### PR TITLE
feat(ts-sdk): add archive lifecycle and disk configuration

### DIFF
--- a/rock/ts-sdk/package-lock.json
+++ b/rock/ts-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rl-rock",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rl-rock",
-      "version": "1.9.2",
+      "version": "1.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/express": "^5.0.6",

--- a/rock/ts-sdk/package.json
+++ b/rock/ts-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rl-rock",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "description": "ROCK TypeScript SDK - Sandbox management and agent framework",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/rock/ts-sdk/src/sandbox/client.test.ts
+++ b/rock/ts-sdk/src/sandbox/client.test.ts
@@ -513,6 +513,143 @@ describe('Zod Validation', () => {
   });
 });
 
+describe('Sandbox archive()', () => {
+  let sandbox: Sandbox;
+  let mockPost: jest.Mock;
+  let mockGet: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPost = jest.fn();
+    mockGet = jest.fn();
+    mockedAxios.create = jest.fn().mockReturnValue({
+      post: mockPost,
+      get: mockGet,
+    });
+
+    sandbox = new Sandbox({
+      image: 'test:latest',
+      startupTimeout: 2,
+    });
+  });
+
+  test('should throw when sandbox_id is not set', async () => {
+    await expect(sandbox.archive()).rejects.toThrow('sandbox_id is not set, cannot archive');
+  });
+
+  test('should call POST /sandboxes/{id}/archive on success', async () => {
+    // Start sandbox first
+    mockPost.mockResolvedValueOnce({
+      data: { status: 'Success', result: { sandbox_id: 'test-id', host_name: 'h', host_ip: '1.2.3.4' } },
+      headers: {},
+    });
+    mockGet.mockResolvedValue({
+      data: { status: 'Success', result: { is_alive: true } },
+      headers: {},
+    });
+    await sandbox.start();
+
+    // Mock archive response
+    mockPost.mockResolvedValueOnce({
+      data: { status: 'Success', result: 'test-id archiving' },
+      headers: {},
+    });
+
+    await expect(sandbox.archive()).resolves.toBeUndefined();
+
+    const archiveCall = mockPost.mock.calls.find((call: unknown[]) =>
+      (call[0] as string).includes('/sandboxes/test-id/archive')
+    );
+    expect(archiveCall).toBeDefined();
+  });
+
+  test('should throw BadRequestRockError when API returns 4xxx code', async () => {
+    // Start sandbox first
+    mockPost.mockResolvedValueOnce({
+      data: { status: 'Success', result: { sandbox_id: 'test-id', host_name: 'h', host_ip: '1.2.3.4' } },
+      headers: {},
+    });
+    mockGet.mockResolvedValue({
+      data: { status: 'Success', result: { is_alive: true } },
+      headers: {},
+    });
+    await sandbox.start();
+
+    // Mock archive failure
+    mockPost.mockResolvedValueOnce({
+      data: { status: 'Failed', result: { code: Codes.BAD_REQUEST } },
+      headers: {},
+    });
+
+    await expect(sandbox.archive()).rejects.toThrow(BadRequestRockError);
+  });
+});
+
+describe('Sandbox start() - disk field', () => {
+  let mockPost: jest.Mock;
+  let mockGet: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPost = jest.fn();
+    mockGet = jest.fn();
+    mockedAxios.create = jest.fn().mockReturnValue({
+      post: mockPost,
+      get: mockGet,
+    });
+  });
+
+  test('should include disk in start payload', async () => {
+    const sandbox = new Sandbox({
+      image: 'test:latest',
+      startupTimeout: 2,
+      disk: '20g',
+    });
+
+    mockPost.mockResolvedValueOnce({
+      data: { status: 'Success', result: { sandbox_id: 'test-id', host_name: 'h', host_ip: '1.2.3.4' } },
+      headers: {},
+    });
+    mockGet.mockResolvedValue({
+      data: { status: 'Success', result: { is_alive: true } },
+      headers: {},
+    });
+
+    await sandbox.start();
+
+    const startCall = mockPost.mock.calls.find((call: unknown[]) =>
+      (call[0] as string).includes('/start_async')
+    );
+    expect(startCall).toBeDefined();
+    const payload = startCall![1] as Record<string, unknown>;
+    expect(payload.disk).toBe('20g');
+  });
+
+  test('should send null disk by default', async () => {
+    const sandbox = new Sandbox({
+      image: 'test:latest',
+      startupTimeout: 2,
+    });
+
+    mockPost.mockResolvedValueOnce({
+      data: { status: 'Success', result: { sandbox_id: 'test-id', host_name: 'h', host_ip: '1.2.3.4' } },
+      headers: {},
+    });
+    mockGet.mockResolvedValue({
+      data: { status: 'Success', result: { is_alive: true } },
+      headers: {},
+    });
+
+    await sandbox.start();
+
+    const startCall = mockPost.mock.calls.find((call: unknown[]) =>
+      (call[0] as string).includes('/start_async')
+    );
+    const payload = startCall![1] as Record<string, unknown>;
+    expect(payload.disk).toBeNull();
+  });
+});
+
 /**
  * arun() session creation behavior tests
  * 

--- a/rock/ts-sdk/src/sandbox/client.ts
+++ b/rock/ts-sdk/src/sandbox/client.ts
@@ -117,6 +117,7 @@ export abstract class AbstractSandbox {
   abstract closeSession(request: CloseSessionRequest): Promise<CloseSessionResponse>;
   abstract delete(): Promise<void>;
   abstract restart(): Promise<void>;
+  abstract archive(): Promise<void>;
   abstract commit(imageTag: string, username: string, password: string): Promise<CommandResponse | undefined>;
   abstract attach(sandboxId: string): Promise<void>;
   abstract arun(
@@ -310,6 +311,7 @@ export class Sandbox extends AbstractSandbox {
       limitCpus: this.config.limitCpus,
       sandboxId: this.config.sandboxId,
       autoDeleteSeconds: this.config.autoDeleteSeconds,
+      disk: this.config.disk,
     };
 
     logger.debug(`Calling start_async API: ${url}`);
@@ -478,6 +480,30 @@ export class Sandbox extends AbstractSandbox {
     throw new InternalServerRockError(
       `Failed to restart sandbox within ${this.config.startupTimeout}s, sandbox: ${this.toString()}`
     );
+  }
+
+  /**
+   * Archive a stopped sandbox (snapshot container + upload logs).
+   *
+   * The sandbox must be in STOPPED state. After this call the server transitions
+   * it to ARCHIVING, and a background scanner will move it to ARCHIVED once
+   * both the image and log uploads are confirmed.
+   */
+  async archive(): Promise<void> {
+    if (!this.sandboxId) {
+      throw new Error('sandbox_id is not set, cannot archive');
+    }
+    const url = `${this.url}/sandboxes/${this.sandboxId}/archive`;
+    const headers = this.buildHeaders();
+    const response = await HttpUtils.post<SandboxResponse & { code?: number }>(url, headers, {});
+    logger.debug(`Archive sandbox response: ${JSON.stringify(response)}`);
+    if (response.status !== 'Success') {
+      const result = response.result;
+      if (result) {
+        raiseForCode(result.code, `Failed to archive sandbox: ${JSON.stringify(response)}`);
+      }
+      throw new Error(`Failed to archive sandbox: ${JSON.stringify(response)}`);
+    }
   }
 
   /**

--- a/rock/ts-sdk/src/sandbox/config.test.ts
+++ b/rock/ts-sdk/src/sandbox/config.test.ts
@@ -110,6 +110,23 @@ describe('Config uses envVars (not hardcoded)', () => {
   });
 });
 
+describe('SandboxConfigSchema - disk field', () => {
+  test('should default disk to null', () => {
+    const config = SandboxConfigSchema.parse({});
+    expect(config.disk).toBeNull();
+  });
+
+  test('should accept disk value', () => {
+    const config = SandboxConfigSchema.parse({ disk: '20g' });
+    expect(config.disk).toBe('20g');
+  });
+
+  test('should accept null disk', () => {
+    const config = SandboxConfigSchema.parse({ disk: null });
+    expect(config.disk).toBeNull();
+  });
+});
+
 describe('Config lazy evaluation of env vars', () => {
   // This test verifies that env var defaults are evaluated lazily (at parse time)
   // not eagerly (at module load time). This allows env vars to be changed

--- a/rock/ts-sdk/src/sandbox/config.ts
+++ b/rock/ts-sdk/src/sandbox/config.ts
@@ -41,6 +41,7 @@ export const SandboxConfigSchema = BaseConfigSchema.extend({
   useKataRuntime: z.boolean().default(false),
   sandboxId: z.string().optional(),
   autoDeleteSeconds: z.number().int().nullable().default(null),
+  disk: z.string().nullable().default(null),
 });
 
 /**

--- a/rock/ts-sdk/src/types/responses.test.ts
+++ b/rock/ts-sdk/src/types/responses.test.ts
@@ -7,6 +7,8 @@
 
 import {
   SandboxStatusResponseSchema,
+  SandboxState,
+  StateTransitionRecordSchema,
   IsAliveResponseSchema,
   CommandResponseSchema,
   ObservationSchema,
@@ -262,5 +264,108 @@ describe('OssCredentials', () => {
         expiration: '2025-03-28T12:00:00Z',
       });
     }).toThrow();
+  });
+});
+
+describe('SandboxState', () => {
+  test('should define all state values', () => {
+    expect(SandboxState.PENDING).toBe('pending');
+    expect(SandboxState.RUNNING).toBe('running');
+    expect(SandboxState.STOPPED).toBe('stopped');
+    expect(SandboxState.ARCHIVING).toBe('archiving');
+    expect(SandboxState.ARCHIVED).toBe('archived');
+    expect(SandboxState.DELETED).toBe('deleted');
+  });
+});
+
+describe('StateTransitionRecord', () => {
+  test('should parse valid record', () => {
+    const result = StateTransitionRecordSchema.parse({
+      fromState: 'stopped',
+      toState: 'archiving',
+      event: 'archive',
+      timestamp: '2026-07-09T10:00:00+08:00',
+    });
+    expect(result.fromState).toBe('stopped');
+    expect(result.toState).toBe('archiving');
+    expect(result.event).toBe('archive');
+    expect(result.timestamp).toBe('2026-07-09T10:00:00+08:00');
+  });
+});
+
+describe('SandboxStatusResponse - new fields', () => {
+  test('should parse state as enum value', () => {
+    const result = SandboxStatusResponseSchema.parse({
+      sandboxId: 'test-id',
+      isAlive: true,
+      state: 'running',
+    });
+    expect(result.state).toBe('running');
+  });
+
+  test('should parse archiving and archived states', () => {
+    const archiving = SandboxStatusResponseSchema.parse({ state: 'archiving' });
+    expect(archiving.state).toBe('archiving');
+
+    const archived = SandboxStatusResponseSchema.parse({ state: 'archived' });
+    expect(archived.state).toBe('archived');
+  });
+
+  test('should default state to null when not provided', () => {
+    const result = SandboxStatusResponseSchema.parse({ sandboxId: 'test-id' });
+    expect(result.state).toBeNull();
+  });
+
+  test('should accept null state', () => {
+    const result = SandboxStatusResponseSchema.parse({ state: null });
+    expect(result.state).toBeNull();
+  });
+
+  test('should parse disk field', () => {
+    const result = SandboxStatusResponseSchema.parse({
+      sandboxId: 'test-id',
+      disk: '20g',
+    });
+    expect(result.disk).toBe('20g');
+  });
+
+  test('should default disk to null', () => {
+    const result = SandboxStatusResponseSchema.parse({ sandboxId: 'test-id' });
+    expect(result.disk).toBeNull();
+  });
+
+  test('should parse stateHistory', () => {
+    const result = SandboxStatusResponseSchema.parse({
+      sandboxId: 'test-id',
+      stateHistory: [
+        { fromState: 'pending', toState: 'running', event: 'alive', timestamp: '2026-07-09T10:00:00+08:00' },
+        { fromState: 'running', toState: 'stopped', event: 'stop', timestamp: '2026-07-09T11:00:00+08:00' },
+      ],
+    });
+    expect(result.stateHistory).toHaveLength(2);
+    expect(result.stateHistory[0]!.fromState).toBe('pending');
+    expect(result.stateHistory[1]!.event).toBe('stop');
+  });
+
+  test('should default stateHistory to empty array', () => {
+    const result = SandboxStatusResponseSchema.parse({ sandboxId: 'test-id' });
+    expect(result.stateHistory).toEqual([]);
+  });
+
+  test('backward compatibility: existing response without new fields parses correctly', () => {
+    const legacyResponse = {
+      sandboxId: '295264ad162d43e6af25cf7974a76657',
+      hostName: 'test-host',
+      hostIp: '11.166.8.116',
+      isAlive: true,
+      image: 'python:3.11',
+      cpus: 2.0,
+      memory: '8g',
+    };
+    const result = SandboxStatusResponseSchema.parse(legacyResponse);
+    expect(result.sandboxId).toBe('295264ad162d43e6af25cf7974a76657');
+    expect(result.state).toBeNull();
+    expect(result.disk).toBeNull();
+    expect(result.stateHistory).toEqual([]);
   });
 });

--- a/rock/ts-sdk/src/types/responses.ts
+++ b/rock/ts-sdk/src/types/responses.ts
@@ -8,6 +8,32 @@ import { z } from 'zod';
 import { Codes } from './codes.js';
 
 /**
+ * Sandbox state enum
+ */
+export const SandboxState = {
+  PENDING: 'pending',
+  RUNNING: 'running',
+  STOPPED: 'stopped',
+  ARCHIVING: 'archiving',
+  ARCHIVED: 'archived',
+  DELETED: 'deleted',
+} as const;
+
+export type SandboxState = (typeof SandboxState)[keyof typeof SandboxState];
+
+/**
+ * State transition record
+ */
+export const StateTransitionRecordSchema = z.object({
+  fromState: z.string(),
+  toState: z.string(),
+  event: z.string(),
+  timestamp: z.string(),
+});
+
+export type StateTransitionRecord = z.infer<typeof StateTransitionRecordSchema>;
+
+/**
  * Base sandbox response
  */
 export const SandboxResponseSchema = z.object({
@@ -46,11 +72,13 @@ export const SandboxStatusResponseSchema = z.object({
   namespace: z.string().optional(),
   cpus: z.number().optional(),
   memory: z.string().optional(),
+  disk: z.string().nullable().default(null),
   diskLimitRootfs: z.string().nullable().default(null),
-  state: z.unknown().optional(),
+  state: z.enum(['pending', 'running', 'stopped', 'archiving', 'archived', 'deleted']).nullable().default(null),
   startTime: z.string().nullable().default(null),
   stopTime: z.string().nullable().default(null),
   createTime: z.string().nullable().default(null),
+  stateHistory: z.array(StateTransitionRecordSchema).default([]),
   // Response headers info
   cluster: z.string().optional(),
   requestId: z.string().optional(),


### PR DESCRIPTION
## What changed
- Add `Sandbox.archive()` for stopped sandbox archival.
- Add optional `disk` sandbox configuration and forward it to `start_async`.
- Expose typed sandbox lifecycle states, transition history, and disk fields in status responses.
- Bump the TypeScript SDK package and lockfile version to `1.10.0`.

## Why
The TypeScript SDK needs parity with the sandbox archive lifecycle and disk configuration already available from the service.

## Validation
- `npm ci`
- `npm run build`
- `npx jest --selectProjects unit --runInBand src/sandbox/config.test.ts src/types/responses.test.ts`
- `npx jest --selectProjects unit --runInBand src/sandbox/client.test.ts --testNamePattern="Sandbox archive|disk field"`

Refs #1240