### PR TITLE
feat(proxy): support persistent OpenSandbox sessions

### DIFF
--- a/rock/admin/core/redis_key.py
+++ b/rock/admin/core/redis_key.py
@@ -1,5 +1,6 @@
 ALIVE_PREFIX = "alive:"
 TIMEOUT_PREFIX = "timeout:"
+OPENSANDBOX_SESSIONS_PREFIX = "opensandbox:sessions:"
 
 
 def alive_sandbox_key(sandbox_id: str) -> str:
@@ -8,3 +9,7 @@ def alive_sandbox_key(sandbox_id: str) -> str:
 
 def timeout_sandbox_key(sandbox_id: str) -> str:
     return f"{TIMEOUT_PREFIX}{sandbox_id}"
+
+
+def opensandbox_sessions_key(sandbox_id: str) -> str:
+    return f"{OPENSANDBOX_SESSIONS_PREFIX}{sandbox_id}"

--- a/rock/common/exception.py
+++ b/rock/common/exception.py
@@ -55,6 +55,7 @@ def handle_exceptions(error_message: str = "error occurred"):
                 return RockResponse(
                     status=ResponseStatus.FAILED,
                     message=error_message,
+                    error=str(e),
                     result=from_rock_exception(e),
                 )
             except Exception as e:

--- a/rock/sandbox/base_manager.py
+++ b/rock/sandbox/base_manager.py
@@ -101,7 +101,11 @@ class BaseManager(ABC):
     async def _collect_and_report_metrics_internal(self):
         """Collect and report metrics for all sandboxes"""
         overall_start = time.perf_counter()
-        await self._report_system_resource_metrics()
+        # CPU/memory/disk capacity is currently sourced from Ray. External
+        # orchestrators still report backend-independent sandbox counts below,
+        # but must not touch Ray when admin intentionally started without it.
+        if self.rock_config.runtime.operator_type.lower() == "ray":
+            await self._report_system_resource_metrics()
 
         sandbox_cnt, sandbox_meta = await self._collect_sandbox_meta()
         if sandbox_cnt == 0:
@@ -163,12 +167,10 @@ class BaseManager(ABC):
         return cnt, meta
 
     @abstractmethod
-    async def _auto_transition(self):
-        ...
+    async def _auto_transition(self): ...
 
     @abstractmethod
-    async def _reconcile(self):
-        ...
+    async def _reconcile(self): ...
 
     def stop_monitoring(self):
         if self.scheduler and self.scheduler.running:

--- a/rock/sandbox/operator/abstract.py
+++ b/rock/sandbox/operator/abstract.py
@@ -10,13 +10,15 @@ from rock.utils.providers.redis_provider import RedisProvider
 
 
 class AbstractOperator(ABC):
+    supports_running_delete: bool = False
+    """Whether this operator can delete a sandbox directly from RUNNING."""
+
     _redis_provider: RedisProvider | None = None
     _nacos_provider: NacosConfigProvider | None = None
     _runtime_config: RuntimeConfig | None = None
 
     @abstractmethod
-    async def submit(self, config: DeploymentConfig, user_info: dict = {}) -> SandboxInfo:
-        ...
+    async def submit(self, config: DeploymentConfig, user_info: dict = {}) -> SandboxInfo: ...
 
     @abstractmethod
     async def restart(self, config: DeploymentConfig, host_ip: str | None = None) -> SandboxInfo:
@@ -29,16 +31,13 @@ class AbstractOperator(ABC):
         ...
 
     @abstractmethod
-    async def get_status(self, sandbox_id: str) -> SandboxInfo | None:
-        ...
+    async def get_status(self, sandbox_id: str) -> SandboxInfo | None: ...
 
     @abstractmethod
-    async def stop(self, sandbox_id: str, reason: StopReason = StopReason.MANUAL) -> bool:
-        ...
+    async def stop(self, sandbox_id: str, reason: StopReason = StopReason.MANUAL) -> bool: ...
 
     @abstractmethod
