### PR TITLE
Load AES encryption key exclusively from YAML

### DIFF
--- a/rock-conf/rock-local.yml
+++ b/rock-conf/rock-local.yml
@@ -11,6 +11,8 @@ warmup:
     images:
       - "python:3.11"
 
+aes_encrypt_key: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
 # Image registry mirror — configured via Nacos (hot-reload supported).
 # Nacos YAML format:
 #

--- a/rock-conf/rock-test.yml
+++ b/rock-conf/rock-test.yml
@@ -12,3 +12,5 @@ ray:
 warmup:
     images:
       - "python:3.11"
+
+aes_encrypt_key: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="

--- a/rock/config.py
+++ b/rock/config.py
@@ -256,7 +256,6 @@ class ProxyServiceConfig:
     max_connections: int = 500
     max_keepalive_connections: int = 100
     batch_get_status_max_count: int = 2000
-    aes_encrypt_key: str | None = None
 
 
 @dataclass
@@ -536,6 +535,7 @@ class RockConfig:
     runtime: RuntimeConfig = field(default_factory=RuntimeConfig)
     opensandbox: OpenSandboxConfig = field(default_factory=OpenSandboxConfig)
     proxy_service: ProxyServiceConfig = field(default_factory=ProxyServiceConfig)
+    aes_encrypt_key: str | None = None
     scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
     database: DatabaseConfig = field(default_factory=DatabaseConfig)
     image_registry_mirrors: list[ImageRegistryMirror] = field(default_factory=list)
@@ -605,6 +605,8 @@ class RockConfig:
             kwargs["opensandbox"] = OpenSandboxConfig(**config["opensandbox"])
         if "proxy_service" in config:
             kwargs["proxy_service"] = ProxyServiceConfig(**config["proxy_service"])
+        if "aes_encrypt_key" in config:
+            kwargs["aes_encrypt_key"] = config["aes_encrypt_key"]
         if "scheduler" in config:
             kwargs["scheduler"] = SchedulerConfig(**config["scheduler"])
         if "database" in config:

--- a/rock/sandbox/sandbox_manager.py
+++ b/rock/sandbox/sandbox_manager.py
@@ -73,16 +73,11 @@ class SandboxManager(BaseManager):
         self._dir_storage = None
         self._image_storage = None
         self._init_archive_storage(rock_config)
-<<<<<<< HEAD
-        self._aes_encrypter = AESEncryption()
-        self._proxy_service = create_sandbox_proxy_service(rock_config=rock_config, meta_store=meta_store)
-=======
         aes_encrypt_key = rock_config.aes_encrypt_key
         if not aes_encrypt_key:
             raise ValueError("aes_encrypt_key must be configured in YAML for the admin role")
         self._aes_encrypter = AESEncryption(aes_encrypt_key)
-        self._proxy_service = SandboxProxyService(rock_config=rock_config, meta_store=meta_store)
->>>>>>> 5ef04d734 (rm aes_encrypt_key from nacos)
+        self._proxy_service = create_sandbox_proxy_service(rock_config=rock_config, meta_store=meta_store)
         logger.info("sandbox service init success")
 
     def _init_archive_storage(self, rock_config: RockConfig) -> None:

--- a/rock/sandbox/sandbox_manager.py
+++ b/rock/sandbox/sandbox_manager.py
@@ -41,7 +41,7 @@ from rock.sandbox.sandbox_meta_store import SandboxMetaStore
 from rock.sandbox.sandbox_statemachine import SandboxStateMachine, get_current_state_started_at
 from rock.sandbox.service.factory import create_sandbox_proxy_service
 from rock.sandbox.utils.timeout import SandboxTimeoutHelper
-from rock.sdk.common.exceptions import BadRequestRockError, InternalServerRockError
+from rock.sdk.common.exceptions import BadRequestRockError
 from rock.utils import REQUEST_TIMEOUT_SECONDS, StageTimer
 from rock.utils.crypto_utils import AESEncryption
 from rock.utils.format import convert_to_gb, parse_size_to_bytes
@@ -73,8 +73,16 @@ class SandboxManager(BaseManager):
         self._dir_storage = None
         self._image_storage = None
         self._init_archive_storage(rock_config)
+<<<<<<< HEAD
         self._aes_encrypter = AESEncryption()
         self._proxy_service = create_sandbox_proxy_service(rock_config=rock_config, meta_store=meta_store)
+=======
+        aes_encrypt_key = rock_config.aes_encrypt_key
+        if not aes_encrypt_key:
+            raise ValueError("aes_encrypt_key must be configured in YAML for the admin role")
+        self._aes_encrypter = AESEncryption(aes_encrypt_key)
+        self._proxy_service = SandboxProxyService(rock_config=rock_config, meta_store=meta_store)
+>>>>>>> 5ef04d734 (rm aes_encrypt_key from nacos)
         logger.info("sandbox service init success")
 
     def _init_archive_storage(self, rock_config: RockConfig) -> None:
@@ -102,15 +110,6 @@ class SandboxManager(BaseManager):
             return None
         return await SandboxStateMachine.from_state_value(info.get("state"), sandbox_info=info)
 
