### PR TITLE
fix(rocklet): skip kata dind setup when docker data-root cannot be created

### DIFF
--- a/rock/rocklet/local_files/docker_run.sh
+++ b/rock/rocklet/local_files/docker_run.sh
@@ -38,13 +38,27 @@ setup_kata_dind() {
             docker_root="$custom_root"
         fi
     fi
-    mkdir -p "$docker_root"
-    for i in $(seq 0 7); do
-        mknod -m 660 /dev/loop$i b 7 $i 2>/dev/null || true
-    done
-    mount -o loop /docker-disk.img "$docker_root"
-    mount -o remount,rw /sys/fs/cgroup
-    mount -o remount,rw /proc/sys
+    # Directory creation requires write and execute permissions on the nearest existing parent.
+    if [ ! -d "$docker_root" ]; then
+        local nearest_existing_path="$docker_root"
+        while [ ! -e "$nearest_existing_path" ]; do
+            nearest_existing_path=$(dirname "$nearest_existing_path")
+        done
+        if [ ! -d "$nearest_existing_path" ] || [ ! -w "$nearest_existing_path" ] || [ ! -x "$nearest_existing_path" ]; then
+            echo "Warning: no permission to create Docker data root '$docker_root'; skipping Kata DinD setup." >&2
+        else
+            mkdir -p "$docker_root"
+        fi
+    fi
+
+    if [ -d "$docker_root" ]; then
+        for i in $(seq 0 7); do
+            mknod -m 660 /dev/loop$i b 7 $i 2>/dev/null || true
+        done
+        mount -o loop /docker-disk.img "$docker_root"
+        mount -o remount,rw /sys/fs/cgroup
+        mount -o remount,rw /proc/sys
+    fi
 }
 
 # Run rocklet


### PR DESCRIPTION
## Summary

- check permissions before creating the Docker data-root for Kata DinD;
- log a clear warning and skip unavailable Kata DinD steps without returning early from `setup_kata_dind`;
- preserve writable multi-level custom Docker `data-root` paths.

## Problem

When a sandbox image uses a non-root default user, `docker_run.sh` cannot create `/var/lib/docker`.

Because the script enables `set -o errexit`, the permission error terminates the startup script before Rocklet starts.

## Implementation

When the Docker data-root does not exist, walk upward to find the nearest existing path and verify that it is:

- a directory;
- writable;
- executable/traversable.

If the directory cannot be created, the script only prints a warning. The DinD `mkdir`, `mknod`, and `mount` steps run only when the Docker data-root exists, so `setup_kata_dind` reaches its normal end and the subsequent Rocklet startup continues.

## Test Plan

- [x] `bash -n rock/rocklet/local_files/docker_run.sh`
- [x] `git diff --check`
- [x] `tests/unit/deployments/test_docker_env_injection.py`: 8 passed
- [x] non-root + Kata + non-writable `/var/lib/docker`: warning emitted, directory not created, Rocklet startup marker observed, exit code `0`
- [x] non-root + Kata + writable multi-level custom `data-root`: directory created and exit code `0`
- [x] non-root + non-Kata: existing behavior unchanged
- [x] `mount` and `mknod` mocked during local permission tests

No automated Shell test file was added because existing changes to `setup_kata_dind` and `docker_run.sh` use script-level and integration validation rather than a dedicated Shell unit-test framework. The existing Docker environment-injection unit suite was run as regression coverage.

Real Kata runtime validation still needs to be performed on a Kata-enabled Linux worker.

refs #1308