-    async def delete(self, config: DeploymentConfig, host_ip: str | None = None) -> bool:
-        ...
+    async def delete(self, config: DeploymentConfig, host_ip: str | None = None) -> bool: ...
 
     async def start_archive(
         self,

--- a/rock/sandbox/operator/opensandbox/client.py
+++ b/rock/sandbox/operator/opensandbox/client.py
@@ -192,6 +192,31 @@ class OpenSandboxClient:
         async with self._runtime_handle(opensandbox_id, "execute") as handle:
             return await handle.commands.run(command, opts=opts)
 
+    async def create_session(self, opensandbox_id: str, *, cwd: str | None = None) -> str:
+        async with self._runtime_handle(opensandbox_id, "create_session") as handle:
+            return await handle.commands.create_session(working_directory=cwd)
+
+    async def run_in_session(
+        self,
+        opensandbox_id: str,
+        session_id: str,
+        command: str,
+        *,
+        timeout: float | None = None,
+        cwd: str | None = None,
+    ):
+        async with self._runtime_handle(opensandbox_id, "run_in_session") as handle:
+            return await handle.commands.run_in_session(
+                session_id,
+                command,
+                timeout=timedelta(seconds=timeout) if timeout is not None else None,
+                working_directory=cwd,
+            )
+
+    async def delete_session(self, opensandbox_id: str, session_id: str) -> None:
+        async with self._runtime_handle(opensandbox_id, "delete_session") as handle:
+            await handle.commands.delete_session(session_id)
+
     async def read_bytes(self, opensandbox_id: str, path: str) -> bytes:
         async with self._runtime_handle(opensandbox_id, "read_bytes") as handle:
             return await handle.files.read_bytes(path)

--- a/rock/sandbox/operator/opensandbox/operator.py
+++ b/rock/sandbox/operator/opensandbox/operator.py
@@ -90,6 +90,8 @@ def _qualify_image_registry(image: str, prefix: str | None) -> str:
 class OpenSandboxOperator(AbstractOperator):
     """Operator that manages sandboxes on an OpenSandbox backend."""
 
+    supports_running_delete = True
+
     def __init__(self, os_config: OpenSandboxConfig, redis_provider=None, *, client: OpenSandboxClient | None = None):
         self._os_config = os_config
         self._redis_provider = redis_provider

--- a/rock/sandbox/operator/opensandbox/operator.py
+++ b/rock/sandbox/operator/opensandbox/operator.py
@@ -22,6 +22,7 @@ from rock.deployments.config import DockerDeploymentConfig
 from rock.logger import init_logger
 from rock.sandbox.operator.abstract import AbstractOperator
 from rock.sandbox.operator.opensandbox.client import OpenSandboxClient
+from rock.sandbox.operator.opensandbox.session_registry import OpenSandboxSessionRegistry
 from rock.sdk.common.exceptions import BadRequestRockError
 
 logger = init_logger(__name__)
@@ -171,4 +172,11 @@ class OpenSandboxOperator(AbstractOperator):
             raise BadRequestRockError(f"cannot resolve opensandbox_id for sandbox {sandbox_id}")
         logger.info("[%s] opensandbox delete -> kill", sandbox_id)
         await self._client.kill(opensandbox_id)
+        if self._redis_provider is not None:
+            try:
+                await OpenSandboxSessionRegistry(self._redis_provider).clear(sandbox_id)
+            except Exception as error:
+                # The remote sandbox is already irreversibly deleted. Do not turn
+                # best-effort local metadata cleanup into a false delete failure.
+                logger.warning("[%s] failed to clear OpenSandbox session mappings: %s", sandbox_id, error)
         return True

--- a/rock/sandbox/operator/opensandbox/session_registry.py
+++ b/rock/sandbox/operator/opensandbox/session_registry.py
@@ -1,0 +1,111 @@
+import time
+from uuid import uuid4
+
+from redis.exceptions import WatchError
+
+from rock.admin.core.redis_key import opensandbox_sessions_key
+from rock.utils.providers import RedisProvider
+
+_RESERVATION_PREFIX = "__rock_session_creating__:"
+_DEFAULT_RESERVATION_TTL_SECONDS = 120
+
+
+class OpenSandboxSessionRegistry:
+    """Persist ROCK session-name mappings across Admin workers."""
+
+    def __init__(
+        self,
+        redis_provider: RedisProvider,
+        reservation_ttl_seconds: float = _DEFAULT_RESERVATION_TTL_SECONDS,
+    ):
+        self._redis = redis_provider
+        self._reservation_ttl_seconds = reservation_ttl_seconds
+
+    def _client(self):
+        return self._redis._ensure_client()
+
+    @staticmethod
+    def _is_expired_reservation(value: str | None, now: float) -> bool:
+        if value is None:
+            return True
+        if not value.startswith(_RESERVATION_PREFIX):
+            return False
+        try:
+            deadline = float(value[len(_RESERVATION_PREFIX) :].split(":", 1)[0])
+        except (TypeError, ValueError):
+            return False
+        return deadline <= now
+
+    async def reserve(self, sandbox_id: str, session_name: str) -> str | None:
+        key = opensandbox_sessions_key(sandbox_id)
+        while True:
+            now = time.time()
+            reservation = f"{_RESERVATION_PREFIX}{now + self._reservation_ttl_seconds}:{uuid4().hex}"
+            try:
+                async with self._client().pipeline(transaction=True) as pipe:
+                    await pipe.watch(key)
+                    current = await pipe.hget(key, session_name)
+                    if not self._is_expired_reservation(current, now):
+                        await pipe.unwatch()
+                        return None
+                    pipe.multi()
+                    pipe.hset(key, session_name, reservation)
+                    await pipe.execute()
+                    return reservation
+            except WatchError:
+                continue
+
+    async def commit(self, sandbox_id: str, session_name: str, reservation: str, session_id: str) -> bool:
+        key = opensandbox_sessions_key(sandbox_id)
+        while True:
+            try:
+                async with self._client().pipeline(transaction=True) as pipe:
+                    await pipe.watch(key)
+                    if await pipe.hget(key, session_name) != reservation:
+                        await pipe.unwatch()
+                        return False
+                    pipe.multi()
+                    pipe.hset(key, session_name, session_id)
+                    await pipe.execute()
+                    return True
+            except WatchError:
+                continue
+
+    async def rollback(self, sandbox_id: str, session_name: str, reservation: str) -> bool:
+        key = opensandbox_sessions_key(sandbox_id)
+        while True:
+            try:
+                async with self._client().pipeline(transaction=True) as pipe:
+                    await pipe.watch(key)
+                    if await pipe.hget(key, session_name) != reservation:
+                        await pipe.unwatch()
+                        return False
+                    pipe.multi()
+                    pipe.hdel(key, session_name)
+                    await pipe.execute()
+                    return True
+            except WatchError:
+                continue
+
+    async def remove(self, sandbox_id: str, session_name: str, session_id: str) -> bool:
+        key = opensandbox_sessions_key(sandbox_id)
+        while True:
+            try:
+                async with self._client().pipeline(transaction=True) as pipe:
+                    await pipe.watch(key)
+                    if await pipe.hget(key, session_name) != session_id:
+                        await pipe.unwatch()
+                        return False
+                    pipe.multi()
+                    pipe.hdel(key, session_name)
+                    await pipe.execute()
+                    return True
+            except WatchError:
+                continue
+
+    async def get(self, sandbox_id: str, session_name: str) -> str | None:
+        session_id = await self._client().hget(opensandbox_sessions_key(sandbox_id), session_name)
+        return None if session_id is None or session_id.startswith(_RESERVATION_PREFIX) else session_id
+
+    async def clear(self, sandbox_id: str) -> None:
+        await self._client().delete(opensandbox_sessions_key(sandbox_id))

--- a/rock/sandbox/operator/opensandbox/session_registry.py
+++ b/rock/sandbox/operator/opensandbox/session_registry.py
@@ -1,4 +1,5 @@
 import time
+from collections.abc import Callable
 from uuid import uuid4
 
 from redis.exceptions import WatchError
@@ -36,72 +37,66 @@ class OpenSandboxSessionRegistry:
             return False
         return deadline <= now
 
-    async def reserve(self, sandbox_id: str, session_name: str) -> str | None:
+    async def _update_if(
+        self,
+        sandbox_id: str,
+        session_name: str,
+        condition: Callable[[str | None], bool],
+        value: str | None,
+    ) -> bool:
         key = opensandbox_sessions_key(sandbox_id)
         while True:
-            now = time.time()
-            reservation = f"{_RESERVATION_PREFIX}{now + self._reservation_ttl_seconds}:{uuid4().hex}"
             try:
                 async with self._client().pipeline(transaction=True) as pipe:
                     await pipe.watch(key)
                     current = await pipe.hget(key, session_name)
-                    if not self._is_expired_reservation(current, now):
+                    if not condition(current):
                         await pipe.unwatch()
-                        return None
+                        return False
                     pipe.multi()
-                    pipe.hset(key, session_name, reservation)
+                    if value is None:
+                        pipe.hdel(key, session_name)
+                    else:
+                        pipe.hset(key, session_name, value)
                     await pipe.execute()
-                    return reservation
+                    return True
             except WatchError:
                 continue
+
+    async def reserve(self, sandbox_id: str, session_name: str) -> str | None:
+        now = time.time()
+        reservation = f"{_RESERVATION_PREFIX}{now + self._reservation_ttl_seconds}:{uuid4().hex}"
+        updated = await self._update_if(
+            sandbox_id,
+            session_name,
+            lambda current: self._is_expired_reservation(current, now),
+            reservation,
+        )
+        return reservation if updated else None
 
     async def commit(self, sandbox_id: str, session_name: str, reservation: str, session_id: str) -> bool:
-        key = opensandbox_sessions_key(sandbox_id)
-        while True:
-            try:
-                async with self._client().pipeline(transaction=True) as pipe:
-                    await pipe.watch(key)
-                    if await pipe.hget(key, session_name) != reservation:
-                        await pipe.unwatch()
-                        return False
-                    pipe.multi()
-                    pipe.hset(key, session_name, session_id)
-                    await pipe.execute()
-                    return True
-            except WatchError:
-                continue
+        return await self._update_if(
+            sandbox_id,
+            session_name,
+            lambda current: current == reservation,
+            session_id,
+        )
 
     async def rollback(self, sandbox_id: str, session_name: str, reservation: str) -> bool:
-        key = opensandbox_sessions_key(sandbox_id)
-        while True:
-            try:
-                async with self._client().pipeline(transaction=True) as pipe:
-                    await pipe.watch(key)
-                    if await pipe.hget(key, session_name) != reservation:
-                        await pipe.unwatch()
-                        return False
-                    pipe.multi()
-                    pipe.hdel(key, session_name)
-                    await pipe.execute()
-                    return True
-            except WatchError:
-                continue
+        return await self._update_if(
+            sandbox_id,
+            session_name,
+            lambda current: current == reservation,
+            None,
+        )
 
     async def remove(self, sandbox_id: str, session_name: str, session_id: str) -> bool:
-        key = opensandbox_sessions_key(sandbox_id)
-        while True:
-            try:
-                async with self._client().pipeline(transaction=True) as pipe:
-                    await pipe.watch(key)
-                    if await pipe.hget(key, session_name) != session_id:
-                        await pipe.unwatch()
-                        return False
-                    pipe.multi()
-                    pipe.hdel(key, session_name)
-                    await pipe.execute()
-                    return True
-            except WatchError:
-                continue
+        return await self._update_if(
+            sandbox_id,
+            session_name,
+            lambda current: current == session_id,
+            None,
+        )
 
     async def get(self, sandbox_id: str, session_name: str) -> str | None:
         session_id = await self._client().hget(opensandbox_sessions_key(sandbox_id), session_name)

--- a/rock/sandbox/operator/opensandbox/session_registry.py
+++ b/rock/sandbox/operator/opensandbox/session_registry.py
@@ -9,6 +9,7 @@ from rock.utils.providers import RedisProvider
 
 _RESERVATION_PREFIX = "__rock_session_creating__:"
 _DEFAULT_RESERVATION_TTL_SECONDS = 120
+_MAX_TRANSACTION_ATTEMPTS = 5
 
 
 class OpenSandboxSessionRegistry:
@@ -45,7 +46,7 @@ class OpenSandboxSessionRegistry:
         value: str | None,
     ) -> bool:
         key = opensandbox_sessions_key(sandbox_id)
-        while True:
+        for attempt in range(_MAX_TRANSACTION_ATTEMPTS):
             try:
                 async with self._client().pipeline(transaction=True) as pipe:
                     await pipe.watch(key)
@@ -61,7 +62,10 @@ class OpenSandboxSessionRegistry:
                     await pipe.execute()
                     return True
             except WatchError:
-                continue
+                if attempt == _MAX_TRANSACTION_ATTEMPTS - 1:
+                    raise
+
+        raise AssertionError("unreachable")
 
     async def reserve(self, sandbox_id: str, session_name: str) -> str | None:
         now = time.time()

--- a/rock/sandbox/sandbox_manager.py
+++ b/rock/sandbox/sandbox_manager.py
@@ -296,8 +296,9 @@ class SandboxManager(BaseManager):
                 }
                 sm.sandbox_info = sandbox_info
 
