### PR TITLE
feat(k8s): add template selector

### DIFF
--- a/rock/config.py
+++ b/rock/config.py
@@ -341,6 +341,28 @@ class PoolConfig:
 
 
 @dataclass
+class TemplateSelectorRule:
+    """Template selector rule for matching sandbox config to a K8s template.
+
+    Rules are loaded from Nacos (key ``template_rules``) as a mapping where
+    the key is the template name and the value is the rule conditions.
+    All matching conditions are optional; a rule matches only when every
+    specified condition is satisfied.
+
+    ``image`` supports shell-style wildcards (``*``, ``?``) and may be a
+    single pattern or a list of patterns. ``image_os`` and
+    ``accelerator_types`` are lists of allowed values. ``min_num_gpus``/
+    ``max_num_gpus`` define an inclusive GPU count range.
+    """
+
+    image: str | list[str] | None = None
+    image_os: list[str] | None = None
+    min_num_gpus: float | None = None
+    max_num_gpus: float | None = None
+    accelerator_types: list[str] | None = None
+
+
+@dataclass
 class K8sConfig:
     """Kubernetes configuration for K8s operator."""
 
@@ -354,9 +376,6 @@ class K8sConfig:
     # conflict) then lets the inline `templates` block override. After loading
     # the field is consumed (cleared) so K8sConfig only carries `templates`.
     template_includes: list[str] = field(default_factory=list)
-
-    # Template mapping: image_os -> template_name, e.g., {"windows": "windows_template", "linux": "default"}
-    template_map: dict[str, str] = field(default_factory=dict)
 
     # API client rate limiting
     api_qps: float = 20.0  # Queries per second

--- a/rock/sandbox/operator/k8s/constants.py
+++ b/rock/sandbox/operator/k8s/constants.py
@@ -27,8 +27,7 @@ class K8sConstants:
 
     # Built-in template names
     TEMPLATE_DEFAULT = "default"
-    TEMPLATE_GPU_SINGLE = "gpu-single"
-    TEMPLATE_GPU_MULTI = "gpu-multi"
 
     # Nacos config keys
     NACOS_POOLS_KEY = "pools"
+    NACOS_TEMPLATE_RULES_KEY = "template_rules"

--- a/rock/sandbox/operator/k8s/provider.py
+++ b/rock/sandbox/operator/k8s/provider.py
@@ -346,12 +346,21 @@ class BatchSandboxProvider(K8sProvider):
             nacos_config = await self._nacos_provider.get_config()
             if nacos_config and K8sConstants.NACOS_TEMPLATE_RULES_KEY in nacos_config:
                 rules_data = nacos_config[K8sConstants.NACOS_TEMPLATE_RULES_KEY]
+                if not isinstance(rules_data, dict):
+                    logger.warning(
+                        f"Invalid template_rules config: expected dict, got {type(rules_data).__name__}"
+                    )
+                    return {}
+
                 rules: dict[str, TemplateSelectorRule] = {}
                 for template_name, rule_data in rules_data.items():
                     if isinstance(rule_data, dict):
                         rules[template_name] = TemplateSelectorRule(**rule_data)
                     else:
-                        rules[template_name] = TemplateSelectorRule()
+                        logger.warning(
+                            f"Skipping invalid template rule {template_name!r}: "
+                            f"expected dict, got {type(rule_data).__name__}"
+                        )
                 logger.debug(f"Loaded {len(rules)} template rules from Nacos")
                 return rules
 

--- a/rock/sandbox/operator/k8s/provider.py
+++ b/rock/sandbox/operator/k8s/provider.py
@@ -1,6 +1,7 @@
 """K8s provider implementations for managing sandbox resources."""
 
 import base64
+import fnmatch
 import json
 import os
 import re
@@ -14,7 +15,7 @@ from kubernetes import config as k8s_config
 
 from rock.actions.sandbox.config import RemoteSandboxRuntimeConfig
 from rock.actions.sandbox.sandbox_info import SandboxInfo
