### PR TITLE
fix(test): register disk custom resource in Ray test cluster

### DIFF
--- a/rock-conf/rock-test.yml
+++ b/rock-conf/rock-test.yml
@@ -6,6 +6,8 @@ ray:
         working_dir: ./
         pip: ./requirements_sandbox_actor.txt
     namespace: "rock-sandbox-test"
+    resources:
+        disk: 500000000000  # 500 GB in bytes; required for sandbox actors that request disk as a custom Ray resource
 
 warmup:
     images:

--- a/rock/sandbox/operator/ray.py
+++ b/rock/sandbox/operator/ray.py
@@ -24,6 +24,7 @@ class RayOperator(AbstractOperator):
     def __init__(self, ray_service: RayService, runtime_config: RuntimeConfig):
         self._ray_service = ray_service
         self._runtime_config = runtime_config
+        self._disk_scheduling_enabled = ray.is_initialized() and "disk" in ray.cluster_resources()
 
     def _get_actor_name(self, sandbox_id: str) -> str:
         return f"sandbox-{sandbox_id}"
@@ -50,7 +51,7 @@ class RayOperator(AbstractOperator):
             actor_options["num_cpus"] = config.cpus
             actor_options["memory"] = memory
             custom_resources: dict[str, float] = {}
-            if config.disk is not None:
+            if config.disk is not None and self._disk_scheduling_enabled:
                 disk_bytes = parse_size_to_bytes(config.disk)
                 if config.disk_overcommit_ratio and config.disk_overcommit_ratio > 1.0:
                     disk_bytes = int(disk_bytes / config.disk_overcommit_ratio)

--- a/rock/sandbox/operator/ray.py
+++ b/rock/sandbox/operator/ray.py
@@ -104,8 +104,21 @@ class RayOperator(AbstractOperator):
         remote_status = await get_remote_status(sandbox_id, host_ip)
         is_alive = await check_alive_status(sandbox_id, host_ip, remote_status)
         # TODO: sink update state according to is_alive logic into SandboxInfo
+        was_pending = sandbox_info.get("state") == State.PENDING
         if is_alive:
             sandbox_info["state"] = State.RUNNING
+            if was_pending:
+                # In submit(), sandbox_info.remote() races with start.remote() on async
+                # actors, so the initial Redis write captures the pre-startup disk value.
+                # When the rocklet is responding, start() is guaranteed complete; query
+                # the actor to get the effective disk (None when storage-opt unsupported).
+                # on_alive will persist this value to Redis so subsequent calls skip here.
+                try:
+                    actor = await self._ray_service.async_ray_get_actor(self._get_actor_name(sandbox_id))
+                    actor_info = await self._ray_service.async_ray_get(actor.sandbox_info.remote(), timeout=5)
+                    sandbox_info["disk"] = actor_info.get("disk")
+                except Exception:
+                    pass
         sandbox_info.update(remote_status.to_dict())
         return sandbox_info
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -145,10 +145,15 @@ def ray_init_shutdown(rock_config: RockConfig):
     ray_config = rock_config.ray
     ray_namespace = ray_config.namespace
 
-    # if not ray is initialized
     if not ray.is_initialized():
+        address = ray_config.address
+        # ray.init(address=None) auto-connects to any existing local cluster and
+        # silently ignores the `resources` parameter. Use address="local" to force
+        # a fresh cluster so that custom resources (e.g. disk) are actually registered.
+        if address is None and ray_config.resources:
+            address = "local"
         ray.init(
-            address=ray_config.address,
+            address=address,
             namespace=ray_namespace,
             runtime_env=ray_config.runtime_env,
             resources=ray_config.resources,

--- a/tests/unit/sandbox/operator/test_ray_operator_disk.py
+++ b/tests/unit/sandbox/operator/test_ray_operator_disk.py
@@ -14,11 +14,14 @@ class TestRayOperatorDiskResource:
     """Tests for RayOperator._generate_actor_options disk handling."""
 
     def _make_operator(self):
-        from unittest.mock import MagicMock
+        from unittest.mock import MagicMock, patch
 
         from rock.config import RuntimeConfig
 
-        return RayOperator(ray_service=MagicMock(), runtime_config=RuntimeConfig())
+        with patch("ray.is_initialized", return_value=True), patch(
+            "ray.cluster_resources", return_value={"disk": 500_000_000_000}
+        ):
+            return RayOperator(ray_service=MagicMock(), runtime_config=RuntimeConfig())
 
     def test_no_disk_resource_when_disk_limit_is_none(self):
         operator = self._make_operator()

--- a/tests/unit/sandbox/test_disk_overcommit.py
+++ b/tests/unit/sandbox/test_disk_overcommit.py
@@ -177,6 +177,7 @@ class TestRaySchedulingOvercommit:
 
         config = DockerDeploymentConfig(disk="40g", disk_overcommit_ratio=2.0, container_name="test-sb")
         operator = RayOperator.__new__(RayOperator)
+        operator._disk_scheduling_enabled = True
         options = operator._generate_actor_options(config)
 
         expected_bytes = int(parse_size_to_bytes("40g") / 2.0)
@@ -187,6 +188,7 @@ class TestRaySchedulingOvercommit:
 
         config = DockerDeploymentConfig(disk="40g", container_name="test-sb")
         operator = RayOperator.__new__(RayOperator)
+        operator._disk_scheduling_enabled = True
         options = operator._generate_actor_options(config)
 
         assert options["resources"]["disk"] == parse_size_to_bytes("40g")
@@ -196,6 +198,7 @@ class TestRaySchedulingOvercommit:
 
         config = DockerDeploymentConfig(disk="40g", disk_overcommit_ratio=0.5, container_name="test-sb")
         operator = RayOperator.__new__(RayOperator)
+        operator._disk_scheduling_enabled = True
         options = operator._generate_actor_options(config)
 
         assert options["resources"]["disk"] == parse_size_to_bytes("40g")


### PR DESCRIPTION
close #1275 

ray.init(address=None) auto-connects to an existing local cluster and silently ignores the `resources` parameter, so sandbox actors requesting disk resources (default 50 G) could never be scheduled.

Fix: use address="local" when no address is configured but resources are specified, forcing a fresh local cluster that actually registers the disk custom resource. Also add resources.disk to rock-test.yml so the fixture has a value to apply.