+        delete_event = "delete_running" if is_opensandbox and state == State.RUNNING else "delete"
         await sm.send(
-            "delete",
+            delete_event,
             sandbox_id=sandbox_id,
             operator=self._operator,
             meta_store=self._meta_store,

--- a/rock/sandbox/sandbox_manager.py
+++ b/rock/sandbox/sandbox_manager.py
@@ -269,10 +269,32 @@ class SandboxManager(BaseManager):
         if state == State.DELETED:
             logger.info(f"delete: sandbox {sandbox_id} already deleted, noop")
             return
-        if state not in (State.STOPPED, State.ARCHIVED):
+        deletable_states = {State.STOPPED, State.ARCHIVED}
+        is_opensandbox = self.rock_config.runtime.operator_type.lower() == "opensandbox"
+        if is_opensandbox:
+            # OpenSandbox exposes kill/delete rather than ROCK's stop contract,
+            # so a live remote sandbox must be directly deletable.
+            deletable_states.add(State.RUNNING)
+        if state not in deletable_states:
             raise BadRequestRockError(
                 f"Sandbox {sandbox_id} cannot be deleted: current state is '{state.value}', must be stopped or archived first"
             )
+
+        if is_opensandbox and state == State.RUNNING:
+            # Active metadata is served from Redis, while the deployment spec
+            # is stored only in the DB. Rebuild the small subset required by
+            # OpenSandboxOperator.delete so the remote sandbox is actually
+            # killed instead of merely soft-deleting ROCK's metadata.
+            sandbox_info = sm.sandbox_info or {}
+            if not sandbox_info.get("spec"):
+                sandbox_info["spec"] = {
+                    "container_name": sandbox_id,
+                    "image": sandbox_info.get("image") or DockerDeploymentConfig.model_fields["image"].default,
+                    "memory": sandbox_info.get("memory") or DockerDeploymentConfig.model_fields["memory"].default,
+                    "cpus": float(sandbox_info.get("cpus") or DockerDeploymentConfig.model_fields["cpus"].default),
+                    "extended_params": sandbox_info.get("extended_params") or {},
+                }
+                sm.sandbox_info = sandbox_info
 
         await sm.send(
             "delete",

--- a/rock/sandbox/sandbox_manager.py
+++ b/rock/sandbox/sandbox_manager.py
@@ -270,21 +270,18 @@ class SandboxManager(BaseManager):
             logger.info(f"delete: sandbox {sandbox_id} already deleted, noop")
             return
         deletable_states = {State.STOPPED, State.ARCHIVED}
-        is_opensandbox = self.rock_config.runtime.operator_type.lower() == "opensandbox"
-        if is_opensandbox:
-            # OpenSandbox exposes kill/delete rather than ROCK's stop contract,
-            # so a live remote sandbox must be directly deletable.
+        supports_running_delete = self._operator.supports_running_delete
+        if supports_running_delete:
             deletable_states.add(State.RUNNING)
         if state not in deletable_states:
             raise BadRequestRockError(
                 f"Sandbox {sandbox_id} cannot be deleted: current state is '{state.value}', must be stopped or archived first"
             )
 
-        if is_opensandbox and state == State.RUNNING:
+        if supports_running_delete and state == State.RUNNING:
             # Active metadata is served from Redis, while the deployment spec
-            # is stored only in the DB. Rebuild the small subset required by
-            # OpenSandboxOperator.delete so the remote sandbox is actually
-            # killed instead of merely soft-deleting ROCK's metadata.
+            # is stored only in the DB. Rebuild the generic deployment fields
+            # required by operators that support deleting a live sandbox.
             sandbox_info = sm.sandbox_info or {}
             if not sandbox_info.get("spec"):
                 sandbox_info["spec"] = {
@@ -296,7 +293,7 @@ class SandboxManager(BaseManager):
                 }
                 sm.sandbox_info = sandbox_info
 
-        delete_event = "delete_running" if is_opensandbox and state == State.RUNNING else "delete"
+        delete_event = "delete_running" if supports_running_delete and state == State.RUNNING else "delete"
         await sm.send(
             delete_event,
             sandbox_id=sandbox_id,

--- a/rock/sandbox/sandbox_meta_store.py
+++ b/rock/sandbox/sandbox_meta_store.py
@@ -54,6 +54,10 @@ class SandboxMetaStore:
     # Public API
     # ------------------------------------------------------------------
 
+    @property
+    def redis_provider(self) -> RedisProvider:
+        return self._redis
+
     @monitor_metastore_operation
     async def create(
         self,

--- a/rock/sandbox/sandbox_statemachine.py
+++ b/rock/sandbox/sandbox_statemachine.py
@@ -45,7 +45,7 @@ class SandboxStateMachine(StateChart):
         - stop:      pending/running → stopped  (stops operator, archives meta)
         - stop_noop: stopped → stopped  (idempotent; logs and returns)
         - alive:     pending → running  (called from get_status on pending→running; also usable by reconciler)
-        - delete:    stopped → deleted  (operator removes docker container, soft-deletes meta)
+        - delete:    running/stopped/archived → deleted (running is used by backends without stop, e.g. OpenSandbox)
     """
 
     allow_event_without_transition = False  # raise TransitionNotAllowed instead of silently ignoring invalid events
@@ -64,7 +64,7 @@ class SandboxStateMachine(StateChart):
     stop_noop = stopped.to(stopped)
     alive = pending.to(running)
     restart = stopped.to(pending)
-    delete = stopped.to(deleted) | archived.to(deleted)
+    delete = running.to(deleted) | stopped.to(deleted) | archived.to(deleted)
     archive = stopped.to(archiving)
     archive_done = archiving.to(archived)
     archive_failed = archiving.to(stopped)

--- a/rock/sandbox/sandbox_statemachine.py
+++ b/rock/sandbox/sandbox_statemachine.py
@@ -45,7 +45,8 @@ class SandboxStateMachine(StateChart):
         - stop:      pending/running → stopped  (stops operator, archives meta)
         - stop_noop: stopped → stopped  (idempotent; logs and returns)
         - alive:     pending → running  (called from get_status on pending→running; also usable by reconciler)
-        - delete:    running/stopped/archived → deleted (running is used by backends without stop, e.g. OpenSandbox)
+        - delete:    stopped/archived → deleted
+        - delete_running: running → deleted (strict remote deletion for backends without stop, e.g. OpenSandbox)
     """
 
     allow_event_without_transition = False  # raise TransitionNotAllowed instead of silently ignoring invalid events
@@ -64,7 +65,8 @@ class SandboxStateMachine(StateChart):
     stop_noop = stopped.to(stopped)
     alive = pending.to(running)
     restart = stopped.to(pending)
-    delete = running.to(deleted) | stopped.to(deleted) | archived.to(deleted)
+    delete = stopped.to(deleted) | archived.to(deleted)
+    delete_running = running.to(deleted)
     archive = stopped.to(archiving)
     archive_done = archiving.to(archived)
     archive_failed = archiving.to(stopped)
@@ -227,6 +229,33 @@ class SandboxStateMachine(StateChart):
                 await image_storage.delete(ref)
             except Exception as e:
                 logger.warning(f"delete: cleanup archive image {ref} failed: {e}")
+
+        sandbox_info["state"] = RockState.DELETED
+        sandbox_info["delete_time"] = get_iso8601_timestamp()
+        await meta_store.archive(sandbox_id, sandbox_info)
+        self.sandbox_info = sandbox_info
+
+    async def on_delete_running(
+        self,
+        sandbox_id: str,
+        operator,
+        meta_store,
+        reason: DeleteReason = DeleteReason.MANUAL,
+        dir_storage=None,
+        image_storage=None,
+    ) -> None:
+        """Delete a live sandbox without hiding a failed remote kill."""
+        logger.info(f"delete running sandbox {sandbox_id} (reason={reason.value})")
+        sandbox_info = self.sandbox_info or {}
+        if "sandbox_id" not in sandbox_info:
+            sandbox_info["sandbox_id"] = sandbox_id
+
+        spec = sandbox_info.get("spec") or {}
+        if not spec:
+            raise BadRequestRockError(f"Sandbox {sandbox_id} has no spec snapshot; cannot delete a running sandbox")
+
+        delete_config = DockerDeploymentConfig(**spec)
+        await operator.delete(delete_config, host_ip=sandbox_info.get("host_ip"))
 
         sandbox_info["state"] = RockState.DELETED
         sandbox_info["delete_time"] = get_iso8601_timestamp()

--- a/rock/sandbox/service/backends/opensandbox.py
+++ b/rock/sandbox/service/backends/opensandbox.py
@@ -1,12 +1,27 @@
+import re
 import shlex
 from io import IOBase
 from pathlib import Path
 
 from fastapi import UploadFile
 
-from rock.actions import CommandResponse, ReadFileResponse, UploadResponse, WriteFileResponse
+from rock.actions import (
+    BashObservation,
+    CloseBashSessionResponse,
+    CommandResponse,
+    CreateBashSessionResponse,
+    ReadFileResponse,
+    UploadResponse,
+    WriteFileResponse,
+)
 from rock.actions.sandbox.response import State
-from rock.admin.proto.request import SandboxCommand, SandboxReadFileRequest, SandboxWriteFileRequest
+from rock.admin.proto.request import (
+    SandboxBashAction,
+    SandboxCommand,
+    SandboxCreateBashSessionRequest,
+    SandboxReadFileRequest,
+    SandboxWriteFileRequest,
+)
 from rock.logger import init_logger
 from rock.rocklet.exceptions import CommandTimeoutError, NonZeroExitCodeError
 from rock.sandbox.operator.opensandbox.client import OpenSandboxClient
@@ -73,6 +88,110 @@ class OpenSandboxBackend:
                 message = f"{command.error_msg}: {message}"
             raise NonZeroExitCodeError(message)
         return response
+
+    @staticmethod
+    def _execution_output(execution) -> tuple[str, str]:
+        stdout = "".join(message.text for message in execution.logs.stdout)
+        stderr = "".join(message.text for message in execution.logs.stderr)
+        if execution.error:
+            stderr = f"{stderr}\n{execution.error}" if stderr else str(execution.error)
+        return stdout, stderr
+
+    async def create_session(
+        self,
+        sandbox_id: str,
+        info: dict,
+        request: SandboxCreateBashSessionRequest,
+    ) -> tuple[str, CreateBashSessionResponse]:
+        opensandbox_id = self._opensandbox_id(info)
+        if request.remote_user is not None:
+            execution = await self._client.execute(opensandbox_id, "id -un")
+            stdout, stderr = self._execution_output(execution)
+            effective_user = stdout.strip()
+            if execution.exit_code != 0 or not effective_user:
+                detail = stderr.strip() or f"exit code {execution.exit_code}"
+                raise BadRequestRockError(f"Cannot determine OpenSandbox effective user: {detail}")
+            if request.remote_user != effective_user:
+                raise BadRequestRockError(
+                    f"OpenSandbox does not support remote_user={request.remote_user}; "
+                    f"the sandbox effective user is {effective_user}"
+                )
+
+        # Execd sessions inherit the sandbox/container environment. `env_enable`
+        # must not copy the Admin process environment across the trust boundary.
+        init_commands = []
+        for key, value in (request.env or {}).items():
+            if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key) is None:
+                raise BadRequestRockError(f"Invalid environment variable name: {key!r}")
+            init_commands.append(f"export {key}={shlex.quote(value)}")
+        init_commands.extend(f"source {shlex.quote(path)}" for path in request.startup_source)
+
+        session_id = await self._client.create_session(opensandbox_id)
+        if not init_commands:
+            return session_id, CreateBashSessionResponse()
+
+        try:
+            execution = await self._client.run_in_session(
+                opensandbox_id,
+                session_id,
+                " && ".join(init_commands),
+                timeout=request.startup_timeout,
+            )
+            stdout, stderr = self._execution_output(execution)
+            if execution.error and "timeout" in execution.error.name.lower():
+                raise CommandTimeoutError(
+                    f"Timeout ({request.startup_timeout}s) exceeded while initializing OpenSandbox session"
+                )
+            if execution.exit_code != 0:
+                raise NonZeroExitCodeError(
+                    f"Failed to initialize OpenSandbox session with exit code {execution.exit_code}: "
+                    f"{(stderr or stdout)!r}"
+                )
+            return session_id, CreateBashSessionResponse(output=stdout + stderr)
+        except Exception:
+            try:
+                await self._client.delete_session(opensandbox_id, session_id)
+            except Exception as cleanup_error:
+                logger.warning(
+                    "[%s] failed to clean up OpenSandbox session after initialization: %s", sandbox_id, cleanup_error
+                )
+            raise
+
+    async def run_session(
+        self,
+        sandbox_id: str,
+        info: dict,
+        session_id: str,
+        action: SandboxBashAction,
+    ) -> BashObservation:
+        if action.is_interactive_command or action.is_interactive_quit or action.expect:
+            raise BadRequestRockError("OpenSandbox sessions do not support interactive commands")
+        execution = await self._client.run_in_session(
+            self._opensandbox_id(info),
+            session_id,
+            action.command,
+            timeout=action.timeout,
+        )
+        stdout, stderr = self._execution_output(execution)
+        if execution.error and "timeout" in execution.error.name.lower():
+            raise CommandTimeoutError(f"Timeout ({action.timeout}s) exceeded while running session command")
+        if action.check == "raise" and execution.exit_code != 0:
+            message = (
+                f"Command {action.command!r} failed with exit code {execution.exit_code}. "
+                f"Here is the output:\n{(stdout + stderr)!r}"
+            )
+            if action.error_msg:
+                message = f"{action.error_msg}: {message}"
+            raise NonZeroExitCodeError(message)
+        return BashObservation(
+            output=stdout + stderr,
+            exit_code=None if action.check == "ignore" else execution.exit_code,
+        )
+
+    async def close_session(self, sandbox_id: str, info: dict, session_id: str) -> CloseBashSessionResponse:
+        del sandbox_id
+        await self._client.delete_session(self._opensandbox_id(info), session_id)
+        return CloseBashSessionResponse()
 
     async def get_state(self, info: dict) -> State:
         remote_state = await self._client.get_state(self._opensandbox_id(info))

--- a/rock/sandbox/service/opensandbox_proxy_service.py
+++ b/rock/sandbox/service/opensandbox_proxy_service.py
@@ -26,14 +26,18 @@ from rock.admin.proto.response import SandboxStatusResponse
 from rock.common.port_validation import validate_port_forward_port
 from rock.config import RockConfig
 from rock.deployments.constants import Port
+from rock.logger import init_logger
+from rock.rocklet.exceptions import SessionDoesNotExistError, SessionExistsError
 from rock.sandbox import __version__ as gateway_version
 from rock.sandbox.operator.opensandbox.client import OpenSandboxClient
+from rock.sandbox.operator.opensandbox.session_registry import OpenSandboxSessionRegistry
 from rock.sandbox.sandbox_meta_store import SandboxMetaStore
 from rock.sandbox.service.backends.opensandbox import OpenSandboxBackend
 from rock.sandbox.service.sandbox_proxy_service import SandboxProxyService
 from rock.sdk.common.exceptions import BadRequestRockError
 
 OPENSANDBOX_BACKEND = "opensandbox"
+logger = init_logger(__name__)
 
 
 class OpenSandboxProxyService(SandboxProxyService):
@@ -44,9 +48,11 @@ class OpenSandboxProxyService(SandboxProxyService):
         rock_config: RockConfig,
         meta_store: SandboxMetaStore,
         backend: OpenSandboxBackend | None = None,
+        session_registry: OpenSandboxSessionRegistry | None = None,
     ):
         super().__init__(rock_config=rock_config, meta_store=meta_store)
         self._opensandbox_backend = backend or OpenSandboxBackend(OpenSandboxClient(rock_config.opensandbox))
+        self._session_registry = session_registry or OpenSandboxSessionRegistry(meta_store.redis_provider)
         self._opensandbox_protocol = rock_config.opensandbox.protocol
 
     async def aclose(self) -> None:
@@ -76,15 +82,60 @@ class OpenSandboxProxyService(SandboxProxyService):
 
     @monitor_sandbox_operation()
     async def create_session(self, request: CreateSessionRequest) -> CreateBashSessionResponse:
-        await self._unsupported(request.sandbox_id, "sessions")
+        await self._update_expire_time(request.sandbox_id)
+        info = await self._get_runtime_info(request.sandbox_id)
+        reservation = await self._session_registry.reserve(request.sandbox_id, request.session)
+        if reservation is None:
+            raise SessionExistsError(f"session {request.session!r} already exists")
+        session_id = None
+        try:
+            session_id, response = await self._opensandbox_backend.create_session(request.sandbox_id, info, request)
+            committed = await self._session_registry.commit(
+                request.sandbox_id,
+                request.session,
+                reservation,
+                session_id,
+            )
+            if not committed:
+                raise RuntimeError("OpenSandbox session reservation expired before commit")
+            return response
+        except Exception:
+            if session_id is not None:
+                try:
+                    await self._opensandbox_backend.close_session(request.sandbox_id, info, session_id)
+                except Exception as cleanup_error:
+                    logger.warning(
+                        "[%s] failed to clean up unregistered OpenSandbox session: %s",
+                        request.sandbox_id,
+                        cleanup_error,
+                    )
+            try:
+                await self._session_registry.rollback(request.sandbox_id, request.session, reservation)
+            except Exception as cleanup_error:
+                logger.warning(
+                    "[%s] failed to roll back OpenSandbox session reservation: %s", request.sandbox_id, cleanup_error
+                )
+            raise
 
     @monitor_sandbox_operation()
     async def run_in_session(self, action: BashAction) -> BashObservation:
-        await self._unsupported(action.sandbox_id, "sessions")
+        await self._update_expire_time(action.sandbox_id)
+        info = await self._get_runtime_info(action.sandbox_id)
+        session_id = await self._session_registry.get(action.sandbox_id, action.session)
+        if session_id is None:
+            raise SessionDoesNotExistError(f"session {action.session!r} does not exist")
+        return await self._opensandbox_backend.run_session(action.sandbox_id, info, session_id, action)
 
     @monitor_sandbox_operation()
     async def close_session(self, request: CloseBashSessionRequest) -> CloseBashSessionResponse:
-        await self._unsupported(request.sandbox_id, "sessions")
+        await self._update_expire_time(request.sandbox_id)
+        info = await self._get_runtime_info(request.sandbox_id)
+        session_id = await self._session_registry.get(request.sandbox_id, request.session)
+        if session_id is None:
+            raise SessionDoesNotExistError(f"session {request.session!r} does not exist")
+        response = await self._opensandbox_backend.close_session(request.sandbox_id, info, session_id)
+        await self._session_registry.remove(request.sandbox_id, request.session, session_id)
+        return response
 
     @monitor_sandbox_operation()
     async def is_alive(self, sandbox_id: str) -> IsAliveResponse:

--- a/tests/unit/common/test_exception_handlers.py
+++ b/tests/unit/common/test_exception_handlers.py
@@ -8,7 +8,8 @@ from fastapi.exceptions import RequestValidationError
 from httpx import ASGITransport, AsyncClient
 from pydantic import BaseModel, StringConstraints
 
-from rock.common.exception import request_validation_exception_handler
+from rock.common.exception import handle_exceptions, request_validation_exception_handler
+from rock.sdk.common.exceptions import BadRequestRockError
 
 
 class _Body(BaseModel):
@@ -27,6 +28,11 @@ def app():
     @app.get("/echo_query")
     async def _echo_query(sandbox_id: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]):
         return {"ok": True}
+
+    @app.get("/rock_error")
+    @handle_exceptions(error_message="request failed")
+    async def _rock_error():
+        raise BadRequestRockError("OpenSandbox does not support remote_user=alice; effective user is root")
 
     return app
 
@@ -82,3 +88,15 @@ async def test_valid_request_passes_through(app):
         resp = await client.post("/echo", json={"sandbox_id": "abc"})
     assert resp.status_code == 200
     assert resp.json() == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_rock_exception_message_is_exposed_in_error_field(app):
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/rock_error")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "Failed"
+    assert "remote_user=alice" in body["error"]
+    assert body["result"]["failure_reason"] == body["error"]

--- a/tests/unit/sandbox/archive/test_delete_clears_archive.py
+++ b/tests/unit/sandbox/archive/test_delete_clears_archive.py
@@ -15,6 +15,7 @@ def manager():
     m = MagicMock(spec=SandboxManager)
     m._meta_store = AsyncMock()
     m._operator = MagicMock()
+    m._operator.supports_running_delete = False
     m._dir_storage = AsyncMock()
     m._dir_storage.client_config = {"endpoint": "e", "bucket": "b", "access_key": "a", "secret_key": "s", "region": "r"}
     m._dir_storage.delete = AsyncMock(return_value=True)

--- a/tests/unit/sandbox/operator/opensandbox/test_opensandbox_client.py
+++ b/tests/unit/sandbox/operator/opensandbox/test_opensandbox_client.py
@@ -186,7 +186,12 @@ async def test_connection_config_built_from_rock_config(client):
 
 class FakeRuntimeHandle:
     def __init__(self):
-        self.commands = SimpleNamespace(run=AsyncMock(return_value=SimpleNamespace(exit_code=0)))
+        self.commands = SimpleNamespace(
+            run=AsyncMock(return_value=SimpleNamespace(exit_code=0)),
+            create_session=AsyncMock(return_value="session-1"),
+            run_in_session=AsyncMock(return_value=SimpleNamespace(exit_code=0)),
+            delete_session=AsyncMock(),
+        )
         self.files = SimpleNamespace(
             read_bytes=AsyncMock(return_value=b"hello"),
             get_file_info=AsyncMock(return_value={}),
@@ -267,6 +272,51 @@ async def test_runtime_primitives_delegate_to_handle(runtime_client):
     handle.files.get_file_info.assert_awaited_once_with(["/tmp/a"])
     handle.files.write_file.assert_awaited_once_with("/tmp/a", stream, mode=644)
     assert handle.close.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_session_primitives_delegate_to_handle(runtime_client):
+    client, _ = runtime_client
+    handle = FakeRuntimeHandle()
+    FakeSandbox.connected_handle = handle
+
+    session_id = await client.create_session("osb-1", cwd="/workspace")
+    execution = await client.run_in_session(
+        "osb-1",
+        session_id,
+        "pwd",
+        timeout=3,
+        cwd="/tmp",
+    )
+    await client.delete_session("osb-1", session_id)
+
+    assert session_id == "session-1"
+    assert execution.exit_code == 0
+    handle.commands.create_session.assert_awaited_once_with(working_directory="/workspace")
+    handle.commands.run_in_session.assert_awaited_once_with(
+        "session-1",
+        "pwd",
+        timeout=timedelta(seconds=3),
+        working_directory="/tmp",
+    )
+    handle.commands.delete_session.assert_awaited_once_with("session-1")
+    assert handle.close.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_run_in_session_preserves_unset_timeout_and_cwd(runtime_client):
+    client, _ = runtime_client
+    handle = FakeRuntimeHandle()
+    FakeSandbox.connected_handle = handle
+
+    await client.run_in_session("osb-1", "session-1", "echo ok")
+
+    handle.commands.run_in_session.assert_awaited_once_with(
+        "session-1",
+        "echo ok",
+        timeout=None,
+        working_directory=None,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/sandbox/operator/opensandbox/test_opensandbox_operator.py
+++ b/tests/unit/sandbox/operator/opensandbox/test_opensandbox_operator.py
@@ -13,6 +13,7 @@ from rock.sandbox.operator.opensandbox.operator import (
     _docker_mem_to_k8s,
     _map_state,
 )
+from rock.sandbox.operator.opensandbox.session_registry import OpenSandboxSessionRegistry
 from rock.sdk.common.exceptions import BadRequestRockError
 
 
@@ -216,3 +217,29 @@ async def test_delete_kills(operator, client):
     ok = await operator.delete(config)
     assert ok is True
     assert ("kill", "osb-1") in client.calls
+
+
+@pytest.mark.asyncio
+async def test_delete_clears_persisted_session_mappings(os_config, client, redis_provider):
+    registry = OpenSandboxSessionRegistry(redis_provider)
+    reservation = await registry.reserve("sbx-1", "worker")
+    assert reservation is not None
+    assert await registry.commit("sbx-1", "worker", reservation, "os-session-1") is True
+    operator = OpenSandboxOperator(os_config=os_config, redis_provider=redis_provider, client=client)
+
+    await operator.delete(_deployment_config(sandbox_id="sbx-1", extended_params={"opensandbox_id": "osb-1"}))
+
+    assert await registry.get("sbx-1", "worker") is None
+
+
+@pytest.mark.asyncio
+async def test_delete_succeeds_when_session_mapping_cleanup_fails(os_config, client, redis_provider, monkeypatch):
+    clear = AsyncMock(side_effect=RuntimeError("redis unavailable"))
+    monkeypatch.setattr(OpenSandboxSessionRegistry, "clear", clear)
+    operator = OpenSandboxOperator(os_config=os_config, redis_provider=redis_provider, client=client)
+
+    ok = await operator.delete(_deployment_config(sandbox_id="sbx-1", extended_params={"opensandbox_id": "osb-1"}))
+
+    assert ok is True
+    assert ("kill", "osb-1") in client.calls
+    clear.assert_awaited_once_with("sbx-1")

--- a/tests/unit/sandbox/operator/opensandbox/test_opensandbox_operator.py
+++ b/tests/unit/sandbox/operator/opensandbox/test_opensandbox_operator.py
@@ -65,6 +65,10 @@ def _deployment_config(sandbox_id="sbx-1", *, memory="8g", cpus=2, **kwargs):
 # ---- helpers ---------------------------------------------------------------
 
 
+def test_supports_running_delete(operator):
+    assert operator.supports_running_delete is True
+
+
 def test_docker_mem_to_k8s():
     assert _docker_mem_to_k8s("8g") == "8Gi"
     assert _docker_mem_to_k8s("8G") == "8Gi"

--- a/tests/unit/sandbox/service/backends/test_opensandbox_backend.py
+++ b/tests/unit/sandbox/service/backends/test_opensandbox_backend.py
@@ -6,7 +6,13 @@ import pytest
 from fastapi import UploadFile
 
 from rock.actions.sandbox.response import State
-from rock.admin.proto.request import SandboxCommand, SandboxReadFileRequest, SandboxWriteFileRequest
+from rock.admin.proto.request import (
+    SandboxBashAction,
+    SandboxCommand,
+    SandboxCreateBashSessionRequest,
+    SandboxReadFileRequest,
+    SandboxWriteFileRequest,
+)
 from rock.rocklet.exceptions import CommandTimeoutError, NonZeroExitCodeError
 from rock.sandbox.service.backends.opensandbox import OpenSandboxBackend
 from rock.sdk.common.exceptions import BadRequestRockError
@@ -258,6 +264,204 @@ async def test_get_state_maps_opensandbox_lifecycle(client, remote_state, expect
     backend = OpenSandboxBackend(client)
 
     assert await backend.get_state(_info()) == expected
+
+
+@pytest.mark.asyncio
+async def test_create_session_uses_container_user_and_does_not_copy_admin_env(client):
+    client.create_session.return_value = "session-1"
+    backend = OpenSandboxBackend(client)
+
+    session_id, response = await backend.create_session(
+        "sbx-1",
+        _info(),
+        SandboxCreateBashSessionRequest(session="default", env_enable=True, sandbox_id="sbx-1"),
+    )
+
+    assert session_id == "session-1"
+    assert response.output == ""
+    client.create_session.assert_awaited_once_with("osb-1")
+    client.execute.assert_not_awaited()
+    client.run_in_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_session_initializes_explicit_env_and_startup_sources(client):
+    client.create_session.return_value = "session-1"
+    client.run_in_session.return_value = _execution(stdout="ready\n")
+    backend = OpenSandboxBackend(client)
+
+    _, response = await backend.create_session(
+        "sbx-1",
+        _info(),
+        SandboxCreateBashSessionRequest(
+            session="default",
+            env={"GREETING": "hello world"},
+            startup_source=["/work/profile with spaces.sh"],
+            startup_timeout=3,
+            sandbox_id="sbx-1",
+        ),
+    )
+
+    assert response.output == "ready\n"
+    assert client.run_in_session.await_args.args == (
+        "osb-1",
+        "session-1",
+        "export GREETING='hello world' && source '/work/profile with spaces.sh'",
+    )
+    assert client.run_in_session.await_args.kwargs == {"timeout": 3.0}
+
+
+@pytest.mark.asyncio
+async def test_create_session_allows_explicit_effective_user(client):
+    client.execute.return_value = _execution(stdout="sandbox\n")
+    client.create_session.return_value = "session-1"
+    backend = OpenSandboxBackend(client)
+
+    await backend.create_session(
+        "sbx-1",
+        _info(),
+        SandboxCreateBashSessionRequest(session="default", remote_user="sandbox", sandbox_id="sbx-1"),
+    )
+
+    client.execute.assert_awaited_once_with("osb-1", "id -un")
+    client.create_session.assert_awaited_once_with("osb-1")
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_different_remote_user_before_creation(client):
+    client.execute.return_value = _execution(stdout="sandbox\n")
+    backend = OpenSandboxBackend(client)
+
+    with pytest.raises(BadRequestRockError, match="remote_user=root.*effective user is sandbox"):
+        await backend.create_session(
+            "sbx-1",
+            _info(),
+            SandboxCreateBashSessionRequest(session="default", remote_user="root", sandbox_id="sbx-1"),
+        )
+
+    client.create_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_session_deletes_remote_session_when_initialization_fails(client):
+    client.create_session.return_value = "session-1"
+    client.run_in_session.return_value = _execution(stderr="missing", exit_code=1)
+    backend = OpenSandboxBackend(client)
+
+    with pytest.raises(NonZeroExitCodeError, match="initialize"):
+        await backend.create_session(
+            "sbx-1",
+            _info(),
+            SandboxCreateBashSessionRequest(
+                session="default",
+                startup_source=["/missing"],
+                sandbox_id="sbx-1",
+            ),
+        )
+
+    client.delete_session.assert_awaited_once_with("osb-1", "session-1")
+
+
+@pytest.mark.asyncio
+async def test_create_session_maps_initialization_timeout_and_cleans_up(client):
+    client.create_session.return_value = "session-1"
+    client.run_in_session.return_value = _execution(
+        exit_code=None,
+        error=SimpleNamespace(name="TimeoutError", value="deadline exceeded"),
+    )
+    backend = OpenSandboxBackend(client)
+
+    with pytest.raises(CommandTimeoutError, match=r"Timeout \(3.0s\)"):
+        await backend.create_session(
+            "sbx-1",
+            _info(),
+            SandboxCreateBashSessionRequest(
+                session="default",
+                startup_source=["/slow"],
+                startup_timeout=3,
+                sandbox_id="sbx-1",
+            ),
+        )
+
+    client.delete_session.assert_awaited_once_with("osb-1", "session-1")
+
+
+@pytest.mark.asyncio
+async def test_run_session_maps_output_and_check_policy(client):
+    client.run_in_session.return_value = _execution(stdout="out", stderr="err", exit_code=2)
+    backend = OpenSandboxBackend(client)
+    action = SandboxBashAction(command="false", session="default", check="silent", sandbox_id="sbx-1")
+
+    response = await backend.run_session("sbx-1", _info(), "session-1", action)
+
+    assert response.output == "outerr"
+    assert response.exit_code == 2
+    assert response.failure_reason == ""
+    client.run_in_session.assert_awaited_once_with("osb-1", "session-1", "false", timeout=None)
+
+
+@pytest.mark.asyncio
+async def test_run_session_check_raise_uses_existing_error(client):
+    client.run_in_session.return_value = _execution(stderr="failed", exit_code=2)
+    backend = OpenSandboxBackend(client)
+
+    with pytest.raises(NonZeroExitCodeError, match="prefix"):
+        await backend.run_session(
+            "sbx-1",
+            _info(),
+            "session-1",
+            SandboxBashAction(
+                command="false",
+                session="default",
+                check="raise",
+                error_msg="prefix",
+                sandbox_id="sbx-1",
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_session_check_ignore_omits_exit_code(client):
+    client.run_in_session.return_value = _execution(stderr="failed", exit_code=2)
+    backend = OpenSandboxBackend(client)
+
+    response = await backend.run_session(
+        "sbx-1",
+        _info(),
+        "session-1",
+        SandboxBashAction(command="false", session="default", check="ignore", sandbox_id="sbx-1"),
+    )
+
+    assert response.exit_code is None
+    assert response.output == "failed"
+
+
+@pytest.mark.asyncio
+async def test_run_session_rejects_interactive_mode(client):
+    backend = OpenSandboxBackend(client)
+
+    with pytest.raises(BadRequestRockError, match="interactive"):
+        await backend.run_session(
+            "sbx-1",
+            _info(),
+            "session-1",
+            SandboxBashAction(
+                command="python",
+                session="default",
+                is_interactive_command=True,
+                sandbox_id="sbx-1",
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_close_session_deletes_remote_session(client):
+    backend = OpenSandboxBackend(client)
+
+    response = await backend.close_session("sbx-1", _info(), "session-1")
+
+    assert response.session_type == "bash"
+    client.delete_session.assert_awaited_once_with("osb-1", "session-1")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/sandbox/service/backends/test_opensandbox_session_registry.py
+++ b/tests/unit/sandbox/service/backends/test_opensandbox_session_registry.py
@@ -106,3 +106,19 @@ async def test_stale_owner_cannot_commit_or_rollback_new_reservation(redis_provi
     assert await registry.rollback("sbx-1", "default", first) is False
     assert await registry.commit("sbx-1", "default", second, "current-session") is True
     assert await registry.get("sbx-1", "default") == "current-session"
+
+
+@pytest.mark.asyncio
+async def test_update_if_applies_conditional_set_and_delete(registry):
+    def is_empty(current):
+        return current is None
+
+    def is_session(current):
+        return current == "os-session-1"
+
+    assert await registry._update_if("sbx-1", "default", is_empty, "os-session-1") is True
+    assert await registry._update_if("sbx-1", "default", is_empty, "replacement") is False
+    assert await registry.get("sbx-1", "default") == "os-session-1"
+
+    assert await registry._update_if("sbx-1", "default", is_session, None) is True
+    assert await registry.get("sbx-1", "default") is None

--- a/tests/unit/sandbox/service/backends/test_opensandbox_session_registry.py
+++ b/tests/unit/sandbox/service/backends/test_opensandbox_session_registry.py
@@ -1,4 +1,5 @@
 import pytest
+from redis.exceptions import WatchError
 
 from rock.admin.core.redis_key import opensandbox_sessions_key
 from rock.sandbox.operator.opensandbox.session_registry import OpenSandboxSessionRegistry
@@ -122,3 +123,47 @@ async def test_update_if_applies_conditional_set_and_delete(registry):
 
     assert await registry._update_if("sbx-1", "default", is_session, None) is True
     assert await registry.get("sbx-1", "default") is None
+
+
+@pytest.mark.asyncio
+async def test_update_if_stops_after_repeated_watch_conflicts(registry, monkeypatch):
+    attempts = 0
+    max_attempts = 5
+
+    class ConflictingPipeline:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def watch(self, _key):
+            return None
+
+        async def hget(self, _key, _field):
+            return None
+
+        def multi(self):
+            return None
+
+        def hset(self, _key, _field, _value):
+            return None
+
+        async def execute(self):
+            nonlocal attempts
+            attempts += 1
+            if attempts > max_attempts:
+                raise AssertionError("transaction retry limit was exceeded")
+            raise WatchError
+
+    class ConflictingClient:
+        def pipeline(self, *, transaction):
+            assert transaction is True
+            return ConflictingPipeline()
+
+    monkeypatch.setattr(registry, "_client", lambda: ConflictingClient())
+
+    with pytest.raises(WatchError):
+        await registry._update_if("sbx-1", "default", lambda current: current is None, "os-session-1")
+
+    assert attempts == max_attempts

--- a/tests/unit/sandbox/service/backends/test_opensandbox_session_registry.py
+++ b/tests/unit/sandbox/service/backends/test_opensandbox_session_registry.py
@@ -1,0 +1,108 @@
+import pytest
+
+from rock.admin.core.redis_key import opensandbox_sessions_key
+from rock.sandbox.operator.opensandbox.session_registry import OpenSandboxSessionRegistry
+
+
+@pytest.fixture
+def registry(redis_provider):
+    return OpenSandboxSessionRegistry(redis_provider)
+
+
+@pytest.mark.asyncio
+async def test_reserve_is_atomic_for_duplicate_session_names(registry):
+    assert await registry.reserve("sbx-1", "default") is not None
+    assert await registry.reserve("sbx-1", "default") is None
+
+
+@pytest.mark.asyncio
+async def test_commit_makes_session_id_available(registry):
+    reservation = await registry.reserve("sbx-1", "default")
+    assert reservation is not None
+    assert await registry.get("sbx-1", "default") is None
+
+    assert await registry.commit("sbx-1", "default", reservation, "os-session-1") is True
+
+    assert await registry.get("sbx-1", "default") == "os-session-1"
+
+
+@pytest.mark.asyncio
+async def test_rollback_releases_owned_reservation(registry):
+    reservation = await registry.reserve("sbx-1", "default")
+    assert reservation is not None
+
+    assert await registry.rollback("sbx-1", "default", reservation) is True
+
+    assert await registry.reserve("sbx-1", "default") is not None
+
+
+@pytest.mark.asyncio
+async def test_remove_deletes_committed_session(registry):
+    reservation = await registry.reserve("sbx-1", "default")
+    assert reservation is not None
+    assert await registry.commit("sbx-1", "default", reservation, "os-session-1") is True
+
+    assert await registry.remove("sbx-1", "default", "os-session-1") is True
+
+    assert await registry.get("sbx-1", "default") is None
+
+
+@pytest.mark.asyncio
+async def test_stale_session_cannot_remove_replacement_mapping(registry):
+    first = await registry.reserve("sbx-1", "default")
+    assert first is not None
+    assert await registry.commit("sbx-1", "default", first, "old-session") is True
+    assert await registry.remove("sbx-1", "default", "old-session") is True
+
+    second = await registry.reserve("sbx-1", "default")
+    assert second is not None
+    assert await registry.commit("sbx-1", "default", second, "new-session") is True
+
+    assert await registry.remove("sbx-1", "default", "old-session") is False
+    assert await registry.get("sbx-1", "default") == "new-session"
+
+
+@pytest.mark.asyncio
+async def test_clear_removes_all_sessions_for_one_sandbox_only(registry):
+    for sandbox_id, name, session_id in (
+        ("sbx-1", "default", "os-session-1"),
+        ("sbx-1", "worker", "os-session-2"),
+        ("sbx-2", "default", "os-session-3"),
+    ):
+        reservation = await registry.reserve(sandbox_id, name)
+        assert reservation is not None
+        assert await registry.commit(sandbox_id, name, reservation, session_id) is True
+
+    await registry.clear("sbx-1")
+
+    assert await registry.get("sbx-1", "default") is None
+    assert await registry.get("sbx-1", "worker") is None
+    assert await registry.get("sbx-2", "default") == "os-session-3"
+
+
+def test_registry_key_is_namespaced_by_sandbox():
+    assert opensandbox_sessions_key("sbx-1") == "opensandbox:sessions:sbx-1"
+
+
+@pytest.mark.asyncio
+async def test_expired_reservation_can_be_reclaimed(redis_provider):
+    registry = OpenSandboxSessionRegistry(redis_provider, reservation_ttl_seconds=0)
+    first = await registry.reserve("sbx-1", "default")
+    second = await registry.reserve("sbx-1", "default")
+
+    assert first is not None
+    assert second is not None
+    assert second != first
+
+
+@pytest.mark.asyncio
+async def test_stale_owner_cannot_commit_or_rollback_new_reservation(redis_provider):
+    registry = OpenSandboxSessionRegistry(redis_provider, reservation_ttl_seconds=0)
+    first = await registry.reserve("sbx-1", "default")
+    second = await registry.reserve("sbx-1", "default")
+    assert first is not None and second is not None
+
+    assert await registry.commit("sbx-1", "default", first, "stale-session") is False
+    assert await registry.rollback("sbx-1", "default", first) is False
+    assert await registry.commit("sbx-1", "default", second, "current-session") is True
+    assert await registry.get("sbx-1", "default") == "current-session"

--- a/tests/unit/sandbox/service/test_opensandbox_service_proxy.py
+++ b/tests/unit/sandbox/service/test_opensandbox_service_proxy.py
@@ -5,6 +5,12 @@ import pytest
 from starlette.datastructures import Headers
 
 from rock.actions.sandbox.response import State
+from rock.admin.proto.request import (
+    SandboxBashAction,
+    SandboxCloseBashSessionRequest,
+    SandboxCreateBashSessionRequest,
+)
+from rock.rocklet.exceptions import SessionDoesNotExistError, SessionExistsError
 from rock.sandbox.service.opensandbox_proxy_service import OPENSANDBOX_BACKEND, OpenSandboxProxyService
 from rock.sdk.common.exceptions import BadRequestRockError
 
@@ -20,12 +26,128 @@ def _info():
 @pytest.fixture
 def service():
     backend = AsyncMock()
+    registry = AsyncMock()
+    registry.reserve.return_value = "reservation-1"
+    registry.commit.return_value = True
     result = OpenSandboxProxyService.__new__(OpenSandboxProxyService)
     result._opensandbox_backend = backend
+    result._session_registry = registry
     result._opensandbox_protocol = "https"
     result._meta_store = SimpleNamespace(get=AsyncMock(return_value=_info()), update=AsyncMock())
     result._update_expire_time = AsyncMock()
     return result, backend
+
+
+@pytest.mark.asyncio
+async def test_create_session_reserves_and_commits_mapping(service):
+    proxy, backend = service
+    backend.create_session.return_value = ("os-session-1", SimpleNamespace(output="ready", session_type="bash"))
+    request = SandboxCreateBashSessionRequest(session="worker", sandbox_id="sbx-1")
+
+    response = await proxy.create_session(request)
+
+    assert response.output == "ready"
+    proxy._session_registry.reserve.assert_awaited_once_with("sbx-1", "worker")
+    backend.create_session.assert_awaited_once_with("sbx-1", _info(), request)
+    proxy._session_registry.commit.assert_awaited_once_with("sbx-1", "worker", "reservation-1", "os-session-1")
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_duplicate_before_backend_call(service):
+    proxy, backend = service
+    proxy._session_registry.reserve.return_value = None
+
+    with pytest.raises(SessionExistsError, match="worker"):
+        await proxy.create_session(SandboxCreateBashSessionRequest(session="worker", sandbox_id="sbx-1"))
+
+    backend.create_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_session_releases_reservation_when_backend_fails(service):
+    proxy, backend = service
+    backend.create_session.side_effect = RuntimeError("create failed")
+
+    with pytest.raises(RuntimeError, match="create failed"):
+        await proxy.create_session(SandboxCreateBashSessionRequest(session="worker", sandbox_id="sbx-1"))
+
+    proxy._session_registry.rollback.assert_awaited_once_with("sbx-1", "worker", "reservation-1")
+
+
+@pytest.mark.asyncio
+async def test_create_session_preserves_commit_error_when_cleanup_also_fails(service):
+    proxy, backend = service
+    backend.create_session.return_value = ("os-session-1", SimpleNamespace(output="", session_type="bash"))
+    proxy._session_registry.commit.side_effect = RuntimeError("commit failed")
+    backend.close_session.side_effect = RuntimeError("cleanup failed")
+
+    with pytest.raises(RuntimeError, match="commit failed"):
+        await proxy.create_session(SandboxCreateBashSessionRequest(session="worker", sandbox_id="sbx-1"))
+
+    proxy._session_registry.rollback.assert_awaited_once_with("sbx-1", "worker", "reservation-1")
+
+
+@pytest.mark.asyncio
+async def test_create_session_closes_remote_session_when_reservation_expires(service):
+    proxy, backend = service
+    backend.create_session.return_value = ("os-session-1", SimpleNamespace(output="", session_type="bash"))
+    proxy._session_registry.commit.return_value = False
+
+    with pytest.raises(RuntimeError, match="reservation expired"):
+        await proxy.create_session(SandboxCreateBashSessionRequest(session="worker", sandbox_id="sbx-1"))
+
+    backend.close_session.assert_awaited_once_with("sbx-1", _info(), "os-session-1")
+    proxy._session_registry.rollback.assert_awaited_once_with("sbx-1", "worker", "reservation-1")
+
+
+@pytest.mark.asyncio
+async def test_run_session_resolves_persisted_mapping(service):
+    proxy, backend = service
+    proxy._session_registry.get.return_value = "os-session-1"
+    backend.run_session.return_value = SimpleNamespace(output="ok", exit_code=0)
+    action = SandboxBashAction(command="pwd", session="worker", sandbox_id="sbx-1")
+
+    response = await proxy.run_in_session(action)
+
+    assert response.output == "ok"
+    backend.run_session.assert_awaited_once_with("sbx-1", _info(), "os-session-1", action)
+
+
+@pytest.mark.asyncio
+async def test_run_session_preserves_missing_session_error(service):
+    proxy, backend = service
+    proxy._session_registry.get.return_value = None
+
+    with pytest.raises(SessionDoesNotExistError, match="worker"):
+        await proxy.run_in_session(SandboxBashAction(command="pwd", session="worker", sandbox_id="sbx-1"))
+
+    backend.run_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_close_session_releases_mapping_only_after_remote_delete(service):
+    proxy, backend = service
+    proxy._session_registry.get.return_value = "os-session-1"
+    backend.close_session.return_value = SimpleNamespace(session_type="bash")
+    request = SandboxCloseBashSessionRequest(session="worker", sandbox_id="sbx-1")
+
+    response = await proxy.close_session(request)
+
+    assert response.session_type == "bash"
+    backend.close_session.assert_awaited_once_with("sbx-1", _info(), "os-session-1")
+    proxy._session_registry.remove.assert_awaited_once_with("sbx-1", "worker", "os-session-1")
+
+
+@pytest.mark.asyncio
+async def test_close_session_keeps_mapping_when_remote_delete_fails(service):
+    proxy, backend = service
+    proxy._session_registry.get.return_value = "os-session-1"
+    backend.close_session.side_effect = RuntimeError("delete failed")
+
+    with pytest.raises(RuntimeError, match="delete failed"):
+        await proxy.close_session(SandboxCloseBashSessionRequest(session="worker", sandbox_id="sbx-1"))
+
+    proxy._session_registry.remove.assert_not_awaited()
 
 
 class FakeHTTPResponse:

--- a/tests/unit/sandbox/service/test_runtime_backend_routing.py
+++ b/tests/unit/sandbox/service/test_runtime_backend_routing.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from rock.actions import CommandResponse
+from rock.actions import CommandResponse, CreateBashSessionResponse
 from rock.actions.sandbox.response import State
 from rock.admin.proto.request import SandboxCommand, SandboxCreateBashSessionRequest
 from rock.sandbox.service.opensandbox_proxy_service import OPENSANDBOX_BACKEND, OpenSandboxProxyService
@@ -122,14 +122,15 @@ async def test_opensandbox_is_alive_uses_backend_state(opensandbox_proxy_service
 
 
 @pytest.mark.asyncio
-async def test_opensandbox_session_is_rejected(opensandbox_proxy_service):
+async def test_opensandbox_session_routes_to_backend(opensandbox_proxy_service):
     service, backend = opensandbox_proxy_service
     service._meta_store.get = AsyncMock(return_value=_info(backend=OPENSANDBOX_BACKEND, opensandbox_id="osb-1"))
+    backend.create_session.return_value = ("os-session-1", CreateBashSessionResponse(output="ready"))
 
-    with pytest.raises(BadRequestRockError, match="does not support sessions"):
-        await service.create_session(SandboxCreateBashSessionRequest(session="test", sandbox_id="sbx-1"))
+    response = await service.create_session(SandboxCreateBashSessionRequest(session="test", sandbox_id="sbx-1"))
 
-    backend.execute.assert_not_awaited()
+    assert response.output == "ready"
+    backend.create_session.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/sandbox/test_resource_metrics_disk.py
+++ b/tests/unit/sandbox/test_resource_metrics_disk.py
@@ -1,6 +1,6 @@
 """Unit tests for disk resource metrics collection and reporting."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -67,3 +67,15 @@ async def test_report_system_resource_metrics_records_disk(sandbox_manager):
     assert calls[MetricsConstants.AVAILABLE_DISK_RESOURCE] == 60.0
     assert calls[MetricsConstants.TOTAL_CPU_RESOURCE] == 8
     assert calls[MetricsConstants.AVAILABLE_CPU_RESOURCE] == 4
+
+
+@pytest.mark.asyncio
+async def test_opensandbox_metrics_skip_ray_system_resources(sandbox_manager, monkeypatch):
+    monkeypatch.setattr(sandbox_manager.rock_config.runtime, "operator_type", "opensandbox")
+    sandbox_manager._report_system_resource_metrics = AsyncMock()
+    sandbox_manager._collect_sandbox_meta = AsyncMock(return_value=(0, {}))
+
+    await sandbox_manager._collect_and_report_metrics_internal()
+
+    sandbox_manager._report_system_resource_metrics.assert_not_awaited()
+    sandbox_manager._collect_sandbox_meta.assert_awaited_once()

--- a/tests/unit/sandbox/test_sandbox_manager_delete.py
+++ b/tests/unit/sandbox/test_sandbox_manager_delete.py
@@ -70,6 +70,32 @@ class TestDelete:
         manager._operator.delete.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_opensandbox_delete_from_running_kills_and_archives(self, manager):
+        manager.rock_config.runtime.operator_type = "opensandbox"
+        manager._meta_store.get = AsyncMock(
+            return_value={
+                "sandbox_id": "sb-1",
+                "state": State.RUNNING,
+                "host_ip": "opensandbox.local",
+                # Active sandbox metadata comes from Redis, while ``spec`` is
+                # DB-only and is therefore absent on this path.
+                "image": "python:3.11",
+                "memory": "2g",
+                "cpus": 1,
+                "extended_params": {"opensandbox_id": "osb-1", "backend": "opensandbox"},
+            }
+        )
+
+        await manager.delete("sb-1")
+
+        manager._operator.delete.assert_awaited_once()
+        delete_config = manager._operator.delete.call_args.args[0]
+        assert delete_config.container_name == "sb-1"
+        assert delete_config.extended_params["opensandbox_id"] == "osb-1"
+        manager._meta_store.archive.assert_awaited_once()
+        assert manager._meta_store.archive.call_args[0][1]["state"] == State.DELETED
+
+    @pytest.mark.asyncio
     async def test_delete_from_stopped_archives_with_deleted_state(self, manager):
         manager._meta_store.get = AsyncMock(
             return_value={

--- a/tests/unit/sandbox/test_sandbox_manager_delete.py
+++ b/tests/unit/sandbox/test_sandbox_manager_delete.py
@@ -96,6 +96,27 @@ class TestDelete:
         assert manager._meta_store.archive.call_args[0][1]["state"] == State.DELETED
 
     @pytest.mark.asyncio
+    async def test_opensandbox_delete_from_running_kill_failure_preserves_running(self, manager):
+        manager.rock_config.runtime.operator_type = "opensandbox"
+        manager._meta_store.get = AsyncMock(
+            return_value={
+                "sandbox_id": "sb-1",
+                "state": State.RUNNING,
+                "host_ip": "opensandbox.local",
+                "image": "python:3.11",
+                "memory": "2g",
+                "cpus": 1,
+                "extended_params": {"opensandbox_id": "osb-1", "backend": "opensandbox"},
+            }
+        )
+        manager._operator.delete.side_effect = RuntimeError("kill failed")
+
+        with pytest.raises(RuntimeError, match="kill failed"):
+            await manager.delete("sb-1")
+
+        manager._meta_store.archive.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_delete_from_stopped_archives_with_deleted_state(self, manager):
         manager._meta_store.get = AsyncMock(
             return_value={

--- a/tests/unit/sandbox/test_sandbox_manager_delete.py
+++ b/tests/unit/sandbox/test_sandbox_manager_delete.py
@@ -27,6 +27,7 @@ def rock_config_min():
 @pytest.fixture
 def manager(rock_config_min):
     operator = AsyncMock()
+    operator.supports_running_delete = False
     meta_store = AsyncMock()
     meta_store.get = AsyncMock(return_value=None)
     # Patch BaseManager scheduler setup so tests don't spawn APScheduler.
@@ -70,8 +71,40 @@ class TestDelete:
         manager._operator.delete.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_opensandbox_delete_from_running_kills_and_archives(self, manager):
+    async def test_running_delete_uses_operator_capability_not_backend_name(self, manager):
+        manager._operator.supports_running_delete = True
+        manager._meta_store.get = AsyncMock(
+            return_value={
+                "sandbox_id": "sb-1",
+                "state": State.RUNNING,
+                "host_ip": "remote.local",
+                "image": "python:3.11",
+                "memory": "2g",
+                "cpus": 1,
+                "extended_params": {"remote_id": "remote-1"},
+            }
+        )
+
+        await manager.delete("sb-1")
+
+        manager._operator.delete.assert_awaited_once()
+        manager._meta_store.archive.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_backend_name_does_not_enable_running_delete_without_operator_capability(self, manager):
         manager.rock_config.runtime.operator_type = "opensandbox"
+        manager._meta_store.get = AsyncMock(
+            return_value={"sandbox_id": "sb-1", "state": State.RUNNING, "host_ip": "remote.local"}
+        )
+
+        with pytest.raises(BadRequestRockError):
+            await manager.delete("sb-1")
+
+        manager._operator.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_capable_operator_delete_from_running_kills_and_archives(self, manager):
+        manager._operator.supports_running_delete = True
         manager._meta_store.get = AsyncMock(
             return_value={
                 "sandbox_id": "sb-1",
@@ -96,8 +129,8 @@ class TestDelete:
         assert manager._meta_store.archive.call_args[0][1]["state"] == State.DELETED
 
     @pytest.mark.asyncio
-    async def test_opensandbox_delete_from_running_kill_failure_preserves_running(self, manager):
-        manager.rock_config.runtime.operator_type = "opensandbox"
+    async def test_capable_operator_delete_from_running_failure_preserves_running(self, manager):
+        manager._operator.supports_running_delete = True
         manager._meta_store.get = AsyncMock(
             return_value={
                 "sandbox_id": "sb-1",

--- a/tests/unit/sandbox/test_sandbox_statemachine.py
+++ b/tests/unit/sandbox/test_sandbox_statemachine.py
@@ -345,15 +345,38 @@ class TestDeleteTransitions:
             await sm.send("delete", **self._kwargs())
 
     @pytest.mark.asyncio
-    async def test_delete_from_running_transitions_to_deleted(self):
+    async def test_delete_from_running_raises(self):
         sm = await SandboxStateMachine.from_state_value(State.RUNNING, sandbox_info={})
-        await sm.send("delete", **self._kwargs())
+        with pytest.raises(TransitionNotAllowed):
+            await sm.send("delete", **self._kwargs())
+
+    @pytest.mark.asyncio
+    async def test_delete_running_from_running_transitions_to_deleted(self):
+        sm = await SandboxStateMachine.from_state_value(State.RUNNING, sandbox_info=dict(_VALID_DELETE_INFO))
+        operator = AsyncMock()
+        meta_store = AsyncMock()
+        await sm.send("delete_running", **self._kwargs(operator=operator, meta_store=meta_store))
         assert sm.deleted.is_active
+        operator.delete.assert_awaited_once()
+        meta_store.archive.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_running_failure_preserves_running(self):
+        operator = AsyncMock()
+        operator.delete.side_effect = RuntimeError("kill failed")
+        meta_store = AsyncMock()
+        sm = await SandboxStateMachine.from_state_value(State.RUNNING, sandbox_info=dict(_VALID_DELETE_INFO))
+
+        with pytest.raises(RuntimeError, match="kill failed"):
+            await sm.send("delete_running", **self._kwargs(operator=operator, meta_store=meta_store))
+
+        assert sm.running.is_active
+        meta_store.archive.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_deleted_is_final_no_transitions_allowed(self):
         sm = await SandboxStateMachine.from_state_value(State.DELETED, sandbox_info={})
-        for event in ("stop", "stop_noop", "alive", "restart", "delete"):
+        for event in ("stop", "stop_noop", "alive", "restart", "delete", "delete_running"):
             with pytest.raises(TransitionNotAllowed):
                 await sm.send(event, **self._kwargs(), sandbox_info={})
 

--- a/tests/unit/sandbox/test_sandbox_statemachine.py
+++ b/tests/unit/sandbox/test_sandbox_statemachine.py
@@ -345,10 +345,10 @@ class TestDeleteTransitions:
             await sm.send("delete", **self._kwargs())
 
     @pytest.mark.asyncio
-    async def test_delete_from_running_raises(self):
+    async def test_delete_from_running_transitions_to_deleted(self):
         sm = await SandboxStateMachine.from_state_value(State.RUNNING, sandbox_info={})
-        with pytest.raises(TransitionNotAllowed):
-            await sm.send("delete", **self._kwargs())
+        await sm.send("delete", **self._kwargs())
+        assert sm.deleted.is_active
 
     @pytest.mark.asyncio
     async def test_deleted_is_final_no_transitions_allowed(self):


### PR DESCRIPTION
## Summary

- implement OpenSandbox `create_session`, `run_in_session`, and `close_session` through the official SDK
- persist `(sandbox_id, ROCK session name) -> OpenSandbox session id` mappings in Redis so sessions work across Admin workers
- use expiring, owner-checked Redis reservations for concurrent create/rollback/close safety and clear mappings after sandbox deletion
- preserve ROCK duplicate/missing-session, check, timeout, startup-source, and explicit environment semantics
- use the sandbox/container effective user by default; accept an explicit `remote_user` only when it matches that effective user, otherwise return a clear 4xxx unsupported error
- keep interactive session actions explicitly unsupported; do not copy the Admin process environment when `env_enable=true`

## Compatibility behavior

OpenSandbox execd owns the persistent shell process, so the session naturally inherits the sandbox/container environment and effective user. ROCK does not install or fall back to Rocklet on this path.

For `remote_user`:

- omitted: use the image/container effective user
- equal to the effective user: allowed
- different from the effective user: rejected before creating the session, rather than silently executing as another user

Explicit `env` values and `startup_source` files are initialized inside the new session. Environment names and shell values/paths are validated or quoted before execution.

## Concurrency and cleanup

The Redis registry uses optimistic transactions and opaque reservation ownership tokens:

- duplicate session names are reserved atomically across workers
- abandoned create reservations can be reclaimed after expiry
- a stale creator cannot commit or roll back a newer reservation
- a stale concurrent close cannot remove a replacement session mapping
- initialization/commit failures clean up the remote session without masking the original error
- sandbox deletion clears mappings best-effort after the irreversible remote kill

## Verification

- `ruff format --check` on all changed files: passed
- `ruff check` on all changed files: passed
- `git diff --check`: passed
- focused OpenSandbox client/operator/backend/registry/proxy/routing plus lifecycle/admin regression suite: **182 passed**
- live community OpenSandbox Docker session canary: passed (create, persistent cwd/env across calls, default effective user, explicit matching user, mismatched-user rejection, close/delete cleanup)
- live managed OpenSandbox-compatible direct-endpoint session canary: passed with the same persistence/user/cleanup coverage; credentials were injected from Keychain and were not written to source, files, or logs
- live managed deletion proof: deleting a running ROCK sandbox invoked OpenSandbox kill, removed the remote sandbox, and cleared the Redis session registry
- broader fast suite reached 726 passed before a known baseline Rocklet Docker startup failure (`test_docker_deployment`: `Container process terminated`) and a subsequent Rocklet container-start hang; the same failure reproduces on unmodified master and does not touch this PR's OpenSandbox paths
- final manual cold review found and fixed stale create-reservation poisoning, stale-owner commit/rollback, concurrent-close replacement deletion, and post-kill cleanup error handling before the final focused run

## Delivery plan

This is the required second step from #1233's delivery plan:

1. **#1233 (merged):** stateless runtime backend, files/uploads, status routing, and HTTP/WebSocket service proxying.
2. **This PR:** persistent OpenSandbox sessions with multi-worker-safe Redis mappings and cleanup.
3. **One final integration/docs PR:** gate Rocklet-only scheduler tasks for the OpenSandbox operator, add Admin-level integration coverage, and publish the user-facing backend guide and final capability matrix.

The user-facing guide remains last so it documents stable post-session behavior. Raw TCP portforward over WebSocket, mixed-operator migration within one Admin, and remote command cancellation remain outside this PR.

Refs #1202