-from rock.config import K8sConfig, PoolConfig
+from rock.config import K8sConfig, PoolConfig, TemplateSelectorRule
 from rock.deployments.config import DockerDeploymentConfig
 from rock.deployments.constants import Port
 from rock.logger import init_logger
@@ -129,6 +130,83 @@ class ResourceMatchingPoolSelector(PoolSelector):
         matching_pools.sort(key=lambda x: x[2])
         best_pool_name, _, _ = matching_pools[0]
         return best_pool_name
+
+
+class TemplateSelector(ABC):
+    """Abstract base class for template selection strategy."""
+
+    @abstractmethod
+    def select_template(
+        self,
+        config: DockerDeploymentConfig,
+        rules: dict[str, TemplateSelectorRule],
+    ) -> str | None:
+        """Select a template for the given deployment config.
+
+        Args:
+            config: Docker deployment configuration
+            rules: Available template selector rules
+
+        Returns:
+            Selected template name or None if no rule matches
+        """
+        pass
+
+
+class DefaultTemplateSelector(TemplateSelector):
+    """Template selector that matches by optional image/image_os/gpu criteria.
+
+    Selection criteria:
+    1. ``template_rules`` is a mapping from template name to rule conditions.
+    2. All specified conditions in a rule must match the config.
+    3. Rules are evaluated in declaration order; the first matching rule wins.
+    """
+
+    def select_template(
+        self,
+        config: DockerDeploymentConfig,
+        rules: dict[str, TemplateSelectorRule],
+    ) -> str | None:
+        """Select best matching template based on rules."""
+        if not rules:
+            return None
+
+        for template_name, rule in rules.items():
+            if self._matches(config, rule):
+                return template_name
+
+        return None
+
+    def _matches(
+        self,
+        config: DockerDeploymentConfig,
+        rule: TemplateSelectorRule,
+    ) -> bool:
+        """Check whether a rule matches the sandbox config."""
+        # image: "python:3.11" / "python:*" / ["python:3.11", "custom:*"]
+        if rule.image is not None:
+            image_patterns = [rule.image] if isinstance(rule.image, str) else rule.image
+            if not any(fnmatch.fnmatch(config.image, pattern) for pattern in image_patterns):
+                return False
+
+        # image_os: ["linux", "windows"]
+        if rule.image_os is not None:
+            if config.image_os not in rule.image_os:
+                return False
+
+        # num_gpus range: min_num_gpus / max_num_gpus, e.g. 0, 0.5, 1, 8
+        config_num_gpus = config.num_gpus or 0
+        if rule.min_num_gpus is not None and config_num_gpus < rule.min_num_gpus:
+            return False
+        if rule.max_num_gpus is not None and config_num_gpus > rule.max_num_gpus:
+            return False
+
+        # accelerator_types: ["A100", "H20"]
+        if rule.accelerator_types is not None:
+            if config.accelerator_type not in rule.accelerator_types:
+                return False
+
+        return True
 
 
 class K8sProvider(Protocol):
@@ -255,6 +333,27 @@ class BatchSandboxProvider(K8sProvider):
                         pools[name] = config
                 logger.debug(f"Loaded {len(pools)} pools from Nacos")
                 return pools
+
+        return {}
+
+    async def _get_template_rules(self) -> dict[str, TemplateSelectorRule]:
+        """Get template selector rules from Nacos.
+
+        Returns:
+            Mapping from template name to TemplateSelectorRule
+        """
+        if self._nacos_provider:
+            nacos_config = await self._nacos_provider.get_config()
+            if nacos_config and K8sConstants.NACOS_TEMPLATE_RULES_KEY in nacos_config:
+                rules_data = nacos_config[K8sConstants.NACOS_TEMPLATE_RULES_KEY]
+                rules: dict[str, TemplateSelectorRule] = {}
+                for template_name, rule_data in rules_data.items():
+                    if isinstance(rule_data, dict):
+                        rules[template_name] = TemplateSelectorRule(**rule_data)
+                    else:
+                        rules[template_name] = TemplateSelectorRule()
+                logger.debug(f"Loaded {len(rules)} template rules from Nacos")
+                return rules
 
         return {}
 
