### PR TITLE
feat(opensandbox): complete admin integration (#1202)

### DIFF
--- a/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.11.x/User Guides/opensandbox_backend.md
+++ b/docs/i18n/zh-Hans/docusaurus-plugin-content-docs/version-1.11.x/User Guides/opensandbox_backend.md
@@ -1,0 +1,133 @@
+---
+sidebar_position: 6
+---
+
+# OpenSandbox 后端
+
+OpenSandbox Operator 允许 ROCK 把沙箱生命周期和运行时操作委托给外部
+[OpenSandbox](https://github.com/alibaba/OpenSandbox) 部署。ROCK 客户端仍然只调用 ROCK Admin API，无需编写后端专用逻辑。
+
+## 架构
+
+当 `runtime.operator_type: opensandbox` 时，ROCK Admin 通过 OpenSandbox Python SDK 处理：
+
+- 经 OpenSandbox Server 执行的生命周期操作；
+- 经 OpenSandbox `execd` 端点执行的命令、文件、session 和沙箱内服务访问。
+
+OpenSandbox 沙箱不需要 Rocklet。ROCK 不会为该后端安装、探测 Rocklet，也不会回退到 Rocklet。
+沙箱元数据中的 `extended_params.backend` 是路由依据；字段缺失、未知或与当前 Operator 冲突时会直接失败。
+
+## 安装
+
+安装 Admin 依赖，其中已包含受支持的 OpenSandbox SDK：
+
+```bash
+pip install "rl-rock[admin]"
+```
+
+源码开发环境使用：
+
+```bash
+uv sync --extra admin
+```
+
+## 配置
+
+一个 Admin 部署选择一种 Operator：
+
+```yaml
+runtime:
+  operator_type: opensandbox
+
+opensandbox:
+  endpoint: opensandbox.example.com:8090
+  protocol: https
+  api_key: ""                  # 推荐通过环境变量 OPEN_SANDBOX_API_KEY 提供。
+  runtime: docker              # 仅作说明；实际 runtime 由 OpenSandbox Server 选择。
+  image_registry_prefix: ""    # 可选：为没有显式 registry 的镜像名添加前缀。
+  use_server_proxy: false
+  default_timeout: 600
+
+scheduler:
+  enabled: false
+```
+
+`endpoint` 是 OpenSandbox Server 域名和可选端口，不包含 URL path；协议由 `protocol` 单独配置。
+`api_key` 为空时，OpenSandbox SDK 会读取环境变量 `OPEN_SANDBOX_API_KEY`。
+
+`use_server_proxy` 决定命令和文件请求如何到达 `execd`：
+
+- `false` 使用 OpenSandbox Server 返回的端点，ROCK Admin 必须能访问这些端点；
+- `true` 经 OpenSandbox Server 转发，仅在目标部署支持 server-proxy 模式时开启。
+
+ROCK 严格遵循该设置，不会失败后自动改走另一条链路。
+
+## 客户端用法
+
+现有 ROCK SDK 对后端保持透明：
+
+```python
+from rock.sdk.sandbox.client import Sandbox
+from rock.sdk.sandbox.config import SandboxConfig
+from rock.actions import Command
+
+sandbox = Sandbox(
+    SandboxConfig(
+        image="python:3.11",
+        cpus=2,
+        memory="4g",
+        base_url="http://rock-admin.example.com:8080",
+    )
+)
+
+await sandbox.start()
+result = await sandbox.execute(Command(command="python -V"))
+print(result.stdout)
+```
+
+Admin 同时保存 ROCK sandbox ID 和 OpenSandbox ID，调用方始终只使用 ROCK ID。
+
+## 能力矩阵
+
+| 能力 | OpenSandbox 后端 | 说明 |
+|---|---|---|
+| 创建、查询状态、列表 | 支持 | 创建后先返回 `pending`，ROCK 轮询 OpenSandbox 生命周期状态。 |
+| 删除运行中的沙箱 | 支持 | 映射为不可逆的 OpenSandbox `kill`。 |
+| Stop、Restart | 不支持 | Pause/Resume 要求创建时启用 persistence，当前 ROCK 后端不暴露这组能力。 |
+| Archive、Restore、镜像 Commit | 不支持 | 这些路径依赖 ROCK 管理的 worker 存储或 Ray Actor。 |
+| 执行命令 | 支持 | `cwd`、显式命令环境变量、超时和退出码检查会映射到 `execd`。 |
+| 读文件、写文件、上传文件 | 支持 | 上传时把文件流直接交给 SDK，Admin 不会把整个文件缓存在内存中。 |
+| 持久命令 Session | 支持 | Session 名称映射保存在 Redis 中，不同 Admin worker 可复用同一个 session。 |
+| 交互式 Session 命令 | 不支持 | `expect` 以及交互式 command/quit 模式会被明确拒绝。 |
+| HTTP 服务代理 | 支持 | ROCK 通过 OpenSandbox 解析目标端口，并保留端点要求的鉴权 header。 |
+| WebSocket 服务代理 | 支持 | 与 HTTP 代理使用相同的端点发现协议。 |
+| WebSocket 上的原始 TCP 端口转发 | 不支持 | 后端会明确拒绝该操作。 |
+| Worker 运维 Scheduler | 不适用 | 即使 `scheduler.enabled` 为 true，ROCK 也会跳过依赖 Ray/Rocklet 的 worker scheduler。 |
+
+### Session 环境变量和用户
+
+OpenSandbox session 继承沙箱/容器本身的环境。即使 SDK 请求中 `env_enable=true`，ROCK 也不会跨越信任边界复制
+Admin 进程的环境变量。
+
+请通过 session 请求中的显式 `env` 和 `startup_source` 初始化环境变量和 shell 文件。这些命令只在创建 session
+时执行一次，该 session 的后续命令可以观察到其效果。
+
+ROCK 无法切换 OpenSandbox session 的运行用户。如果传入 `remote_user`，ROCK 会用 `id -un` 校验；只有它已经
+等于沙箱的实际用户时请求才会成功。
+
+## 服务代理
+
+沙箱内监听的应用可继续使用 ROCK 现有代理路由访问。目标端口可通过 path
+`/proxy/{sandbox_id}/port/{port}/{path}`、`X-ROCK-Target-Port` header 或 `rock_target_port` query 参数指定，
+三种方式只能选择一种。
+
+ROCK 会向 OpenSandbox 生命周期服务查询端点，并转发其返回的鉴权 header。端点既可以是直连地址，也可以是
+server-proxy 地址；ROCK 不假设具体的域名路由策略。
+
+## 运维说明
+
+- 多个 Admin worker 必须使用共享 Redis，持久 session 映射保存在其中。
+- 不要为该 Operator 启用 Rocklet 专用的 worker 运维任务。OpenSandbox 被选中时，Admin 会记录 warning 并跳过该
+  scheduler。
+- 把 `use_server_proxy`、端点可达性和鉴权视为部署协议。ROCK 不会在不同链路或不同后端之间静默回退。
+- 不要在同一个 Admin 部署后混用 Ray/Kubernetes 与 OpenSandbox 沙箱；Operator 是部署级选择。

--- a/docs/versioned_docs/version-1.11.x/User Guides/opensandbox_backend.md
+++ b/docs/versioned_docs/version-1.11.x/User Guides/opensandbox_backend.md
@@ -1,0 +1,139 @@
+---
+sidebar_position: 6
+---
+
+# OpenSandbox Backend
+
+The OpenSandbox operator lets ROCK delegate sandbox lifecycle and runtime operations to an external
+[OpenSandbox](https://github.com/alibaba/OpenSandbox) deployment. ROCK clients continue to call the ROCK Admin API;
+they do not need backend-specific code.
+
+## Architecture
+
+With `runtime.operator_type: opensandbox`, ROCK Admin uses the OpenSandbox Python SDK for both:
+
+- lifecycle operations through the OpenSandbox server; and
+- command, file, session, and exposed-service operations through OpenSandbox `execd` endpoints.
+
+OpenSandbox sandboxes do not need Rocklet. ROCK does not install, discover, or fall back to Rocklet for this backend.
+The sandbox metadata field `extended_params.backend` is authoritative, and an invalid or conflicting backend fails
+closed.
+
+## Installation
+
+Install the Admin dependencies, which include the supported OpenSandbox SDK:
+
+```bash
+pip install "rl-rock[admin]"
+```
+
+For a source checkout:
+
+```bash
+uv sync --extra admin
+```
+
+## Configuration
+
+Configure one Admin deployment to use one operator type:
+
+```yaml
+runtime:
+  operator_type: opensandbox
+
+opensandbox:
+  endpoint: opensandbox.example.com:8090
+  protocol: https
+  api_key: ""                  # Prefer OPEN_SANDBOX_API_KEY in the environment.
+  runtime: docker              # Informational; the OpenSandbox server selects the runtime.
+  image_registry_prefix: ""    # Optional prefix for image names without an explicit registry.
+  use_server_proxy: false
+  default_timeout: 600
+
+scheduler:
+  enabled: false
+```
+
+`endpoint` is the OpenSandbox server domain and optional port, without a URL path. Set `protocol` separately.
+If `api_key` is empty, the OpenSandbox SDK reads `OPEN_SANDBOX_API_KEY`.
+
+`use_server_proxy` controls how command and file requests reach `execd`:
+
+- `false` uses endpoints returned by the OpenSandbox server. ROCK Admin must be able to reach those endpoints.
+- `true` routes requests through the OpenSandbox server. Enable it only when that deployment supports server-proxy
+  mode.
+
+ROCK follows this setting strictly and does not retry through the other route.
+
+## Client Usage
+
+The existing ROCK SDK remains backend-transparent:
+
+```python
+from rock.sdk.sandbox.client import Sandbox
+from rock.sdk.sandbox.config import SandboxConfig
+from rock.actions import Command
+
+sandbox = Sandbox(
+    SandboxConfig(
+        image="python:3.11",
+        cpus=2,
+        memory="4g",
+        base_url="http://rock-admin.example.com:8080",
+    )
+)
+
+await sandbox.start()
+result = await sandbox.execute(Command(command="python -V"))
+print(result.stdout)
+```
+
+The Admin service stores both the ROCK sandbox ID and the OpenSandbox ID. Callers continue to use only the ROCK ID.
+
+## Capability Matrix
+
+| Capability | OpenSandbox backend | Notes |
+|---|---|---|
+| Create, status, list | Supported | Creation returns `pending`; ROCK polls the OpenSandbox lifecycle state. |
+| Delete a running sandbox | Supported | Maps to irreversible OpenSandbox `kill`. |
+| Stop, restart | Not supported | Pause/resume requires persistence configured at creation time and is not exposed by this ROCK backend. |
+| Archive, restore, image commit | Not supported | These paths depend on ROCK-managed worker storage or Ray actors. |
+| Execute command | Supported | `cwd`, explicit command environment, timeout, and exit-code checks are mapped to `execd`. |
+| Read, write, upload file | Supported | Upload passes the file stream to the SDK without buffering the whole file in Admin memory. |
+| Persistent command session | Supported | Session-name mappings are stored in Redis so different Admin workers can reuse the same session. |
+| Interactive session commands | Not supported | `expect` and interactive command/quit modes are rejected explicitly. |
+| HTTP service proxy | Supported | ROCK resolves the requested sandbox port through OpenSandbox and preserves required endpoint headers. |
+| WebSocket service proxy | Supported | Uses the same endpoint-discovery contract as HTTP proxy. |
+| Raw TCP port forwarding over WebSocket | Not supported | The backend rejects this operation explicitly. |
+| Worker maintenance scheduler | Not applicable | ROCK skips the Ray/Rocklet worker scheduler even if `scheduler.enabled` is true. |
+
+### Session Environment and User
+
+An OpenSandbox session inherits the environment of its sandbox/container. ROCK never copies the Admin process
+environment across this boundary, including when the SDK request has `env_enable=true`.
+
+Use the session request's explicit `env` and `startup_source` fields to initialize values and shell files. Those
+commands run once when the session is created, and later commands in that session observe their effects.
+
+OpenSandbox cannot switch the session user through ROCK. If `remote_user` is supplied, ROCK verifies it against
+`id -un`; the request succeeds only when it already matches the sandbox's effective user.
+
+## Service Proxy
+
+Applications listening inside the sandbox can be reached with the existing ROCK proxy routes. A target port can be
+selected through the path form `/proxy/{sandbox_id}/port/{port}/{path}`, the `X-ROCK-Target-Port` header, or the
+`rock_target_port` query parameter. Specify the port through only one of these mechanisms.
+
+ROCK asks the OpenSandbox lifecycle service for the endpoint and forwards the returned authorization headers. The
+endpoint may be a direct address or a server-proxy address; ROCK does not assume a particular hostname-routing
+strategy.
+
+## Operational Notes
+
+- Use a shared Redis deployment for multiple Admin workers; persistent session mappings are stored there.
+- Do not enable Rocklet-specific worker maintenance tasks for this operator. Admin logs a warning and skips that
+  scheduler when OpenSandbox is selected.
+- Treat `use_server_proxy`, endpoint reachability, and authentication as deployment contracts. ROCK does not silently
+  fall back between routes or backends.
+- Do not mix Ray/Kubernetes and OpenSandbox sandboxes behind one Admin deployment. Select the operator at deployment
+  level.

--- a/rock/admin/main.py
+++ b/rock/admin/main.py
@@ -47,7 +47,12 @@ from rock.common.exception import request_validation_exception_handler
 from rock.config import DatabaseConfig, RockConfig, SchedulerConfig
 from rock.logger import configure_logging, init_logger, reset_log_file
 from rock.sandbox.gem_manager import GemManager
-from rock.sandbox.operator.factory import OperatorContext, OperatorFactory, operator_requires_ray
+from rock.sandbox.operator.factory import (
+    OperatorContext,
+    OperatorFactory,
+    operator_requires_ray,
+    operator_supports_scheduler,
+)
 from rock.sandbox.sandbox_meta_store import SandboxMetaStore
 from rock.sandbox.service.factory import create_sandbox_proxy_service
 from rock.sandbox.service.warmup_service import WarmupService
@@ -93,6 +98,13 @@ def _init_ops_service(
     scheduler_task_table: "SchedulerTaskTable",
 ) -> OpsService:
     """Build OpsService with task registry from scheduler config."""
+    if not operator_supports_scheduler(rock_config.runtime.operator_type):
+        return OpsService(
+            task_table=scheduler_task_table,
+            task_registry={},
+            alive_workers_provider=set,
+        )
+
     ops_task_registry: dict[str, BaseTask] = {}
     if rock_config.scheduler.enabled:
         for task_config in rock_config.scheduler.tasks:
@@ -223,7 +235,13 @@ async def lifespan(app: FastAPI):
         set_warmup_service(warmup_service)
         set_env_service(sandbox_manager)
 
-        if rock_config.scheduler.enabled and is_primary_pod():
+        scheduler_supported = operator_supports_scheduler(rock_config.runtime.operator_type)
+        if rock_config.scheduler.enabled and not scheduler_supported:
+            logger.warning(
+                "Scheduler is enabled but unsupported for operator_type=%s; skipping worker scheduler",
+                rock_config.runtime.operator_type,
+            )
+        elif rock_config.scheduler.enabled and is_primary_pod():
             scheduler_metrics_monitor, scheduler_metrics = _init_scheduler_metrics(rock_config)
             scheduler_thread = SchedulerThread(
                 scheduler_config=rock_config.scheduler,

--- a/rock/sandbox/operator/factory.py
+++ b/rock/sandbox/operator/factory.py
@@ -15,6 +15,7 @@ from rock.utils.providers.redis_provider import RedisProvider
 
 logger = init_logger(__name__)
 
+
 def operator_requires_ray(operator_type: str) -> bool:
     """Whether admin must initialize a Ray cluster for this operator backend.
 
@@ -23,6 +24,16 @@ def operator_requires_ray(operator_type: str) -> bool:
     to an external orchestrator, so admin boots without Ray for them.
     """
     return operator_type.lower() == "ray"
+
+
+def operator_supports_scheduler(operator_type: str) -> bool:
+    """Whether the worker maintenance scheduler supports this operator backend.
+
+    OpenSandbox owns its workers outside ROCK and does not install Rocklet, while
+    the scheduler discovers Ray workers and dispatches every task through their
+    Rocklet endpoints. Other operators retain their existing behavior.
+    """
+    return operator_type.lower() != "opensandbox"
 
 
 @dataclass
@@ -99,6 +110,4 @@ class OperatorFactory:
                 opensandbox_operator.set_nacos_provider(context.nacos_provider)
             return opensandbox_operator
         else:
-            raise ValueError(
-                f"Unsupported operator type: {operator_type}. Supported types: ray, k8s, opensandbox"
-            )
+            raise ValueError(f"Unsupported operator type: {operator_type}. Supported types: ray, k8s, opensandbox")

--- a/rock/sdk/sandbox/client.py
+++ b/rock/sdk/sandbox/client.py
@@ -146,7 +146,9 @@ class Sandbox(AbstractSandbox):
 
         return headers
 
-    async def _parse_error_message_from_status(self, status: dict):
+    async def _parse_error_message_from_status(self, status: dict | None):
+        if not status:
+            return None
         # Traverse each stage in the status dictionary
         for stage, details in status.items():
             # Check if the status of the current stage is "failed" or "timeout"

--- a/tests/integration/admin/opensandbox/test_admin_startup.py
+++ b/tests/integration/admin/opensandbox/test_admin_startup.py
@@ -1,0 +1,40 @@
+import sys
+
+from fastapi.testclient import TestClient
+
+
+def test_admin_starts_with_opensandbox_and_skips_worker_scheduler(tmp_path, monkeypatch):
+    config_path = tmp_path / "rock-opensandbox.yml"
+    config_path.write_text(
+        f"""
+runtime:
+  operator_type: opensandbox
+  python_env_path: {sys.prefix}
+  envhub_db_url: sqlite:////tmp/rock-opensandbox-envhub.db
+opensandbox:
+  endpoint: opensandbox.example.com
+aes_encrypt_key: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+scheduler:
+  enabled: true
+""".lstrip()
+    )
+    monkeypatch.setenv("ROCK_ADMIN_ENV", "test")
+    monkeypatch.setenv("ROCK_ADMIN_ROLE", "admin")
+    monkeypatch.setenv("ROCK_CONFIG", str(config_path))
+
+    from rock.admin import main
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("OpenSandbox admin must not initialize Ray or the worker scheduler")
+
+    monkeypatch.setattr(main, "RayService", fail_if_called)
+    monkeypatch.setattr(main, "SchedulerThread", fail_if_called)
+    monkeypatch.setattr(main, "_init_scheduler_metrics", fail_if_called)
+    monkeypatch.setattr(main, "set_archive_sandbox_table_provider", lambda provider: None)
+    monkeypatch.setattr(main, "set_archive_rock_config_provider", lambda provider: None)
+    monkeypatch.setattr(main, "set_archive_main_loop_provider", lambda provider: None)
+
+    with TestClient(main.create_app()) as client:
+        response = client.get("/")
+
+    assert response.status_code == 200

--- a/tests/unit/admin/test_scheduler_operator_gate.py
+++ b/tests/unit/admin/test_scheduler_operator_gate.py
@@ -1,0 +1,28 @@
+from unittest.mock import MagicMock
+
+from rock.admin.main import _init_ops_service
+from rock.config import RockConfig, SchedulerConfig, TaskConfig
+
+
+def test_opensandbox_ops_service_does_not_register_worker_tasks(monkeypatch):
+    config = RockConfig()
+    config.runtime.operator_type = "opensandbox"
+    config.scheduler = SchedulerConfig(
+        enabled=True,
+        tasks=[
+            TaskConfig(
+                task_class="rock.admin.scheduler.tasks.image_cleanup_task.ImageCleanupTask",
+            )
+        ],
+    )
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("OpenSandbox ops service must not initialize Ray/Rocklet worker tasks")
+
+    monkeypatch.setattr("rock.admin.main.TaskFactory.create_task", fail_if_called)
+    monkeypatch.setattr("rock.admin.main.WorkerIPCache", fail_if_called)
+
+    service = _init_ops_service(config, MagicMock())
+
+    assert service._task_registry == {}
+    assert service._alive_workers_provider() == set()

--- a/tests/unit/sandbox/operator/test_operator_factory.py
+++ b/tests/unit/sandbox/operator/test_operator_factory.py
@@ -5,7 +5,12 @@ from unittest.mock import MagicMock
 import pytest
 
 from rock.config import OpenSandboxConfig, RuntimeConfig
-from rock.sandbox.operator.factory import OperatorContext, OperatorFactory, operator_requires_ray
+from rock.sandbox.operator.factory import (
+    OperatorContext,
+    OperatorFactory,
+    operator_requires_ray,
+    operator_supports_scheduler,
+)
 from rock.sandbox.operator.opensandbox.operator import OpenSandboxOperator
 
 
@@ -14,6 +19,13 @@ def test_operator_requires_ray():
     assert operator_requires_ray("Ray") is True  # case-insensitive
     assert operator_requires_ray("k8s") is False
     assert operator_requires_ray("opensandbox") is False
+
+
+def test_operator_supports_scheduler():
+    assert operator_supports_scheduler("ray") is True
+    assert operator_supports_scheduler("k8s") is True
+    assert operator_supports_scheduler("opensandbox") is False
+    assert operator_supports_scheduler("OpenSandbox") is False
 
 
 def _runtime(operator_type: str) -> RuntimeConfig:

--- a/tests/unit/sdk/sandbox/test_sandbox_client_init.py
+++ b/tests/unit/sdk/sandbox/test_sandbox_client_init.py
@@ -1,5 +1,6 @@
-"""Unit tests for Sandbox.attach() and sandbox_id lifecycle."""
+"""Unit tests for Sandbox startup, attach(), and sandbox_id lifecycle."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -20,6 +21,43 @@ class TestSandboxClientInit:
         config = SandboxConfig(sandbox_id=SANDBOX_ID)
         sandbox = Sandbox(config)
         assert sandbox.sandbox_id is None
+
+
+class TestSandboxStart:
+    @pytest.mark.asyncio
+    async def test_start_keeps_polling_when_pending_status_is_none(self):
+        sandbox = Sandbox(SandboxConfig(startup_timeout=30))
+        pending = SimpleNamespace(
+            namespace=None,
+            experiment_id=None,
+            is_alive=False,
+            status=None,
+        )
+        running = SimpleNamespace(
+            namespace=None,
+            experiment_id=None,
+            is_alive=True,
+            status=None,
+        )
+        start_response = {
+            "status": "Success",
+            "result": {
+                "sandbox_id": SANDBOX_ID,
+                "host_name": None,
+                "host_ip": None,
+            },
+        }
+
+        with (
+            patch.object(sandbox, "_build_headers", return_value={}),
+            patch("rock.utils.HttpUtils.post", new_callable=AsyncMock, return_value=start_response),
+            patch.object(sandbox, "get_status", new_callable=AsyncMock, side_effect=[pending, running]) as get_status,
+            patch("rock.sdk.sandbox.client.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await sandbox.start()
+
+        assert sandbox.sandbox_id == SANDBOX_ID
+        assert get_status.await_count == 2
 
 
 class TestSandboxAttach:


### PR DESCRIPTION
## Summary

Completes the planned OpenSandbox backend integration after #1203, #1233, and #1262.

- skip the Ray/Rocklet worker scheduler and worker `/ops` tasks when `runtime.operator_type` is `opensandbox`
- add a real Admin lifespan startup regression test for the OpenSandbox configuration
- add synchronized English and Chinese OpenSandbox backend guides with configuration, routing contracts, sessions, proxy behavior, and a capability matrix
- keep AOne-specific endpoint and wildcard-domain behavior out of the open-source implementation and documentation

## Compatibility decisions

- OpenSandbox sandboxes do not install or require Rocklet, and ROCK does not fall back to Rocklet for this backend.
- The scheduler gate is backend-specific: existing Ray/Kubernetes behavior is preserved.
- HTTP and WebSocket service proxying use the generic endpoint-discovery contract returned by OpenSandbox; ROCK does not assume a path-routing or wildcard-domain deployment strategy.
- Unsupported operations remain explicit: stop/restart persistence, interactive session commands, archive/restore/image commit, and raw TCP forwarding are not added here.

## Validation

- `uv run ruff check` and `uv run ruff format --check` on all changed Python files
- 296 targeted scheduler/OpenSandbox/Admin tests passed
- real FastAPI Admin lifespan startup passed with OpenSandbox selected and scheduler enabled, while asserting Ray and worker scheduler initialization are skipped
- both new MDX guides compiled independently
- CI-equivalent Docusaurus production build passed for English and zh-Hans with Node 20 and webpack 5.105.4; only pre-existing scheduler anchor warnings remain

## Delivery plan

This is the final planned OpenSandbox integration PR. After this PR, only review or CI fixes will be folded into this same branch; no additional feature PR is currently planned for issue #1202.

The 1.11 documentation version registration is already handled by #1300. Until #1300 lands, these versioned guide files compile but are not linked by the published version selector.

Closes #1202

## Additional validation after SDK compatibility fix

- real AOne Sandbox SDK E2E passed: `Sandbox.start()` handled `Pending` responses with `status: null`, then command execution, session environment/cwd persistence, and deletion completed successfully; remote cleanup was confirmed as `Terminated`
- 615 SDK unit tests and 96 OpenSandbox operator/backend/session tests passed