-    async def refresh_aes_key(self):
-        try:
-            await self.rock_config.update()
-            if aes_encrypt_key := self.rock_config.proxy_service.aes_encrypt_key:
-                self._aes_encrypter.key_update(aes_encrypt_key)
-        except Exception as e:
-            logger.error(f"update aes key failed, error: {e}")
-            raise InternalServerRockError(f"update aes key failed, {str(e)}")
-
     async def _check_sandbox_exists_in_redis(self, config: DeploymentConfig):
         if isinstance(config, DockerDeploymentConfig) and config.container_name:
             sandbox_id = config.container_name
@@ -135,7 +134,6 @@ class SandboxManager(BaseManager):
         sandbox_info["namespace"] = user_info.get("namespace", "default")
         sandbox_info["cluster_name"] = cluster_info.get("cluster_name", "default")
         rock_auth = user_info.get("rock_authorization", "default")
-        await self.refresh_aes_key()
         sandbox_info["rock_authorization_encrypted"] = self._aes_encrypter.encrypt(rock_auth)
         sandbox_info["state"] = State.PENDING
         sandbox_info["create_time"] = get_iso8601_timestamp()

--- a/tests/unit/sandbox/test_sandbox_manager_delete.py
+++ b/tests/unit/sandbox/test_sandbox_manager_delete.py
@@ -15,12 +15,16 @@ from rock.common.constants import DeleteReason
 from rock.config import RockConfig, SandboxConfig
 from rock.sandbox.sandbox_manager import SandboxManager
 from rock.sdk.common.exceptions import BadRequestRockError
+from rock.utils.crypto_utils import AESEncryption
+
+TEST_AES_ENCRYPT_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 
 
 @pytest.fixture
 def rock_config_min():
     cfg = RockConfig()
     cfg.sandbox_config = SandboxConfig()
+    cfg.aes_encrypt_key = TEST_AES_ENCRYPT_KEY
     return cfg
 
 
@@ -40,6 +44,26 @@ def manager(rock_config_min):
             operator=operator,
         )
     return m
+
+
+def test_init_requires_yaml_aes_encrypt_key():
+    config = RockConfig()
+    with (
+        patch("rock.sandbox.base_manager.BaseManager._setup_scheduler"),
+        pytest.raises(ValueError, match="aes_encrypt_key must be configured in YAML"),
+    ):
+        SandboxManager(
+            rock_config=config,
+            meta_store=AsyncMock(),
+            ray_namespace="test",
+            ray_service=MagicMock(),
+            operator=AsyncMock(),
+        )
+
+
+def test_init_uses_yaml_aes_encrypt_key(manager):
+    ciphertext = manager._aes_encrypter.encrypt("rock-authorization")
+    assert AESEncryption(TEST_AES_ENCRYPT_KEY).decrypt(ciphertext) == "rock-authorization"
 
 
 class TestDelete:

--- a/tests/unit/sandbox/test_sandbox_transitions.py
+++ b/tests/unit/sandbox/test_sandbox_transitions.py
@@ -47,7 +47,6 @@ async def mgr(mock_meta_store, mock_operator):
 
     m._aes_encrypter = MagicMock()
     m._aes_encrypter.encrypt = MagicMock(return_value="enc")
-    m.refresh_aes_key = AsyncMock()
 
     # Function to get state machine based on meta_store data — mirrors _get_current_statemachine
     async def get_current_statemachine(sandbox_id: str) -> SandboxStateMachine | None:
@@ -70,7 +69,6 @@ async def mgr(mock_meta_store, mock_operator):
 @pytest.mark.asyncio
 async def test_build_sandbox_info_metadata_does_not_refresh_aes_key(mgr):
     mgr._build_sandbox_info_metadata = SandboxManager._build_sandbox_info_metadata.__get__(mgr, SandboxManager)
-    mgr.refresh_aes_key.reset_mock()
     sandbox_info = {"memory": "1g"}
 
     await mgr._build_sandbox_info_metadata(
@@ -79,7 +77,6 @@ async def test_build_sandbox_info_metadata_does_not_refresh_aes_key(mgr):
         {},
     )
 
-    mgr.refresh_aes_key.assert_not_awaited()
     assert sandbox_info["rock_authorization_encrypted"] == "enc"
 
 

--- a/tests/unit/sandbox/test_sandbox_transitions.py
+++ b/tests/unit/sandbox/test_sandbox_transitions.py
@@ -67,6 +67,22 @@ async def mgr(mock_meta_store, mock_operator):
     return m
 
 
+@pytest.mark.asyncio
+async def test_build_sandbox_info_metadata_does_not_refresh_aes_key(mgr):
+    mgr._build_sandbox_info_metadata = SandboxManager._build_sandbox_info_metadata.__get__(mgr, SandboxManager)
+    mgr.refresh_aes_key.reset_mock()
+    sandbox_info = {"memory": "1g"}
+
+    await mgr._build_sandbox_info_metadata(
+        sandbox_info,
+        {"rock_authorization": "secret"},
+        {},
+    )
+
+    mgr.refresh_aes_key.assert_not_awaited()
+    assert sandbox_info["rock_authorization_encrypted"] == "enc"
+
+
 # ---------------------------------------------------------------------------
 # TestManagerStop
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,17 +6,13 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 import yaml
 