@@ -444,16 +543,13 @@ class BatchSandboxProvider(K8sProvider):
         logger.info(f"Available pools from Nacos: {list(pools.keys())}")
         return ResourceMatchingPoolSelector().select_pool(config, pools)
 
-    def _get_template_name(self, config: DockerDeploymentConfig) -> str:
-        """Get template name from extended_params, GPU detection, or template_map.
+    async def _get_template_name(self, config: DockerDeploymentConfig) -> str:
+        """Get template name from extended_params or Nacos template_rules.
 
         Priority:
         1. Check extended_params for explicit template name
-        2. If config.num_gpus == 1, auto-select 'gpu-single' (single full card)
-        3. If config.num_gpus > 0 and != 1, auto-select 'gpu-multi'
-           (covers fractional shares <1 and multi-card >1)
-        4. Fallback to template_map based on image_os matching
-        5. Return 'default' if not found
+        2. Use Nacos template_rules selector (DefaultTemplateSelector)
+        3. Return 'default' if not found
 
         Args:
             config: Docker deployment configuration
@@ -466,22 +562,13 @@ class BatchSandboxProvider(K8sProvider):
         if template_name:
             return template_name
 
-        # Priority 2: Single full GPU goes to the single-card template
-        if config.num_gpus is not None and config.num_gpus == 1:
-            return K8sConstants.TEMPLATE_GPU_SINGLE
+        # Priority 2: Use Nacos template_rules selector
+        rules = await self._get_template_rules()
+        selected_template = DefaultTemplateSelector().select_template(config, rules)
+        if selected_template:
+            return selected_template
 
-        # Priority 3: Any other positive num_gpus (fractional <1 or multi >1)
-        # routes to the multi-GPU template
-        if config.num_gpus is not None and config.num_gpus > 0:
-            return K8sConstants.TEMPLATE_GPU_MULTI
-
-        # Priority 4: Check template_map based on image_os
-        if config.image_os and self._k8s_config.template_map:
-            mapped_template = self._k8s_config.template_map.get(config.image_os)
-            if mapped_template:
-                return mapped_template
-
-        # Priority 5: Return default
+        # Priority 3: Return default
         return K8sConstants.TEMPLATE_DEFAULT
 
     def _normalize_memory(self, memory: str) -> str:
@@ -595,7 +682,7 @@ class BatchSandboxProvider(K8sProvider):
             return manifest
 
         # Template mode: build from template
-        template_name = self._get_template_name(config)
+        template_name = await self._get_template_name(config)
 
         # Build manifest using template loader. Auth info is passed to the
         # template so the template itself decides where to render it.

--- a/tests/unit/sandbox/operator/test_k8s_provider.py
+++ b/tests/unit/sandbox/operator/test_k8s_provider.py
@@ -477,6 +477,31 @@ class TestGetTemplateRulesFromNacos:
         rules = await provider._get_template_rules()
         assert rules == {}
 
+    async def test_returns_empty_when_template_rules_is_not_dict(self):
+        """Return empty dict when template_rules value is not a dict."""
+        provider = make_provider()
+        provider.set_nacos_provider(
+            MockNacosProvider({K8sConstants.NACOS_TEMPLATE_RULES_KEY: ["not-a-dict"]})
+        )
+
+        rules = await provider._get_template_rules()
+        assert rules == {}
+
+    async def test_skips_invalid_rule_entries(self):
+        """Skip rule entries that are not dicts and keep valid ones."""
+        nacos_config = {
+            K8sConstants.NACOS_TEMPLATE_RULES_KEY: {
+                "valid-rule": {"image_os": ["linux"]},
+                "invalid-rule": "not-a-dict",
+            }
+        }
+        provider = make_provider()
+        provider.set_nacos_provider(MockNacosProvider(nacos_config))
+
+        rules = await provider._get_template_rules()
+        assert list(rules.keys()) == ["valid-rule"]
+        assert rules["valid-rule"].image_os == ["linux"]
+
 
 # ========== _get_pool_ports ==========
 

--- a/tests/unit/sandbox/operator/test_k8s_provider.py
+++ b/tests/unit/sandbox/operator/test_k8s_provider.py
@@ -2,11 +2,15 @@
 
 import pytest
 
-from rock.config import K8sConfig, PoolConfig
+from rock.config import K8sConfig, PoolConfig, TemplateSelectorRule
 from rock.deployments.config import DockerDeploymentConfig
 from rock.deployments.constants import Port
 from rock.sandbox.operator.k8s.constants import K8sConstants
-from rock.sandbox.operator.k8s.provider import BatchSandboxProvider, ResourceMatchingPoolSelector
+from rock.sandbox.operator.k8s.provider import (
+    BatchSandboxProvider,
+    DefaultTemplateSelector,
+    ResourceMatchingPoolSelector,
+)
 
 BASIC_TEMPLATES = {
     "default": {
@@ -20,12 +24,11 @@ BASIC_TEMPLATES = {
 }
 
 
-def make_provider(template_map: dict = None) -> BatchSandboxProvider:
+def make_provider() -> BatchSandboxProvider:
     return BatchSandboxProvider(
         k8s_config=K8sConfig(
             kubeconfig_path=None,
             templates=BASIC_TEMPLATES,
-            template_map=template_map or {},
         )
     )
 
@@ -37,6 +40,7 @@ def make_config(
     extended_params: dict = None,
     image_os: str = "linux",
     num_gpus: float | None = None,
+    accelerator_type: str | None = None,
     disk: str | None = None,
     limit_cpus: float | None = None,
 ) -> DockerDeploymentConfig:
@@ -48,6 +52,7 @@ def make_config(
         extended_params=extended_params or {},
         image_os=image_os,
         num_gpus=num_gpus,
+        accelerator_type=accelerator_type,
         disk=disk,
         limit_cpus=limit_cpus,
     )
@@ -220,71 +225,257 @@ class TestGetPoolName:
 
 
 class TestGetTemplateName:
-    def test_returns_template_from_extended_params(self):
-        """Return template directly from extended_params without using template_map."""
+    async def test_returns_template_from_extended_params(self):
+        """Return template directly from extended_params without using selector."""
         provider = make_provider()
         config = make_config(extended_params={"template_name": "gpu_template"})
-        assert provider._get_template_name(config) == "gpu_template"
+        assert await provider._get_template_name(config) == "gpu_template"
 
-    def test_extended_params_takes_priority_over_template_map(self):
-        """extended_params takes priority over template_map."""
-        provider = make_provider(template_map={"linux": "map_template"})
-        config = make_config(extended_params={"template_name": "ext_template"}, image_os="linux")
-        assert provider._get_template_name(config) == "ext_template"
-
-    def test_returns_template_from_template_map_by_image_os(self):
-        """Priority 2: Look up template_map by image_os when extended_params is empty."""
-        provider = make_provider(template_map={"windows": "windows_template"})
-        config = make_config(image_os="windows")
-        assert provider._get_template_name(config) == "windows_template"
-
-    def test_returns_default_when_image_os_not_in_template_map(self):
-        """Return 'default' when image_os is not in template_map."""
-        provider = make_provider(template_map={"windows": "windows_template"})
-        config = make_config(image_os="linux")
-        assert provider._get_template_name(config) == "default"
-
-    def test_returns_default_when_no_image_os(self):
-        """Skip template_map lookup when image_os is empty, return 'default'."""
-        provider = make_provider(template_map={"windows": "windows_template"})
-        config = make_config(image_os="")
-        assert provider._get_template_name(config) == "default"
-
-    def test_returns_default_when_template_map_empty(self):
-        """Return 'default' when template_map is empty."""
-        provider = make_provider(template_map={})
-        config = make_config(image_os="windows")
-        assert provider._get_template_name(config) == "default"
-
-    def test_returns_default_when_no_params_and_no_template_map(self):
-        """Return 'default' when both extended_params and template_map are empty."""
+    async def test_returns_default_when_no_params_and_no_rules(self):
+        """Return 'default' when extended_params and Nacos rules are empty."""
         provider = make_provider()
         config = make_config()
-        assert provider._get_template_name(config) == "default"
+        assert await provider._get_template_name(config) == "default"
 
-    def test_returns_gpu_single_when_num_gpus_is_one(self):
-        """num_gpus == 1 (single full card) routes to 'gpu-single'."""
+    async def test_returns_template_from_nacos_rules(self):
+        """Return template selected by Nacos template_rules."""
         provider = make_provider()
+        provider.set_nacos_provider(
+            MockNacosProvider(
+                {
+                    K8sConstants.NACOS_TEMPLATE_RULES_KEY: {
+                        "gpu-a100-single": {
+                            "min_num_gpus": 1,
+                            "max_num_gpus": 1,
+                            "accelerator_types": ["A100"],
+                        }
+                    }
+                }
+            )
+        )
+        config = make_config(num_gpus=1, accelerator_type="A100")
+        assert await provider._get_template_name(config) == "gpu-a100-single"
+
+    async def test_extended_params_takes_priority_over_nacos_rules(self):
+        """extended_params template_name beats Nacos template_rules."""
+        provider = make_provider()
+        provider.set_nacos_provider(
+            MockNacosProvider(
+                {
+                    K8sConstants.NACOS_TEMPLATE_RULES_KEY: {
+                        "gpu-a100-single": {
+                            "min_num_gpus": 1,
+                            "max_num_gpus": 1,
+                            "accelerator_types": ["A100"],
+                        }
+                    }
+                }
+            )
+        )
+        config = make_config(
+            extended_params={"template_name": "custom"},
+            num_gpus=1,
+            accelerator_type="A100",
+        )
+        assert await provider._get_template_name(config) == "custom"
+
+    async def test_returns_default_when_nacos_rules_do_not_match(self):
+        """Return 'default' when Nacos rules do not match the config."""
+        provider = make_provider()
+        provider.set_nacos_provider(
+            MockNacosProvider(
+                {
+                    K8sConstants.NACOS_TEMPLATE_RULES_KEY: {
+                        "gpu-a100-single": {
+                            "min_num_gpus": 1,
+                            "max_num_gpus": 1,
+                            "accelerator_types": ["A100"],
+                        }
+                    }
+                }
+            )
+        )
         config = make_config(num_gpus=1)
-        assert provider._get_template_name(config) == K8sConstants.TEMPLATE_GPU_SINGLE
+        # No accelerator_type, so A100-only rule does not match
+        assert await provider._get_template_name(config) == "default"
 
-    def test_returns_gpu_multi_when_fractional_lt_one(self):
-        """Fractional GPU (0 < num_gpus < 1) routes to 'gpu-multi'."""
-        provider = make_provider()
-        config = make_config(num_gpus=0.5)
-        assert provider._get_template_name(config) == K8sConstants.TEMPLATE_GPU_MULTI
 
-    def test_returns_gpu_multi_when_num_gpus_gt_one(self):
-        """Multi-GPU (num_gpus > 1) routes to 'gpu-multi'."""
-        provider = make_provider()
-        config = make_config(num_gpus=2)
-        assert provider._get_template_name(config) == K8sConstants.TEMPLATE_GPU_MULTI
+# ========== DefaultTemplateSelector ==========
 
-    def test_extended_params_takes_priority_over_gpu_routing(self):
-        """extended_params template_name beats the GPU auto-selection."""
+
+class TestDefaultTemplateSelector:
+    def test_select_by_gpu_count_range_and_type(self):
+        """Select template by num_gpus range and accelerator_type."""
+        selector = DefaultTemplateSelector()
+        rules = {
+            "gpu-a100-single": TemplateSelectorRule(
+                min_num_gpus=1,
+                max_num_gpus=1,
+                accelerator_types=["A100"],
+            ),
+            "gpu-a100-multi": TemplateSelectorRule(
+                min_num_gpus=2,
+                accelerator_types=["A100"],
+            ),
+        }
+        config = make_config(num_gpus=1, accelerator_type="A100")
+        assert selector.select_template(config, rules) == "gpu-a100-single"
+
+    def test_select_multi_gpu_by_type(self):
+        """Select multi-GPU template by accelerator_type."""
+        selector = DefaultTemplateSelector()
+        rules = {
+            "gpu-a100-single": TemplateSelectorRule(
+                min_num_gpus=1,
+                max_num_gpus=1,
+                accelerator_types=["A100"],
+            ),
+            "gpu-a100-multi": TemplateSelectorRule(
+                min_num_gpus=2,
+                accelerator_types=["A100"],
+            ),
+        }
+        config = make_config(num_gpus=4, accelerator_type="A100")
+        assert selector.select_template(config, rules) == "gpu-a100-multi"
+
+    def test_select_cpu_when_no_gpu(self):
+        """Select CPU template when num_gpus is 0/None."""
+        selector = DefaultTemplateSelector()
+        rules = {
+            "default": TemplateSelectorRule(image_os=["linux"], max_num_gpus=0),
+            "gpu-a100-single": TemplateSelectorRule(
+                min_num_gpus=1,
+                max_num_gpus=1,
+                accelerator_types=["A100"],
+            ),
+        }
+        config = make_config(num_gpus=None, image_os="linux")
+        assert selector.select_template(config, rules) == "default"
+
+    def test_first_matching_rule_wins(self):
+        """Rules are evaluated in declaration order; first match wins."""
+        selector = DefaultTemplateSelector()
+        rules = {
+            "template-first": TemplateSelectorRule(image_os=["linux"]),
+            "template-second": TemplateSelectorRule(image_os=["linux"]),
+        }
+        config = make_config(image_os="linux")
+        assert selector.select_template(config, rules) == "template-first"
+
+    def test_image_filter(self):
+        """image condition filters out non-matching rules."""
+        selector = DefaultTemplateSelector()
+        rules = {
+            "py311-template": TemplateSelectorRule(image="python:3.11"),
+            "py312-template": TemplateSelectorRule(image="python:3.12"),
+        }
+        config = make_config(image="python:3.12")
+        assert selector.select_template(config, rules) == "py312-template"
+
+    def test_image_wildcard_match(self):
+        """image supports shell-style wildcards."""
+        selector = DefaultTemplateSelector()
+        rules = {
+            "py-template": TemplateSelectorRule(image="python:*"),
+            "other-template": TemplateSelectorRule(image="*"),
+        }
+        config = make_config(image="python:3.12")
+        assert selector.select_template(config, rules) == "py-template"
+
+    def test_image_list_match(self):
+        """image supports a list of patterns."""
+        selector = DefaultTemplateSelector()
+        rules = {
+            "py-template": TemplateSelectorRule(image=["python:3.11", "python:3.12"]),
+        }
+        config = make_config(image="python:3.11")
+        assert selector.select_template(config, rules) == "py-template"
+
+    def test_image_os_list_match(self):
+        """image_os supports a list of values."""
+        selector = DefaultTemplateSelector()
+        rules = {
+            "non-linux-template": TemplateSelectorRule(image_os=["windows", "android"]),
+        }
+        config = make_config(image_os="android")
+        assert selector.select_template(config, rules) == "non-linux-template"
+
+    def test_accelerator_types_list_match(self):
+        """accelerator_types supports multiple accelerator types."""
+        selector = DefaultTemplateSelector()
+        rules = {
+            "gpu-template": TemplateSelectorRule(accelerator_types=["A100", "H20"]),
+        }
+        config = make_config(num_gpus=1, accelerator_type="H20")
+        assert selector.select_template(config, rules) == "gpu-template"
+
+    def test_fractional_gpu_in_range(self):
+        """Fractional num_gpus falls within min/max range."""
+        selector = DefaultTemplateSelector()
+        rules = {
+            "gpu-shared": TemplateSelectorRule(
+                min_num_gpus=0.1,
+                max_num_gpus=0.9,
+                accelerator_types=["A100"],
+            ),
+        }
+        config = make_config(num_gpus=0.5, accelerator_type="A100")
+        assert selector.select_template(config, rules) == "gpu-shared"
+
+    def test_returns_none_when_no_match(self):
+        """Return None when no rule matches."""
+        selector = DefaultTemplateSelector()
+        rules = {
+            "gpu-a100": TemplateSelectorRule(accelerator_types=["A100"]),
+        }
+        config = make_config(num_gpus=1, accelerator_type="H20")
+        assert selector.select_template(config, rules) is None
+
+    def test_returns_none_when_rules_empty(self):
+        """Return None when rules dict is empty."""
+        selector = DefaultTemplateSelector()
+        config = make_config()
+        assert selector.select_template(config, {}) is None
+
+
+# ========== _get_template_rules from nacos ==========
+
+
+class TestGetTemplateRulesFromNacos:
+    async def test_get_template_rules_from_nacos(self):
+        """Get template rules from Nacos."""
+        nacos_config = {
+            K8sConstants.NACOS_TEMPLATE_RULES_KEY: {
+                "gpu-a100-single": {
+                    "min_num_gpus": 1,
+                    "max_num_gpus": 1,
+                    "accelerator_types": ["A100"],
+                }
+            }
+        }
         provider = make_provider()
-        config = make_config(extended_params={"template_name": "custom"}, num_gpus=4)
-        assert provider._get_template_name(config) == "custom"
+        provider.set_nacos_provider(MockNacosProvider(nacos_config))
+
+        rules = await provider._get_template_rules()
+        assert len(rules) == 1
+        assert "gpu-a100-single" in rules
+        assert rules["gpu-a100-single"].min_num_gpus == 1
+        assert rules["gpu-a100-single"].max_num_gpus == 1
+        assert rules["gpu-a100-single"].accelerator_types == ["A100"]
+
+    async def test_returns_empty_when_no_nacos_provider(self):
+        """Return empty dict when no nacos provider."""
+        provider = make_provider()
+        rules = await provider._get_template_rules()
+        assert rules == {}
+
+    async def test_returns_empty_when_nacos_has_no_rules(self):
+        """Return empty dict when Nacos has no template_rules config."""
+        provider = make_provider()
+        provider.set_nacos_provider(MockNacosProvider({"other_key": "value"}))
+
+        rules = await provider._get_template_rules()
+        assert rules == {}
 
 
 # ========== _get_pool_ports ==========
@@ -503,7 +694,6 @@ def make_resource_provider() -> BatchSandboxProvider:
         k8s_config=K8sConfig(
             kubeconfig_path=None,
             templates=RESOURCE_TEMPLATES,
-            template_map={},
         )
     )
 
@@ -560,7 +750,6 @@ def _make_provider_with_templates(templates: dict) -> BatchSandboxProvider:
         k8s_config=K8sConfig(
             kubeconfig_path=None,
             templates=templates,
-            template_map={},
         )
     )
 