-<<<<<<< HEAD
 import rock.config as config_module
-from rock.config import ImageRegistryMirror, RockConfig, RuntimeConfig, _resolve_k8s_template_includes
-=======
 from rock.config import (
     ImageRegistryMirror,
     RockConfig,
     RuntimeConfig,
     _resolve_k8s_template_includes,
 )
->>>>>>> 5ef04d734 (rm aes_encrypt_key from nacos)
 
 
 @pytest.mark.asyncio
@@ -25,7 +21,6 @@ async def test_rock_config():
     assert rock_config
 
 
-<<<<<<< HEAD
 def test_logging_config_defaults_to_exception_tracebacks_enabled():
     config = config_module.LoggingConfig()
 
@@ -43,7 +38,8 @@ def test_logging_config_from_yaml(tmp_path, monkeypatch, enabled):
     rock_config = RockConfig.from_env(str(yaml_path))
 
     assert rock_config.logging.exception_traceback_enabled is enabled
-=======
+
+
 def test_aes_encrypt_key_loads_from_yaml_top_level(tmp_path):
     yaml_path = tmp_path / "rock-test.yml"
     yaml_path.write_text(
@@ -60,7 +56,6 @@ def test_aes_encrypt_key_loads_from_yaml_top_level(tmp_path):
     assert rock_config.aes_encrypt_key == "yaml-key"
     assert not hasattr(rock_config.proxy_service, "aes_encrypt_key")
     assert rock_config.proxy_service.timeout == 42.0
->>>>>>> 5ef04d734 (rm aes_encrypt_key from nacos)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,8 +6,17 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 import yaml
 
+<<<<<<< HEAD
 import rock.config as config_module
 from rock.config import ImageRegistryMirror, RockConfig, RuntimeConfig, _resolve_k8s_template_includes
+=======
+from rock.config import (
+    ImageRegistryMirror,
+    RockConfig,
+    RuntimeConfig,
+    _resolve_k8s_template_includes,
+)
+>>>>>>> 5ef04d734 (rm aes_encrypt_key from nacos)
 
 
 @pytest.mark.asyncio
@@ -16,6 +25,7 @@ async def test_rock_config():
     assert rock_config
 
 
+<<<<<<< HEAD
 def test_logging_config_defaults_to_exception_tracebacks_enabled():
     config = config_module.LoggingConfig()
 
@@ -33,6 +43,24 @@ def test_logging_config_from_yaml(tmp_path, monkeypatch, enabled):
     rock_config = RockConfig.from_env(str(yaml_path))
 
     assert rock_config.logging.exception_traceback_enabled is enabled
+=======
+def test_aes_encrypt_key_loads_from_yaml_top_level(tmp_path):
+    yaml_path = tmp_path / "rock-test.yml"
+    yaml_path.write_text(
+        yaml.safe_dump(
+            {
+                "aes_encrypt_key": "yaml-key",
+                "proxy_service": {"timeout": 42.0},
+            }
+        )
+    )
+
+    rock_config = RockConfig.from_env(str(yaml_path))
+
+    assert rock_config.aes_encrypt_key == "yaml-key"
+    assert not hasattr(rock_config.proxy_service, "aes_encrypt_key")
+    assert rock_config.proxy_service.timeout == 42.0
+>>>>>>> 5ef04d734 (rm aes_encrypt_key from nacos)
 
 
 @pytest.mark.asyncio
@@ -340,6 +368,28 @@ def test_sandbox_config_coerces_nested_dicts_from_yaml():
 
 
 # ===== Nacos hot-reload for image mirror config =====
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("yaml_key", [None, "yaml-key"])
+async def test_nacos_update_ignores_aes_encrypt_key(yaml_key):
+    rock_config = RockConfig(aes_encrypt_key=yaml_key)
+    rock_config.nacos_provider = MagicMock()
+    rock_config.nacos_provider.get_config = AsyncMock(
+        return_value={
+            "aes_encrypt_key": "nacos-top-level-key",
+            "proxy_service": {
+                "aes_encrypt_key": "nacos-proxy-key",
+                "timeout": 42.0,
+            },
+        }
+    )
+
+    await rock_config.update()
+
+    assert rock_config.aes_encrypt_key == yaml_key
+    assert not hasattr(rock_config.proxy_service, "aes_encrypt_key")
+    assert rock_config.proxy_service.timeout == 42.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
closes #1265

## Summary
Load the admin AES encryption key only from top-level YAML and fail startup when the key is missing or invalid.

## Key changes
- Move `aes_encrypt_key` out of `proxy_service` and ignore legacy Nacos values while preserving other proxy configuration updates.
- Initialize encryption once during admin startup without random fallback or runtime refresh.
- Add regression coverage and a fixed test-only YAML key.