### PR DESCRIPTION
Closes #1273

## Summary

This PR introduces `DefaultTemplateSelector` for the K8s operator and removes the legacy hard-coded template selection logic.

## Changes

- Added `TemplateSelectorRule` dataclass with fuzzy matching support:
  - `image`: string / wildcard / list of patterns (via `fnmatch`)
  - `image_os`: list of OS values
  - `min_num_gpus` / `max_num_gpus`: inclusive GPU count range
  - `accelerator_types`: list of accelerator types
- Added `DefaultTemplateSelector.select_template(config, rules)` which returns the first matching template name.
- `_get_template_rules()` loads `template_rules` from Nacos dynamically.
- `_get_template_name()` now has a simplified priority:
  1. `extended_params[template_name]`
  2. Nacos `template_rules` via `DefaultTemplateSelector`
  3. fallback to `default`
- Removed redundant logic and configuration:
  - Deleted `K8sConfig.template_map`
  - Deleted `K8sConstants.TEMPLATE_GPU_SINGLE` and `TEMPLATE_GPU_MULTI`
  - Removed hard-coded GPU auto-routing in `_get_template_name()`
  - Removed related unit tests and test helpers

## Verification

```bash
python -m pytest tests/unit/sandbox/operator/test_k8s_provider.py -q
# 51 passed

ruff check rock/config.py rock/sandbox/operator/k8s/constants.py \
  rock/sandbox/operator/k8s/provider.py \
  tests/unit/sandbox/operator/test_k8s_provider.py
# All checks passed!
```
