### PR TITLE
feat(admin): add Template API for K8s Pool-based sandbox warm path

### DIFF
--- a/docs/proposals/template-design.md
+++ b/docs/proposals/template-design.md
@@ -1,0 +1,151 @@
+# ROCK Template API 设计文档
+
+## 1. 概述
+
+Template API 提供 Sandbox 预热池的创建与查询能力。调用方通过提交镜像和资源规格创建 Template，获得稳定的 `templateID`。该 ID 对应一个 OpenSandbox Pool CRD，由 Pool Controller 自动维护热备 Pod。后续创建 Sandbox 时，`templateID` 作为 `poolRef` 被引用，实现秒级分配。
+
+| 接口 | 说明 |
+| --- | --- |
+| `POST /apis/envs/sandbox/v1/templates` | 提交 Template 创建请求，同步返回 `templateID` 及状态 |
+| `GET /apis/envs/sandbox/v1/templates/{templateID}` | 查询 Template 当前状态 |
+| `DELETE /apis/envs/sandbox/v1/templates/{templateID}` | 删除 Template（= 删除 Pool CRD） |
+
+### 设计要点
+
+- **无独立存储**：K8s Pool CRD 即为持久化层，Informer 本地缓存提供高效读取，无需 DB。
+- **同步创建**：Pool CRD 创建不耗时，请求内同步完成，无需后台异步任务。
+- **天然去重**：相同 spec 生成相同 `templateID`（= Pool Name），K8s API Server 通过 409 Conflict 自动去重。
+- **模版渲染**：Pool 的 PodTemplateSpec、capacitySpec 等通过 YAML 模版配置 + Jinja2 渲染。
+
+### 概念说明
+
+外部 API 遵循 E2B 风格，使用 "Template" 概念。Template 是统一抽象——描述 Sandbox Pod 如何被创建的配置。差异只在交付机制：
+
+| | Warm（当前实现） | Cold（未来可选，不实现） |
+| --- | --- | --- |
+| 底层资源 | Pool CRD | BatchSandbox template config |
+| Pod 何时创建 | 预创建热备，引用时秒级分配 | Sandbox 请求时即时创建 |
+| templateID 映射 | `tpl-xxx` → Pool Name | template name → config key |
+| 状态查询 | 需查 Pool reconcile 进度 | 天然 `ready`（无需预热） |
+
+Operator 内部将 Template 概念转换为 Pool 操作：
+
+| 外部概念 | 内部映射 | K8s 资源 |
+| --- | --- | --- |
+| Template | Pool | Pool CRD |
+| templateID | Pool Name | Pool.metadata.name |
+| Template status | Pool status 映射 | Pool.status |
+
+## 2. 整体设计
+
+### 2.1 链路
+
+```
+创建 Template
+    ├─ 生成 templateID = tpl- + sha256(非空 spec 字段)[:16]
+    ├─ 从 pool_template 配置渲染 Pool CRD manifest
+    ├─ K8sApiClient(Pool).create_custom_object()
+    │    └─ 409 → Pool 已存在，返回已有 templateID + status
+    └─ 返回 templateID + status
+
+查询 Template
+    ├─ templateID = Pool Name
+    ├─ K8sApiClient(Pool).get_custom_object()  ← Informer 本地缓存
+    ├─ 映射 Pool status → template status
+    └─ 返回 templateID + status + timestamps
+
+删除 Template
+    ├─ templateID = Pool Name
+    ├─ K8sApiClient(Pool).delete_custom_object()
+    │    └─ 404 → not found = already deleted
+    └─ K8s GC 自动清理 Pool 拥有的 Pod
+```
+
+### 2.2 templateID 生成
+
+覆盖完整 spec 的**非空字段**，忽略 null/空值，保证前向兼容——后续新增字段传入非空值时自动参与哈希，传入 null 时不影响已有映射。
+
+- 格式：`tpl-{sha256(排序后的非空字段)[:16]}`
+- 前缀用连字符 `-`（符合 K8s RFC 1123 命名规范）
+- 一期非空字段：`from_image`、`cpu_count`、`memory_mb`；`disk_gb`/`num_gpus`/`accelerator_type` 为 null 时不参与哈希
+
+### 2.3 状态映射
+
+Pool CRD status 字段为 `available`/`total`（非 `readyReplicas`/`replicas`）：
+
+| 条件 | Template status | 说明 |
+| --- | --- | --- |
+| Pool 不存在 | 404 | templateID 无效 |
+| `available > 0` | `ready` | 至少一个热备 Pod 就绪 |
+| `available == 0 && total > 0` | `building` | Pod 已创建但未就绪 |
+| `available == 0 && total == 0` | `building` | Controller 尚未处理或 Pool 为空 |
+| conditions 中 `Ready=False` | `error` | Pool 创建失败 |
+
+### 2.4 Pool 标识
+
+Template API 创建的 Pool 携带 Label `rock.sandbox/managed-by: template-api`，与 Nacos 配置的系统 Pool 区分。
+
+### 2.5 关于 Update
+
+不支持 Update。templateID 由 spec 的 hash 生成，改 spec 即产生新 templateID，本质是 create 而非 update。配置变更场景：创建新 Template → 更新引用方配置 → 删除旧 Template。
+
+### 2.6 冒烟测试
+
+`tests/smoke/` 通过命令行参数指定 admin 地址和镜像，不硬编码内部镜像：
+
+```bash
+pytest tests/smoke/ --admin-url http://localhost:8080 --smoke-image python:3.11
+```
+
+| Case | 覆盖链路 | 关键断言 |
+| --- | --- | --- |
+| `test_template_lifecycle` | create → wait ready → delete | templateID 以 `tpl-` 开头、status 变为 `ready`、删除成功 |
+| `test_template_idempotent_create` | 同 spec POST 两次 | 返回相同 templateID |
+
+两个 case 均通过 `try/finally` 保证失败时也清理模板。
+
+## 3. 实现要点
+
+### 3.1 Pool 模版配置
+
+`K8sConfig.pool_template` 字段（YAML 配置 + Jinja2 渲染）生成 Pool CRD spec。关键约定：
+
+- capacitySpec 使用 **camelCase** 键（`bufferMin`/`bufferMax`/`poolMin`/`poolMax`），匹配 Pool CRD spec
+- Jinja2 变量需加**双引号**（`"{{ from_image }}"`），避免 YAML flow mapping 解析错误
+- 渲染后 capacitySpec 值为字符串，需 `int()` 转换才能被 K8s 接受
+- 渲染上下文：`from_image`、`cpu_count`、`memory_mb`
+
+### 3.2 关键常量
+
+- `TEMPLATE_ID_PREFIX = "tpl-"`（RFC 1123 连字符）
+- `LABEL_MANAGED_BY = "rock.sandbox/managed-by"`，值为 `"template-api"`
+- Pool CRD：plural=`pools`，kind=`Pool`
+
+### 3.3 BatchSandboxProvider 扩展
+
+Provider 新增 Pool informer（复用同一 `ApiClient`，独立 watch `pools` CRD），并提供三组方法：
+
+| 外部方法（template 术语） | 内部方法（pool 术语） | 行为 |
+| --- | --- | --- |
+| `create_template(spec)` | `_create_pool(name, spec)` | 渲染 manifest → create_custom_object；409 时返回已有 Pool |
+| `get_template_status(id)` | `_get_pool(name)` | 从 Informer 缓存读取 Pool → 映射 status；未找到返回 None |
+| `delete_template(id)` | `_delete_pool(name)` | delete_custom_object；404 视为已删除 |
+
+辅助方法：`_build_pool_manifest_from_template`（渲染）、`_map_pool_to_template_status`（状态映射）。
+
+## 4. 涉及文件
+
+| 文件 | 变更 |
+| --- | --- |
+| `rock/sandbox/operator/k8s/constants.py` | 新增 Pool CRD 常量、Label 常量、`TEMPLATE_ID_PREFIX` |
+| `rock/sandbox/operator/k8s/provider.py` | 新增 Pool informer、template/pool 转换方法 |
+| `rock/sandbox/sandbox_manager.py` | 新增 template 代理方法 |
+| `rock/admin/entrypoints/template_api.py` | 新增 `template_router`（POST/GET/DELETE 端点） |
+| `rock/admin/main.py` | 注册 `template_router`，prefix `/apis/envs/sandbox/v1` |
+| `rock/admin/proto/request.py` | 新增 `TemplateCreateRequest` |
+| `rock/admin/proto/response.py` | 新增 `TemplateCreateResponse` / `TemplateStatusResponse` |
+| `rock-conf/rock-junxin.yml` | 新增 `pool_template` 配置段 |
+| `tests/unit/test_template_api.py` | 单元测试：ID 生成、渲染、状态映射、常量 |
+| `tests/smoke/conftest.py` | 冒烟测试配置：`--admin-url` / `--smoke-image` |
+| `tests/smoke/test_template.py` | 冒烟测试：lifecycle + 幂等创建 |
+

--- a/docs/proposals/template-design.md
+++ b/docs/proposals/template-design.md
@@ -8,13 +8,14 @@ Template API 提供 Sandbox 预热池的创建与查询能力。调用方通过�
 | --- | --- |
 | `POST /apis/envs/sandbox/v1/templates` | 提交 Template 创建请求，同步返回 `templateID` 及状态 |
 | `GET /apis/envs/sandbox/v1/templates/{templateID}` | 查询 Template 当前状态 |
+| `POST /apis/envs/sandbox/v1/templates/{templateID}/scale` | 调整 Template 容量（PATCH 语义） |
 | `DELETE /apis/envs/sandbox/v1/templates/{templateID}` | 删除 Template（= 删除 Pool CRD） |
 
 ### 设计要点
 
 - **无独立存储**：K8s Pool CRD 即为持久化层，Informer 本地缓存提供高效读取，无需 DB。
 - **同步创建**：Pool CRD 创建不耗时，请求内同步完成，无需后台异步任务。
-- **天然去重**：相同 spec 生成相同 `templateID`（= Pool Name），K8s API Server 通过 409 Conflict 自动去重。
+- **天然去重**：相同 spec 生成相同 `templateID`（= Pool Name），K8s API Server 通过 409 Conflict 自动去重。容量字段不参与 `templateID` 计算。
 - **模版渲染**：Pool 的 PodTemplateSpec、capacitySpec 等通过 YAML 模版配置 + Jinja2 渲染。
 
 ### 概念说明
@@ -59,6 +60,13 @@ Operator 内部将 Template 概念转换为 Pool 操作：
     ├─ K8sApiClient(Pool).delete_custom_object()
     │    └─ 404 → not found = already deleted
     └─ K8s GC 自动清理 Pool 拥有的 Pod
+
+扩缩容 Template
+    ├─ templateID = Pool Name
+    ├─ 校验容量字段（pool_min/pool_max/buffer_min/buffer_max）
+    ├─ 仅将提供的非空字段 PATCH 到 Pool.spec.capacitySpec
+    ├─ K8sApiClient(Pool).update_custom_object()
+    └─ 返回更新后的 templateID + status + capacity
 ```
 
 ### 2.2 templateID 生成
@@ -67,7 +75,8 @@ Operator 内部将 Template 概念转换为 Pool 操作：
 
 - 格式：`tpl-{sha256(排序后的非空字段)[:16]}`
 - 前缀用连字符 `-`（符合 K8s RFC 1123 命名规范）
-- 一期非空字段：`from_image`、`cpu_count`、`memory_mb`；`disk_gb`/`num_gpus`/`accelerator_type` 为 null 时不参与哈希
+- 参与哈希的非空字段：`from_image`、`cpu_count`、`memory_mb`；`disk_gb`/`num_gpus`/`accelerator_type` 为 null 时不参与哈希
+- 容量字段（`pool_min`/`pool_max`/`buffer_min`/`buffer_max`）被排除在外，因为容量不影响 Template 身份
 
 ### 2.3 状态映射
 
@@ -81,13 +90,35 @@ Pool CRD status 字段为 `available`/`total`（非 `readyReplicas`/`replicas`�
 | `available == 0 && total == 0` | `building` | Controller 尚未处理或 Pool 为空 |
 | conditions 中 `Ready=False` | `error` | Pool 创建失败 |
 
+返回的 Template status 中还包含容量信息，结构如下：
+
+```json
+{
+  "capacity": {
+    "spec": {
+      "poolMin": ...,
+      "poolMax": ...,
+      "bufferMin": ...,
+      "bufferMax": ...
+    },
+    "status": {
+      "available": ...,
+      "total": ...,
+      "allocated": ...
+    }
+  }
+}
+```
+
 ### 2.4 Pool 标识
 
 Template API 创建的 Pool 携带 Label `rock.sandbox/managed-by: template-api`，与 Nacos 配置的系统 Pool 区分。
 
 ### 2.5 关于 Update
 
-不支持 Update。templateID 由 spec 的 hash 生成，改 spec 即产生新 templateID，本质是 create 而非 update。配置变更场景：创建新 Template → 更新引用方配置 → 删除旧 Template。
+不支持修改 Template 的 spec 字段（镜像、CPU、内存等）。templateID 由这些 spec 字段的 hash 生成，改 spec 即产生新 templateID，本质是 create 而非 update。配置变更场景：创建新 Template → 更新引用方配置 → 删除旧 Template。
+
+容量字段（`pool_min`/`pool_max`/`buffer_min`/`buffer_max`）可通过 `POST /templates/{templateID}/scale` 单独调整，采用 PATCH 语义：仅更新请求中提供的非空字段，允许缩容到 0，并在 `TemplateScaleRequest` 中校验 `min <= max`。
 
 ### 2.6 冒烟测试
 
@@ -113,7 +144,7 @@ pytest tests/smoke/ --admin-url http://localhost:8080 --smoke-image python:3.11
 - capacitySpec 使用 **camelCase** 键（`bufferMin`/`bufferMax`/`poolMin`/`poolMax`），匹配 Pool CRD spec
 - Jinja2 变量需加**双引号**（`"{{ from_image }}"`），避免 YAML flow mapping 解析错误
 - 渲染后 capacitySpec 值为字符串，需 `int()` 转换才能被 K8s 接受
-- 渲染上下文：`from_image`、`cpu_count`、`memory_mb`
+- 渲染上下文：`from_image`、`cpu_count`、`memory_mb`（容量字段不再来自 `TemplateSpec`，由 `pool_template` 默认配置提供）
 
 ### 3.2 关键常量
 
@@ -138,12 +169,13 @@ Provider 新增 Pool informer（复用同一 `ApiClient`，独立 watch `pools` 
 | 文件 | 变更 |
 | --- | --- |
 | `rock/sandbox/operator/k8s/constants.py` | 新增 Pool CRD 常量、Label 常量、`TEMPLATE_ID_PREFIX` |
-| `rock/sandbox/operator/k8s/provider.py` | 新增 Pool informer、template/pool 转换方法 |
-| `rock/sandbox/sandbox_manager.py` | 新增 template 代理方法 |
-| `rock/admin/entrypoints/template_api.py` | 新增 `template_router`（POST/GET/DELETE 端点） |
+| `rock/sandbox/operator/k8s/provider.py` | 新增 Pool informer、template/pool 转换方法、scale_template |
+| `rock/sandbox/sandbox_manager.py` | 新增 template 代理方法（含 scale_template） |
+| `rock/sandbox/operator/abstract.py` | 新增 `scale_template` 抽象方法默认实现 |
+| `rock/admin/entrypoints/template_api.py` | 新增 `template_router`（POST/GET/DELETE/SCALE 端点） |
 | `rock/admin/main.py` | 注册 `template_router`，prefix `/apis/envs/sandbox/v1` |
-| `rock/admin/proto/request.py` | 新增 `TemplateCreateRequest` |
-| `rock/admin/proto/response.py` | 新增 `TemplateCreateResponse` / `TemplateStatusResponse` |
+| `rock/admin/proto/request.py` | 新增 `TemplateCreateRequest` / `TemplateScaleRequest` |
+| `rock/admin/proto/response.py` | 新增 `TemplateCreateResponse` / `TemplateStatusResponse` / `TemplateCapacityResponse` |
 | `rock-conf/rock-junxin.yml` | 新增 `pool_template` 配置段 |
 | `tests/unit/test_template_api.py` | 单元测试：ID 生成、渲染、状态映射、常量 |
 | `tests/smoke/conftest.py` | 冒烟测试配置：`--admin-url` / `--smoke-image` |

--- a/rock/admin/entrypoints/template_api.py
+++ b/rock/admin/entrypoints/template_api.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter
 
 from rock.actions import RockResponse
 from rock.admin.entrypoints import sandbox_api
-from rock.admin.proto.request import TemplateCreateRequest
+from rock.admin.proto.request import TemplateCreateRequest, TemplateScaleRequest
 from rock.admin.proto.response import TemplateCreateResponse, TemplateStatusResponse
 from rock.common.exception import handle_exceptions
 from rock.common.validation import NonBlankStr
@@ -29,8 +29,9 @@ template_router = APIRouter()
 async def create_template(request: TemplateCreateRequest) -> RockResponse[TemplateCreateResponse]:
     """Create or reuse a template.
 
-    Idempotent: same (fromImage, cpuCount, memoryMB) produces the same templateID.
-    Returns templateID and status ('waiting' for new, current status if exists).
+    Idempotent: same non-null spec fields produce the same templateID.
+    Capacity is excluded from identity; use /templates/{id}/scale to adjust it.
+    Returns templateID and status.
     """
     spec = TemplateSpec(
         from_image=request.from_image,
@@ -57,14 +58,28 @@ async def get_template_status(template_id: NonBlankStr) -> RockResponse[Template
     return RockResponse(result=TemplateStatusResponse(**status))
 
 
+@template_router.post("/templates/{template_id}/scale")
+@handle_exceptions(error_message="scale template failed")
+async def scale_template(
+    template_id: NonBlankStr,
+    request: TemplateScaleRequest,
+) -> RockResponse[TemplateStatusResponse]:
+    """Scale a template's Pool capacity.
+
+    PATCH semantics: only provided capacity fields are updated.
+    """
+    capacity = request.model_dump(exclude_unset=True, by_alias=False)
+    result = await sandbox_api.sandbox_manager.scale_template(template_id, capacity)
+    return RockResponse(result=TemplateStatusResponse(**result))
+
+
 @template_router.delete("/templates/{template_id}")
 @handle_exceptions(error_message="delete template failed")
 async def delete_template(template_id: NonBlankStr) -> RockResponse[str]:
     """Delete a template (Pool CRD).
 
-    Returns failure message if the template is in use.
+    Returns success when deleted or not found. K8s/Pool controller is responsible
+    for protecting a pool that is still referenced by running sandboxes.
     """
-    deleted = await sandbox_api.sandbox_manager.delete_template(template_id)
-    if not deleted:
-        return RockResponse(result=f"{template_id} delete failed")
+    await sandbox_api.sandbox_manager.delete_template(template_id)
     return RockResponse(result=f"{template_id} deleted")

--- a/rock/admin/entrypoints/template_api.py
+++ b/rock/admin/entrypoints/template_api.py
@@ -1,0 +1,70 @@
+"""Template API (Warm path) — create / query / delete Template.
+
+POST    /internal/v1/templates           — create or reuse template
+GET     /internal/v1/templates/{id}      — query template status
+DELETE  /internal/v1/templates/{id}      — delete template
+
+All calls go through sandbox_manager, consistent with the sandbox API pattern.
+"""
+
+from fastapi import APIRouter
+
+from rock.actions import RockResponse
+from rock.admin.entrypoints import sandbox_api
+from rock.admin.proto.request import TemplateCreateRequest
+from rock.admin.proto.response import TemplateCreateResponse, TemplateStatusResponse
+from rock.common.exception import handle_exceptions
+from rock.common.validation import NonBlankStr
+from rock.logger import init_logger
+from rock.sandbox.operator.k8s.provider import TemplateSpec
+from rock.sdk.common.exceptions import BadRequestRockError
+
+logger = init_logger(__name__)
+
+template_router = APIRouter()
+
+
+@template_router.post("/templates")
+@handle_exceptions(error_message="create template failed")
+async def create_template(request: TemplateCreateRequest) -> RockResponse[TemplateCreateResponse]:
+    """Create or reuse a template.
+
+    Idempotent: same (fromImage, cpuCount, memoryMB) produces the same templateID.
+    Returns templateID and status ('waiting' for new, current status if exists).
+    """
+    spec = TemplateSpec(
+        from_image=request.from_image,
+        cpu_count=request.cpu_count,
+        memory_mb=request.memory_mb,
+        disk_gb=request.disk_gb,
+        num_gpus=request.num_gpus,
+        accelerator_type=request.accelerator_type,
+    )
+    result = await sandbox_api.sandbox_manager.create_template(spec)
+    return RockResponse(result=TemplateCreateResponse(**result))
+
+
+@template_router.get("/templates/{template_id}")
+@handle_exceptions(error_message="get template status failed")
+async def get_template_status(template_id: NonBlankStr) -> RockResponse[TemplateStatusResponse]:
+    """Query template status by templateID.
+
+    Returns 404-equivalent (status=Failed) if template_id not found.
+    """
+    status = await sandbox_api.sandbox_manager.get_template_status(template_id)
+    if status is None:
+        raise BadRequestRockError(f"Template {template_id} not found")
+    return RockResponse(result=TemplateStatusResponse(**status))
+
+
+@template_router.delete("/templates/{template_id}")
+@handle_exceptions(error_message="delete template failed")
+async def delete_template(template_id: NonBlankStr) -> RockResponse[str]:
+    """Delete a template (Pool CRD).
+
+    Returns failure message if the template is in use.
+    """
+    deleted = await sandbox_api.sandbox_manager.delete_template(template_id)
+    if not deleted:
+        return RockResponse(result=f"{template_id} delete failed")
+    return RockResponse(result=f"{template_id} deleted")

--- a/rock/admin/main.py
+++ b/rock/admin/main.py
@@ -26,6 +26,7 @@ from rock.admin.core.scheduler_task_table import SchedulerTaskTable
 from rock.admin.entrypoints.admin_ops_api import admin_ops_router, set_ops_service
 from rock.admin.entrypoints.sandbox_api import sandbox_router, set_sandbox_manager
 from rock.admin.entrypoints.sandbox_proxy_api import sandbox_proxy_router, set_sandbox_proxy_service
+from rock.admin.entrypoints.template_api import template_router
 from rock.admin.entrypoints.warmup_api import set_warmup_service, warmup_router
 from rock.admin.gem.api import gem_router, set_env_service
 from rock.admin.metrics.monitor import MetricsMonitor
@@ -343,6 +344,7 @@ async def log_requests_and_responses(request: Request, call_next):
 def _include_routers(app: FastAPI, role: str) -> None:
     if role == "admin":
         app.include_router(sandbox_router, prefix="/apis/envs/sandbox/v1", tags=["sandbox"])
+        app.include_router(template_router, prefix="/apis/envs/sandbox/v1", tags=["template"])
         app.include_router(admin_ops_router, prefix="/apis/envs/sandbox/v1/ops", tags=["admin-ops"])
     else:
         app.include_router(sandbox_proxy_router, prefix="/apis/envs/sandbox/v1", tags=["sandbox"])

--- a/rock/admin/proto/request.py
+++ b/rock/admin/proto/request.py
@@ -1,7 +1,7 @@
 from typing import Annotated, Literal, TypedDict
 
 from fastapi import Header
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from rock import env_vars
 from rock.actions import (
@@ -146,6 +146,37 @@ class SandboxWriteFileRequest(WriteFileRequest):
 
 class WarmupRequest(BaseModel):
     image: str = "python:3.11"
+
+
+class TemplateCreateRequest(BaseModel):
+    """Request body for creating a template (Warm path).
+
+    External fields use E2B-style camelCase; internal snake_case via alias.
+    Phase 1 dedup key: (fromImage, cpuCount, memoryMB) only.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    from_image: NonBlankStr = Field(alias="fromImage")
+    cpu_count: int = Field(alias="cpuCount")
+    memory_mb: int = Field(alias="memoryMB")
+    disk_gb: int | None = Field(default=None, alias="diskGB")
+    num_gpus: float | None = Field(default=None, alias="numGpus")
+    accelerator_type: str | None = Field(default=None, alias="acceleratorType")
+
+    @field_validator("cpu_count")
+    @classmethod
+    def validate_cpu_count(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError("cpuCount must be >= 1")
+        return v
+
+    @field_validator("memory_mb")
+    @classmethod
+    def validate_memory_mb(cls, v: int) -> int:
+        if v < 128:
+            raise ValueError("memoryMB must be >= 128")
+        return v
 
 
 class BatchSandboxStatusRequest(BaseModel):

--- a/rock/admin/proto/request.py
+++ b/rock/admin/proto/request.py
@@ -1,7 +1,7 @@
 from typing import Annotated, Literal, TypedDict
 
 from fastapi import Header
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from rock import env_vars
 from rock.actions import (
@@ -152,7 +152,7 @@ class TemplateCreateRequest(BaseModel):
     """Request body for creating a template (Warm path).
 
     External fields use E2B-style camelCase; internal snake_case via alias.
-    Phase 1 dedup key: (fromImage, cpuCount, memoryMB) only.
+    Dedup key: all non-null fields. Capacity is excluded from identity.
     """
 
     model_config = ConfigDict(populate_by_name=True)
@@ -177,6 +177,41 @@ class TemplateCreateRequest(BaseModel):
         if v < 128:
             raise ValueError("memoryMB must be >= 128")
         return v
+
+
+class TemplateScaleRequest(BaseModel):
+    """Request body for scaling a template's Pool capacity.
+
+    PATCH semantics: only provided fields are updated. All fields are optional.
+    pool_min/buffer_min may be 0.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    pool_min: int | None = Field(default=None, alias="poolMin")
+    pool_max: int | None = Field(default=None, alias="poolMax")
+    buffer_min: int | None = Field(default=None, alias="bufferMin")
+    buffer_max: int | None = Field(default=None, alias="bufferMax")
+
+    @field_validator("pool_min", "pool_max", "buffer_min", "buffer_max")
+    @classmethod
+    def validate_non_negative(cls, v: int | None, info) -> int | None:
+        if v is not None and v < 0:
+            raise ValueError(f"{info.field_name} must be >= 0")
+        return v
+
+    @model_validator(mode="after")
+    def validate_min_max(self):
+        pairs = [
+            ("pool_min", "pool_max"),
+            ("buffer_min", "buffer_max"),
+        ]
+        for min_field, max_field in pairs:
+            min_val = getattr(self, min_field)
+            max_val = getattr(self, max_field)
+            if min_val is not None and max_val is not None and min_val > max_val:
+                raise ValueError(f"{min_field} must be <= {max_field}")
+        return self
 
 
 class BatchSandboxStatusRequest(BaseModel):

--- a/rock/admin/proto/response.py
+++ b/rock/admin/proto/response.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from rock.actions import SandboxResponse
 from rock.actions.sandbox.response import State, StateTransitionRecord
@@ -102,6 +102,21 @@ class SandboxListResponse(SandboxResponse):
     items: list[SandboxListStatusResponse] = []
     total: int = 0
     has_more: bool = False
+
+
+class TemplateCreateResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    template_id: str = Field(alias="templateID")
+    status: str
+
+
+class TemplateStatusResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    template_id: str = Field(alias="templateID")
+    status: str
+    reason: dict | None = None
+    created_at: str = Field(default="", alias="createdAt")
+    updated_at: str = Field(default="", alias="updatedAt")
 
 
 class TaskSetMetadata(BaseModel):

--- a/rock/admin/proto/response.py
+++ b/rock/admin/proto/response.py
@@ -110,6 +110,27 @@ class TemplateCreateResponse(BaseModel):
     status: str
 
 
+class TemplateCapacitySpec(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    pool_min: int | None = Field(default=None, alias="poolMin")
+    pool_max: int | None = Field(default=None, alias="poolMax")
+    buffer_min: int | None = Field(default=None, alias="bufferMin")
+    buffer_max: int | None = Field(default=None, alias="bufferMax")
+
+
+class TemplateCapacityStatus(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    available: int | None = None
+    total: int | None = None
+    allocated: int | None = None
+
+
+class TemplateCapacityResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    spec: TemplateCapacitySpec
+    status: TemplateCapacityStatus
+
+
 class TemplateStatusResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     template_id: str = Field(alias="templateID")
@@ -117,6 +138,7 @@ class TemplateStatusResponse(BaseModel):
     reason: dict | None = None
     created_at: str = Field(default="", alias="createdAt")
     updated_at: str = Field(default="", alias="updatedAt")
+    capacity: TemplateCapacityResponse
 
 
 class TaskSetMetadata(BaseModel):

--- a/rock/config.py
+++ b/rock/config.py
@@ -389,6 +389,10 @@ class K8sConfig:
     # ROCK_IMAGE_AUTH_KEY environment variable if not set here.
     image_auth_key: str | None = None
 
+    # Pool rendering template for Template API (Warm path).
+    # Rendered via Jinja2 to produce Pool CRD spec.
+    pool_template: dict | None = None
+
     # ============================================================================
     # DEPRECATED: The following fields are deprecated and will be removed in a
     # future version. Do NOT use them in new code.

--- a/rock/sandbox/operator/abstract.py
+++ b/rock/sandbox/operator/abstract.py
@@ -1,6 +1,10 @@
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
 
 from rock.actions.sandbox.sandbox_info import SandboxInfo
+
+if TYPE_CHECKING:
+    from rock.sandbox.operator.k8s.provider import TemplateSpec
 from rock.admin.core.redis_key import alive_sandbox_key
 from rock.common.constants import StopReason
 from rock.config import RuntimeConfig
@@ -66,6 +70,38 @@ class AbstractOperator(ABC):
         from rock.deployments.status import ServiceStatus
 
         return ServiceStatus()
+
+    # ========================================================================
+    # Template API (Warm path) — default: raise NotImplementedError
+    # ========================================================================
+
+    async def create_template(self, spec: Any) -> dict:
+        """Create or reuse a template (Pool CRD).
+
+        Only K8sOperator supports this; other operators raise BadRequestRockError.
+        Returns a dict with template_id and status.
+        """
+        from rock.sdk.common.exceptions import BadRequestRockError
+
+        raise BadRequestRockError(f"template not supported on {type(self).__name__}")
+
+    async def get_template_status(self, template_id: str) -> dict | None:
+        """Get template (Pool) status.
+
+        Only K8sOperator supports this; other operators raise BadRequestRockError.
+        """
+        from rock.sdk.common.exceptions import BadRequestRockError
+
+        raise BadRequestRockError(f"template not supported on {type(self).__name__}")
+
+    async def delete_template(self, template_id: str) -> bool:
+        """Delete template (Pool CRD).
+
+        Only K8sOperator supports this; other operators raise BadRequestRockError.
+        """
+        from rock.sdk.common.exceptions import BadRequestRockError
+
+        raise BadRequestRockError(f"template not supported on {type(self).__name__}")
 
     def set_redis_provider(self, redis_provider: RedisProvider):
         self._redis_provider = redis_provider

--- a/rock/sandbox/operator/abstract.py
+++ b/rock/sandbox/operator/abstract.py
@@ -103,6 +103,15 @@ class AbstractOperator(ABC):
 
         raise BadRequestRockError(f"template not supported on {type(self).__name__}")
 
+    async def scale_template(self, template_id: str, capacity: dict[str, Any]) -> dict:
+        """Scale a template's Pool capacity.
+
+        Only K8sOperator supports this; other operators raise BadRequestRockError.
+        """
+        from rock.sdk.common.exceptions import BadRequestRockError
+
+        raise BadRequestRockError(f"template not supported on {type(self).__name__}")
+
     def set_redis_provider(self, redis_provider: RedisProvider):
         self._redis_provider = redis_provider
 

--- a/rock/sandbox/operator/k8s/constants.py
+++ b/rock/sandbox/operator/k8s/constants.py
@@ -31,3 +31,14 @@ class K8sConstants:
     # Nacos config keys
     NACOS_POOLS_KEY = "pools"
     NACOS_TEMPLATE_RULES_KEY = "template_rules"
+
+    # Pool CRD (Warm path: Template API creates Pool CRD)
+    CRD_PLURAL_POOL = "pools"
+    CRD_KIND_POOL = "Pool"
+
+    # Label: distinguish Template API created Pools from system-configured Pools
+    LABEL_MANAGED_BY = "rock.sandbox/managed-by"
+    LABEL_MANAGED_BY_TEMPLATE_API = "template-api"
+
+    # templateID prefix
+    TEMPLATE_ID_PREFIX = "tpl-"

--- a/rock/sandbox/operator/k8s/operator.py
+++ b/rock/sandbox/operator/k8s/operator.py
@@ -7,7 +7,7 @@ from rock.deployments.config import DockerDeploymentConfig
 from rock.logger import init_logger
 from rock.sandbox.operator.abstract import AbstractOperator
 from rock.sandbox.operator.k8s.constants import K8sConstants
-from rock.sandbox.operator.k8s.provider import BatchSandboxProvider
+from rock.sandbox.operator.k8s.provider import BatchSandboxProvider, TemplateSpec
 
 logger = init_logger(__name__)
 
@@ -142,3 +142,36 @@ class K8sOperator(AbstractOperator):
 
     async def delete(self, config: DockerDeploymentConfig, host_ip: str | None = None) -> bool:
         raise NotImplementedError("delete is not yet implemented for K8sOperator")
+
+    # ========================================================================
+    # Template API (Warm path)
+    # ========================================================================
+
+    async def create_template(self, spec: TemplateSpec) -> dict:
+        """Create or reuse a template (Pool CRD).
+
+        Returns a dict with template_id and status.
+        """
+        return await self._provider.create_template(spec)
+
+    async def get_template_status(self, template_id: str) -> dict | None:
+        """Get template (Pool) status.
+
+        Args:
+            template_id: Template identifier (= Pool name)
+
+        Returns:
+            Status dict or None if not found
+        """
+        return await self._provider.get_template_status(template_id)
+
+    async def delete_template(self, template_id: str) -> bool:
+        """Delete template (Pool CRD).
+
+        Args:
+            template_id: Template identifier (= Pool name)
+
+        Returns:
+            True if deleted or not found, False if in use
+        """
+        return await self._provider.delete_template(template_id)

--- a/rock/sandbox/operator/k8s/operator.py
+++ b/rock/sandbox/operator/k8s/operator.py
@@ -1,5 +1,7 @@
 """K8s Operator implementation for managing sandboxes via Kubernetes."""
 
+from typing import Any
+
 from rock.actions.sandbox.sandbox_info import SandboxInfo
 from rock.common.constants import StopReason
 from rock.config import K8sConfig
@@ -175,3 +177,15 @@ class K8sOperator(AbstractOperator):
             True if deleted or not found, False if in use
         """
         return await self._provider.delete_template(template_id)
+
+    async def scale_template(self, template_id: str, capacity: dict[str, Any]) -> dict:
+        """Scale a template's Pool capacity.
+
+        Args:
+            template_id: Template identifier (= Pool name).
+            capacity: Snake-case capacity fields to update.
+
+        Returns:
+            Updated template status dict.
+        """
+        return await self._provider.scale_template(template_id, capacity)

--- a/rock/sandbox/operator/k8s/provider.py
+++ b/rock/sandbox/operator/k8s/provider.py
@@ -1,7 +1,6 @@
 """K8s provider implementations for managing sandbox resources."""
 
 import base64
-import copy
 import fnmatch
 import hashlib
 import json
@@ -11,13 +10,14 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Protocol
 
-import jinja2
 import yaml
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from kubernetes import client
 from kubernetes import config as k8s_config
 
+from rock import InternalServerRockError
 from rock.actions.sandbox.config import RemoteSandboxRuntimeConfig
+from rock.sdk.common.exceptions import BadRequestRockError
 from rock.actions.sandbox.sandbox_info import SandboxInfo
 from rock.config import K8sConfig, PoolConfig, TemplateSelectorRule
 from rock.deployments.config import DockerDeploymentConfig
@@ -27,14 +27,18 @@ from rock.sandbox.operator.k8s.api_client import K8sApiClient
 from rock.sandbox.operator.k8s.constants import K8sConstants
 from rock.sandbox.operator.k8s.template_loader import K8sTemplateLoader
 from rock.sandbox.remote_sandbox import RemoteSandboxRuntime
-from rock.utils.jinja_render import render_node
 
 logger = init_logger(__name__)
 
 
 @dataclass
 class TemplateSpec:
-    """Template creation spec, maps to API camelCase fields."""
+    """Template creation spec, maps to API camelCase fields.
+
+    Capacity (poolMin/poolMax/bufferMin/bufferMax) is intentionally excluded
+    because it does not affect template identity. Use the Scale API to adjust
+    capacity after creation.
+    """
 
     from_image: str
     cpu_count: int
@@ -42,19 +46,28 @@ class TemplateSpec:
     disk_gb: int | None = None
     num_gpus: float | None = None
     accelerator_type: str | None = None
-    buffer_min: int | None = None
-    buffer_max: int | None = None
-    pool_min: int | None = None
-    pool_max: int | None = None
 
 
 def generate_template_id(spec: TemplateSpec) -> str:
-    """Generate template ID from (from_image, cpu_count, memory_mb) only.
+    """Generate template ID from all non-null TemplateSpec fields.
 
-    Phase 1 dedup key: same (fromImage, cpuCount, memoryMB) → same templateID.
-    diskGB, numGpus, acceleratorType are placeholder fields, ignored.
+    The ID is a hash of every provided field, so any difference in
+    from_image, cpu_count, memory_mb, disk_gb, num_gpus, or accelerator_type
+    produces a distinct templateID. Capacity is excluded from identity.
     """
-    raw = f"{spec.from_image}|{spec.cpu_count}|{spec.memory_mb}"
+    parts: list[str] = [
+        f"from_image={spec.from_image}",
+        f"cpu_count={spec.cpu_count}",
+        f"memory_mb={spec.memory_mb}",
+    ]
+    if spec.disk_gb is not None:
+        parts.append(f"disk_gb={spec.disk_gb}")
+    if spec.num_gpus is not None:
+        parts.append(f"num_gpus={spec.num_gpus}")
+    if spec.accelerator_type is not None:
+        parts.append(f"accelerator_type={spec.accelerator_type}")
+
+    raw = "|".join(parts)
     digest = hashlib.sha256(raw.encode()).hexdigest()[:16]
     return f"{K8sConstants.TEMPLATE_ID_PREFIX}{digest}"
 
@@ -311,14 +324,11 @@ class BatchSandboxProvider(K8sProvider):
         self._nacos_provider = None
         self._image_auth_key = self._load_image_auth_key(k8s_config)
 
-        # Pool template for Template API (Warm path)
-        self._pool_template = k8s_config.pool_template
-        self._jinja_env = jinja2.Environment()
-
-        # Initialize template loader with config templates
+        # Initialize template loader with config templates and pool template
         self._template_loader = K8sTemplateLoader(
             templates=k8s_config.templates,
             default_namespace=k8s_config.namespace,
+            pool_template=k8s_config.pool_template,
         )
         logger.info(f"Available K8S templates: {', '.join(self._template_loader.available_templates)}")
 
@@ -923,28 +933,22 @@ class BatchSandboxProvider(K8sProvider):
     async def create_template(self, spec: TemplateSpec) -> dict:
         """Create or reuse a template (Pool CRD).
 
-        Idempotent: same (fromImage, cpuCount, memoryMB) produces the same templateID.
-        Returns a dict with template_id and status.
+        Idempotent: same non-null TemplateSpec fields produce the same templateID.
+        Capacity is excluded from identity. Returns a dict with template_id and status.
         """
         await self._ensure_initialized()
         template_id = generate_template_id(spec)
 
-        # Check if already exists
-        existing = await self._get_pool(template_id)
-        if existing is not None:
-            logger.info(f"Template {template_id} already exists, reusing")
-            return self._map_pool_to_template_status(existing)
-
-        # Create new Pool CRD
-        await self._create_pool(template_id, spec)
-        # Return waiting status (just submitted, controller hasn't started)
-        return {
-            "template_id": template_id,
-            "status": "waiting",
-            "reason": None,
-            "created_at": "",
-            "updated_at": "",
-        }
+        try:
+            # _create_pool handles creation and 409 (already exists), returning
+            # the created or existing Pool object. Map it to template status.
+            pool = await self._create_pool(template_id, spec)
+            return self._map_pool_to_template_status(pool)
+        except InternalServerRockError:
+            raise
+        except Exception as e:
+            logger.error(f"Failed to create template {template_id}: {e}", exc_info=True)
+            raise InternalServerRockError(f"Failed to create template {template_id}: {e}") from e
 
     async def get_template_status(self, template_id: str) -> dict | None:
         """Get template (Pool) status.
@@ -956,10 +960,16 @@ class BatchSandboxProvider(K8sProvider):
             Status dict or None if not found
         """
         await self._ensure_initialized()
-        pool = await self._get_pool(template_id)
-        if pool is None:
-            return None
-        return self._map_pool_to_template_status(pool)
+        try:
+            pool = await self._get_pool(template_id)
+            if pool is None:
+                return None
+            return self._map_pool_to_template_status(pool)
+        except InternalServerRockError:
+            raise
+        except Exception as e:
+            logger.error(f"Failed to get template status {template_id}: {e}", exc_info=True)
+            raise InternalServerRockError(f"Failed to get template status {template_id}: {e}") from e
 
     async def delete_template(self, template_id: str) -> bool:
         """Delete template (Pool CRD).
@@ -968,29 +978,114 @@ class BatchSandboxProvider(K8sProvider):
             template_id: Template identifier (= Pool name)
 
         Returns:
-            True if deleted or not found, False if in use
+            True if deleted or not found. Raises on K8s error.
+
+        Note:
+            We do NOT check whether the pool is referenced by running BatchSandboxes.
+            The Pool controller / K8s finalizer is responsible for protecting an
+            in-use pool. Listing all BatchSandboxes here is too expensive and couples
+            Template API to sandbox lifecycle details.
         """
         await self._ensure_initialized()
 
-        # Check if pool exists
-        pool = await self._get_pool(template_id)
-        if pool is None:
-            logger.info(f"Template {template_id} not found, already deleted")
+        try:
+            # Check if pool exists
+            pool = await self._get_pool(template_id)
+            if pool is None:
+                logger.info(f"Template {template_id} not found, already deleted")
+                return True
+
+            await self._delete_pool(template_id)
             return True
+        except InternalServerRockError:
+            raise
+        except Exception as e:
+            logger.error(f"Failed to delete template {template_id}: {e}", exc_info=True)
+            raise InternalServerRockError(f"Failed to delete template {template_id}: {e}") from e
 
-        # Check if in use
-        if await self._is_pool_in_use(template_id):
-            logger.warning(f"Template {template_id} is in use, cannot delete")
-            return False
+    async def scale_template(self, template_id: str, capacity: dict[str, Any]) -> dict:
+        """Scale a template's Pool capacity.
 
-        await self._delete_pool(template_id)
-        return True
+        Args:
+            template_id: Template identifier (= Pool name).
+            capacity: Snake-case capacity fields to update. Only provided keys
+                are sent to K8s (PATCH semantics). Supported keys:
+                pool_min, pool_max, buffer_min, buffer_max.
 
-    async def _create_pool(self, pool_name: str, spec: TemplateSpec) -> None:
-        """Create Pool CRD from template."""
+        Returns:
+            Updated template status dict.
+
+        Raises:
+            BadRequestRockError: If the pool does not exist or capacity is invalid.
+            InternalServerRockError: On unexpected K8s errors.
+        """
+        await self._ensure_initialized()
+
+        if not capacity:
+            raise BadRequestRockError("No capacity fields provided")
+
+        valid_keys = {"pool_min", "pool_max", "buffer_min", "buffer_max"}
+        invalid_keys = set(capacity.keys()) - valid_keys
+        if invalid_keys:
+            raise BadRequestRockError(f"Invalid capacity fields: {sorted(invalid_keys)}")
+
+        key_map = {
+            "pool_min": "poolMin",
+            "pool_max": "poolMax",
+            "buffer_min": "bufferMin",
+            "buffer_max": "bufferMax",
+        }
+        capacity_spec_patch: dict[str, Any] = {}
+        for key, value in capacity.items():
+            if value is not None:
+                capacity_spec_patch[key_map[key]] = int(value)
+
+        try:
+            pool = await self._get_pool(template_id)
+            if pool is None:
+                raise BadRequestRockError(f"Template {template_id} not found")
+
+            patch_body = {"spec": {"capacitySpec": capacity_spec_patch}}
+            updated = await self._pool_api.update_custom_object(
+                name=template_id,
+                body=patch_body,
+            )
+            return self._map_pool_to_template_status(updated)
+        except BadRequestRockError:
+            raise
+        except InternalServerRockError:
+            raise
+        except Exception as e:
+            logger.error(f"Failed to scale template {template_id}: {e}", exc_info=True)
+            raise InternalServerRockError(f"Failed to scale template {template_id}: {e}") from e
+
+    async def _create_pool(self, pool_name: str, spec: TemplateSpec) -> dict[str, Any]:
+        """Create Pool CRD from template.
+
+        Returns:
+            The created Pool object, or the existing Pool object if it already
+            existed (409).
+        """
         manifest = self._build_pool_manifest_from_template(pool_name, spec)
-        await self._pool_api.create_custom_object(body=manifest)
-        logger.info(f"Created Pool {pool_name} for template")
+        try:
+            pool = await self._pool_api.create_custom_object(body=manifest)
+            logger.info(f"Created Pool {pool_name} for template")
+            return pool
+        except client.exceptions.ApiException as e:
+            if e.status == 409:
+                # Idempotent: another request created it concurrently
+                logger.info(f"Pool {pool_name} already exists, reusing")
+                existing = await self._get_pool(pool_name)
+                if existing is None:
+                    raise InternalServerRockError(
+                        f"Pool {pool_name} returned 409 but could not be fetched"
+                    ) from e
+                return existing
+            logger.error(f"Failed to create Pool {pool_name}: {e}", exc_info=True)
+            raise InternalServerRockError(f"Failed to create Pool {pool_name}: {e.reason}") from e
+        except Exception as e:
+            logger.error(f"Unexpected error creating Pool {pool_name}: {e}", exc_info=True)
+            raise InternalServerRockError(f"Failed to create Pool {pool_name}: {e}") from e
 
     async def _get_pool(self, pool_name: str) -> dict | None:
         """Get Pool CRD from cache.
@@ -999,76 +1094,37 @@ class BatchSandboxProvider(K8sProvider):
         """
         try:
             return await self._pool_api.get_custom_object(name=pool_name)
-        except Exception as e:
-            if hasattr(e, "status") and e.status == 404:
+        except client.exceptions.ApiException as e:
+            if e.status == 404:
                 return None
-            raise
+            logger.error(f"Failed to get Pool {pool_name}: {e}", exc_info=True)
+            raise InternalServerRockError(f"Failed to get Pool {pool_name}: {e.reason}") from e
+        except Exception as e:
+            logger.error(f"Failed to get Pool {pool_name}: {e}", exc_info=True)
+            raise InternalServerRockError(f"Failed to get Pool {pool_name}: {e}") from e
 
     async def _delete_pool(self, pool_name: str) -> None:
         """Delete Pool CRD."""
-        await self._pool_api.delete_custom_object(name=pool_name)
-        logger.info(f"Deleted Pool {pool_name}")
-
-    async def _is_pool_in_use(self, pool_name: str) -> bool:
-        """Check if any BatchSandbox references this pool."""
-        sandboxes = await self._k8s_api.list_custom_objects()
-        for sb in sandboxes:
-            pool_ref = sb.get("spec", {}).get("poolRef")
-            if pool_ref == pool_name:
-                return True
-        return False
+        try:
+            await self._pool_api.delete_custom_object(name=pool_name)
+            logger.info(f"Deleted Pool {pool_name}")
+        except client.exceptions.ApiException as e:
+            if e.status == 404:
+                logger.info(f"Pool {pool_name} not found, treating as deleted")
+                return
+            logger.error(f"Failed to delete Pool {pool_name}: {e}", exc_info=True)
+            raise InternalServerRockError(f"Failed to delete Pool {pool_name}: {e.reason}") from e
+        except Exception as e:
+            logger.error(f"Unexpected error deleting Pool {pool_name}: {e}", exc_info=True)
+            raise InternalServerRockError(f"Failed to delete Pool {pool_name}: {e}") from e
 
     def _build_pool_manifest_from_template(self, pool_name: str, spec: TemplateSpec) -> dict[str, Any]:
         """Build Pool CRD manifest from config template and spec.
 
-        Renders Jinja2 variables in the pool_template config:
-        from_image, cpu_count, memory_mb, disk_gb, num_gpus, accelerator_type,
-        buffer_min, buffer_max, pool_min, pool_max
+        Delegates to the shared K8sTemplateLoader so pool and sandbox template
+        rendering live in one place.
         """
-        template = copy.deepcopy(self._pool_template)
-
-        ctx: dict[str, Any] = {
-            "from_image": spec.from_image,
-            "cpu_count": spec.cpu_count,
-            "memory_mb": spec.memory_mb,
-        }
-        if spec.disk_gb is not None:
-            ctx["disk_gb"] = spec.disk_gb
-        if spec.num_gpus is not None:
-            ctx["num_gpus"] = spec.num_gpus
-        if spec.accelerator_type is not None:
-            ctx["accelerator_type"] = spec.accelerator_type
-        if spec.buffer_min is not None:
-            ctx["buffer_min"] = spec.buffer_min
-        if spec.buffer_max is not None:
-            ctx["buffer_max"] = spec.buffer_max
-        if spec.pool_min is not None:
-            ctx["pool_min"] = spec.pool_min
-        if spec.pool_max is not None:
-            ctx["pool_max"] = spec.pool_max
-
-        rendered = render_node(template, self._jinja_env, ctx)
-
-        # Ensure capacitySpec values are integers (Jinja2 renders them as strings)
-        cap = rendered.get("capacitySpec", {})
-        if cap:
-            for k in ("bufferMin", "bufferMax", "poolMin", "poolMax"):
-                if k in cap:
-                    cap[k] = int(cap[k])
-
-        manifest = {
-            "apiVersion": K8sConstants.CRD_API_VERSION,
-            "kind": K8sConstants.CRD_KIND_POOL,
-            "metadata": {
-                "name": pool_name,
-                "namespace": self.namespace,
-                "labels": {
-                    K8sConstants.LABEL_MANAGED_BY: K8sConstants.LABEL_MANAGED_BY_TEMPLATE_API,
-                },
-            },
-            "spec": rendered,
-        }
-        return manifest
+        return self._template_loader.build_pool_manifest(pool_name, spec)
 
     def _map_pool_to_template_status(self, pool: dict) -> dict:
         """Map Pool CRD to template status dict (design doc format)."""
@@ -1079,34 +1135,25 @@ class BatchSandboxProvider(K8sProvider):
         ready_replicas = status.get("available", 0)
         total_replicas = status.get("total", 0)
 
+        # If the pool is configured with zero capacity, it is immediately ready
+        # because no standby pods are required.
+        capacity_spec = pool.get("spec", {}).get("capacitySpec", {})
+        pool_min = capacity_spec.get("poolMin", 1)
+        buffer_min = capacity_spec.get("bufferMin", 1)
+        zero_capacity = pool_min == 0 and buffer_min == 0
+
         # Determine template status
-        if ready_replicas > 0:
+        if ready_replicas > 0 or zero_capacity:
             template_status = "ready"
         elif total_replicas > 0:
             template_status = "building"
         else:
             template_status = "building"
 
-        # Check for error conditions
-        conditions = status.get("conditions", [])
-        error_message = None
-        for cond in conditions:
-            if cond.get("type") == "Ready" and cond.get("status") == "False":
-                template_status = "error"
-                error_message = cond.get("message", "pool creation failed")
-                break
-
-        # Build reason if error
         reason = None
-        if template_status == "error":
-            reason = {
-                "message": error_message or "pool creation failed",
-                "step": "create_fiber_pool",
-                "logEntries": [],
-            }
 
         created_at = metadata.get("creationTimestamp", "")
-        updated_at = status.get("updatedTime", created_at)
+        updated_at = created_at
 
         return {
             "template_id": pool_name,
@@ -1114,4 +1161,17 @@ class BatchSandboxProvider(K8sProvider):
             "reason": reason,
             "created_at": created_at,
             "updated_at": updated_at,
+            "capacity": {
+                "spec": {
+                    "pool_min": capacity_spec.get("poolMin"),
+                    "pool_max": capacity_spec.get("poolMax"),
+                    "buffer_min": capacity_spec.get("bufferMin"),
+                    "buffer_max": capacity_spec.get("bufferMax"),
+                },
+                "status": {
+                    "available": status.get("available"),
+                    "total": status.get("total"),
+                    "allocated": status.get("allocated"),
+                },
+            },
         }

--- a/rock/sandbox/operator/k8s/provider.py
+++ b/rock/sandbox/operator/k8s/provider.py
@@ -1,13 +1,17 @@
 """K8s provider implementations for managing sandbox resources."""
 
 import base64
+import copy
 import fnmatch
+import hashlib
 import json
 import os
 import re
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Any, Protocol
 
+import jinja2
 import yaml
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from kubernetes import client
@@ -23,8 +27,36 @@ from rock.sandbox.operator.k8s.api_client import K8sApiClient
 from rock.sandbox.operator.k8s.constants import K8sConstants
 from rock.sandbox.operator.k8s.template_loader import K8sTemplateLoader
 from rock.sandbox.remote_sandbox import RemoteSandboxRuntime
+from rock.utils.jinja_render import render_node
 
 logger = init_logger(__name__)
+
+
+@dataclass
+class TemplateSpec:
+    """Template creation spec, maps to API camelCase fields."""
+
+    from_image: str
+    cpu_count: int
+    memory_mb: int
+    disk_gb: int | None = None
+    num_gpus: float | None = None
+    accelerator_type: str | None = None
+    buffer_min: int | None = None
+    buffer_max: int | None = None
+    pool_min: int | None = None
+    pool_max: int | None = None
+
+
+def generate_template_id(spec: TemplateSpec) -> str:
+    """Generate template ID from (from_image, cpu_count, memory_mb) only.
+
+    Phase 1 dedup key: same (fromImage, cpuCount, memoryMB) → same templateID.
+    diskGB, numGpus, acceleratorType are placeholder fields, ignored.
+    """
+    raw = f"{spec.from_image}|{spec.cpu_count}|{spec.memory_mb}"
+    digest = hashlib.sha256(raw.encode()).hexdigest()[:16]
+    return f"{K8sConstants.TEMPLATE_ID_PREFIX}{digest}"
 
 
 class PoolSelector(ABC):
@@ -274,9 +306,14 @@ class BatchSandboxProvider(K8sProvider):
         self._k8s_config = k8s_config
         self._api_client = None
         self._k8s_api: K8sApiClient | None = None
+        self._pool_api: K8sApiClient | None = None
         self._initialized = False
         self._nacos_provider = None
         self._image_auth_key = self._load_image_auth_key(k8s_config)
+
+        # Pool template for Template API (Warm path)
+        self._pool_template = k8s_config.pool_template
+        self._jinja_env = jinja2.Environment()
 
         # Initialize template loader with config templates
         self._template_loader = K8sTemplateLoader(
@@ -522,6 +559,19 @@ class BatchSandboxProvider(K8sProvider):
                 resync_period=self._k8s_config.resync_period,
             )
             await self._k8s_api.start()
+
+            # Pool CRD informer for Template API (Warm path)
+            self._pool_api = K8sApiClient(
+                api_client=self._api_client,
+                group=K8sConstants.CRD_GROUP,
+                version=K8sConstants.CRD_VERSION,
+                plural=K8sConstants.CRD_PLURAL_POOL,
+                namespace=self.namespace,
+                qps=self._k8s_config.api_qps,
+                resync_period=self._k8s_config.resync_period,
+            )
+            await self._pool_api.start()
+
             self._initialized = True
 
             logger.info("Initialized K8s provider with informer")
@@ -865,3 +915,203 @@ class BatchSandboxProvider(K8sProvider):
             port=proxy_port,
         )
         return RemoteSandboxRuntime.from_config(runtime_config)
+
+    # ========================================================================
+    # Template API (Warm path) — create / get / delete Pool CRD
+    # ========================================================================
+
+    async def create_template(self, spec: TemplateSpec) -> dict:
+        """Create or reuse a template (Pool CRD).
+
+        Idempotent: same (fromImage, cpuCount, memoryMB) produces the same templateID.
+        Returns a dict with template_id and status.
+        """
+        await self._ensure_initialized()
+        template_id = generate_template_id(spec)
+
+        # Check if already exists
+        existing = await self._get_pool(template_id)
+        if existing is not None:
+            logger.info(f"Template {template_id} already exists, reusing")
+            return self._map_pool_to_template_status(existing)
+
+        # Create new Pool CRD
+        await self._create_pool(template_id, spec)
+        # Return waiting status (just submitted, controller hasn't started)
+        return {
+            "template_id": template_id,
+            "status": "waiting",
+            "reason": None,
+            "created_at": "",
+            "updated_at": "",
+        }
+
+    async def get_template_status(self, template_id: str) -> dict | None:
+        """Get template (Pool) status.
+
+        Args:
+            template_id: Template identifier (= Pool name)
+
+        Returns:
+            Status dict or None if not found
+        """
+        await self._ensure_initialized()
+        pool = await self._get_pool(template_id)
+        if pool is None:
+            return None
+        return self._map_pool_to_template_status(pool)
+
+    async def delete_template(self, template_id: str) -> bool:
+        """Delete template (Pool CRD).
+
+        Args:
+            template_id: Template identifier (= Pool name)
+
+        Returns:
+            True if deleted or not found, False if in use
+        """
+        await self._ensure_initialized()
+
+        # Check if pool exists
+        pool = await self._get_pool(template_id)
+        if pool is None:
+            logger.info(f"Template {template_id} not found, already deleted")
+            return True
+
+        # Check if in use
+        if await self._is_pool_in_use(template_id):
+            logger.warning(f"Template {template_id} is in use, cannot delete")
+            return False
+
+        await self._delete_pool(template_id)
+        return True
+
+    async def _create_pool(self, pool_name: str, spec: TemplateSpec) -> None:
+        """Create Pool CRD from template."""
+        manifest = self._build_pool_manifest_from_template(pool_name, spec)
+        await self._pool_api.create_custom_object(body=manifest)
+        logger.info(f"Created Pool {pool_name} for template")
+
+    async def _get_pool(self, pool_name: str) -> dict | None:
+        """Get Pool CRD from cache.
+
+        Returns None if not found.
+        """
+        try:
+            return await self._pool_api.get_custom_object(name=pool_name)
+        except Exception as e:
+            if hasattr(e, "status") and e.status == 404:
+                return None
+            raise
+
+    async def _delete_pool(self, pool_name: str) -> None:
+        """Delete Pool CRD."""
+        await self._pool_api.delete_custom_object(name=pool_name)
+        logger.info(f"Deleted Pool {pool_name}")
+
+    async def _is_pool_in_use(self, pool_name: str) -> bool:
+        """Check if any BatchSandbox references this pool."""
+        sandboxes = await self._k8s_api.list_custom_objects()
+        for sb in sandboxes:
+            pool_ref = sb.get("spec", {}).get("poolRef")
+            if pool_ref == pool_name:
+                return True
+        return False
+
+    def _build_pool_manifest_from_template(self, pool_name: str, spec: TemplateSpec) -> dict[str, Any]:
+        """Build Pool CRD manifest from config template and spec.
+
+        Renders Jinja2 variables in the pool_template config:
+        from_image, cpu_count, memory_mb, disk_gb, num_gpus, accelerator_type,
+        buffer_min, buffer_max, pool_min, pool_max
+        """
+        template = copy.deepcopy(self._pool_template)
+
+        ctx: dict[str, Any] = {
+            "from_image": spec.from_image,
+            "cpu_count": spec.cpu_count,
+            "memory_mb": spec.memory_mb,
+        }
+        if spec.disk_gb is not None:
+            ctx["disk_gb"] = spec.disk_gb
+        if spec.num_gpus is not None:
+            ctx["num_gpus"] = spec.num_gpus
+        if spec.accelerator_type is not None:
+            ctx["accelerator_type"] = spec.accelerator_type
+        if spec.buffer_min is not None:
+            ctx["buffer_min"] = spec.buffer_min
+        if spec.buffer_max is not None:
+            ctx["buffer_max"] = spec.buffer_max
+        if spec.pool_min is not None:
+            ctx["pool_min"] = spec.pool_min
+        if spec.pool_max is not None:
+            ctx["pool_max"] = spec.pool_max
+
+        rendered = render_node(template, self._jinja_env, ctx)
+
+        # Ensure capacitySpec values are integers (Jinja2 renders them as strings)
+        cap = rendered.get("capacitySpec", {})
+        if cap:
+            for k in ("bufferMin", "bufferMax", "poolMin", "poolMax"):
+                if k in cap:
+                    cap[k] = int(cap[k])
+
+        manifest = {
+            "apiVersion": K8sConstants.CRD_API_VERSION,
+            "kind": K8sConstants.CRD_KIND_POOL,
+            "metadata": {
+                "name": pool_name,
+                "namespace": self.namespace,
+                "labels": {
+                    K8sConstants.LABEL_MANAGED_BY: K8sConstants.LABEL_MANAGED_BY_TEMPLATE_API,
+                },
+            },
+            "spec": rendered,
+        }
+        return manifest
+
+    def _map_pool_to_template_status(self, pool: dict) -> dict:
+        """Map Pool CRD to template status dict (design doc format)."""
+        pool_name = pool.get("metadata", {}).get("name", "")
+        status = pool.get("status", {})
+        metadata = pool.get("metadata", {})
+
+        ready_replicas = status.get("available", 0)
+        total_replicas = status.get("total", 0)
+
+        # Determine template status
+        if ready_replicas > 0:
+            template_status = "ready"
+        elif total_replicas > 0:
+            template_status = "building"
+        else:
+            template_status = "building"
+
+        # Check for error conditions
+        conditions = status.get("conditions", [])
+        error_message = None
+        for cond in conditions:
+            if cond.get("type") == "Ready" and cond.get("status") == "False":
+                template_status = "error"
+                error_message = cond.get("message", "pool creation failed")
+                break
+
+        # Build reason if error
+        reason = None
+        if template_status == "error":
+            reason = {
+                "message": error_message or "pool creation failed",
+                "step": "create_fiber_pool",
+                "logEntries": [],
+            }
+
+        created_at = metadata.get("creationTimestamp", "")
+        updated_at = status.get("updatedTime", created_at)
+
+        return {
+            "template_id": pool_name,
+            "status": template_status,
+            "reason": reason,
+            "created_at": created_at,
+            "updated_at": updated_at,
+        }

--- a/rock/sandbox/operator/k8s/template_loader.py
+++ b/rock/sandbox/operator/k8s/template_loader.py
@@ -193,9 +193,6 @@ class K8sTemplateLoader:
         are intentionally excluded from ``spec``; they are supplied by the pool
         template defaults and can be adjusted later via the Scale API.
 
-        After rendering, ``capacitySpec`` integer fields are converted from
-        strings back to ints (Jinja2 renders numbers as strings).
-
         Args:
             pool_name: Name for the Pool CRD (also the template ID).
             spec: Template creation spec with the attributes listed above.
@@ -224,13 +221,6 @@ class K8sTemplateLoader:
             ctx["accelerator_type"] = spec.accelerator_type
 
         rendered = render_node(template, self._jinja_env, ctx)
-
-        # Ensure capacitySpec values are integers (Jinja2 renders them as strings)
-        cap = rendered.get("capacitySpec", {})
-        if cap:
-            for k in ("bufferMin", "bufferMax", "poolMin", "poolMax"):
-                if k in cap:
-                    cap[k] = int(cap[k])
 
         return {
             "apiVersion": K8sConstants.CRD_API_VERSION,

--- a/rock/sandbox/operator/k8s/template_loader.py
+++ b/rock/sandbox/operator/k8s/template_loader.py
@@ -1,4 +1,4 @@
-"""K8S template loader for BatchSandbox manifests."""
+"""K8S template loader for BatchSandbox and Pool manifests."""
 
 import copy
 import json
@@ -14,17 +14,24 @@ logger = init_logger(__name__)
 
 
 class K8sTemplateLoader:
-    """Loader for K8S BatchSandbox templates."""
+    """Loader for K8S BatchSandbox and Pool CRD manifests."""
 
-    def __init__(self, templates: dict[str, dict[str, Any]], default_namespace: str = "rock"):
+    def __init__(
+        self,
+        templates: dict[str, dict[str, Any]],
+        default_namespace: str = "rock",
+        pool_template: dict[str, Any] | None = None,
+    ):
         """Initialize template loader.
 
         Args:
-            templates: Dictionary of template configurations from K8sConfig
+            templates: Dictionary of BatchSandbox template configurations from K8sConfig
             default_namespace: Default namespace if template doesn't specify one
+            pool_template: Optional Pool CRD template for Template API (Warm path)
         """
         self._templates: dict[str, dict[str, Any]] = templates
         self._default_namespace = default_namespace
+        self._pool_template = pool_template
 
         if not self._templates:
             raise ValueError("No templates provided. At least one template must be defined in K8sConfig.templates.")
@@ -176,6 +183,67 @@ class K8sTemplateLoader:
         manifest["spec"]["template"]["metadata"]["labels"][K8sConstants.LABEL_SANDBOX_ID] = sandbox_id
 
         return manifest
+
+    def build_pool_manifest(self, pool_name: str, spec: Any) -> dict[str, Any]:
+        """Build a complete Pool CRD manifest from the pool template and spec.
+
+        The pool template is rendered with Jinja2 against a context built from
+        ``spec``: from_image, cpu_count, memory_mb, disk_gb, num_gpus,
+        accelerator_type. Capacity fields (poolMin/poolMax/bufferMin/bufferMax)
+        are intentionally excluded from ``spec``; they are supplied by the pool
+        template defaults and can be adjusted later via the Scale API.
+
+        After rendering, ``capacitySpec`` integer fields are converted from
+        strings back to ints (Jinja2 renders numbers as strings).
+
+        Args:
+            pool_name: Name for the Pool CRD (also the template ID).
+            spec: Template creation spec with the attributes listed above.
+
+        Returns:
+            Complete Pool CRD manifest.
+
+        Raises:
+            ValueError: If no pool template was configured.
+        """
+        if not self._pool_template:
+            raise ValueError("No pool template configured. Set k8s.pool_template in config.")
+
+        template = copy.deepcopy(self._pool_template)
+
+        ctx: dict[str, Any] = {
+            "from_image": spec.from_image,
+            "cpu_count": spec.cpu_count,
+            "memory_mb": spec.memory_mb,
+        }
+        if spec.disk_gb is not None:
+            ctx["disk_gb"] = spec.disk_gb
+        if spec.num_gpus is not None:
+            ctx["num_gpus"] = spec.num_gpus
+        if spec.accelerator_type is not None:
+            ctx["accelerator_type"] = spec.accelerator_type
+
+        rendered = render_node(template, self._jinja_env, ctx)
+
+        # Ensure capacitySpec values are integers (Jinja2 renders them as strings)
+        cap = rendered.get("capacitySpec", {})
+        if cap:
+            for k in ("bufferMin", "bufferMax", "poolMin", "poolMax"):
+                if k in cap:
+                    cap[k] = int(cap[k])
+
+        return {
+            "apiVersion": K8sConstants.CRD_API_VERSION,
+            "kind": K8sConstants.CRD_KIND_POOL,
+            "metadata": {
+                "name": pool_name,
+                "namespace": self._default_namespace,
+                "labels": {
+                    K8sConstants.LABEL_MANAGED_BY: K8sConstants.LABEL_MANAGED_BY_TEMPLATE_API,
+                },
+            },
+            "spec": rendered,
+        }
 
     @property
     def available_templates(self) -> list[str]:

--- a/rock/sandbox/sandbox_manager.py
+++ b/rock/sandbox/sandbox_manager.py
@@ -3,6 +3,7 @@ import datetime
 import time
 import zoneinfo
 from datetime import timezone
+from typing import Any
 
 from fastapi import UploadFile
 
@@ -118,6 +119,17 @@ class SandboxManager(BaseManager):
         if self._operator is None:
             raise BadRequestRockError("No operator configured")
         return await self._operator.delete_template(template_id)
+
+    async def scale_template(self, template_id: str, capacity: dict[str, Any]) -> dict:
+        """Scale a template's Pool capacity.
+
+        ``capacity`` uses snake_case keys (pool_min, pool_max, buffer_min,
+        buffer_max) and only contains fields that were provided by the caller.
+        Delegates to operator. Non-K8s operators raise BadRequestRockError.
+        """
+        if self._operator is None:
+            raise BadRequestRockError("No operator configured")
+        return await self._operator.scale_template(template_id, capacity)
 
     def _init_archive_storage(self, rock_config: RockConfig) -> None:
         archive_cfg = rock_config.lifecycle.archive

--- a/rock/sandbox/sandbox_manager.py
+++ b/rock/sandbox/sandbox_manager.py
@@ -87,6 +87,38 @@ class SandboxManager(BaseManager):
         self._proxy_service = create_sandbox_proxy_service(rock_config=rock_config, meta_store=meta_store)
         logger.info("sandbox service init success")
 
+    # ========================================================================
+    # Template API (Warm path) — delegate to operator
+    # ========================================================================
+
+    async def create_template(self, spec) -> dict:
+        """Create or reuse a template (Pool CRD).
+
+        Delegates to operator. Non-K8s operators raise BadRequestRockError.
+        """
+        if self._operator is None:
+            raise BadRequestRockError("No operator configured")
+        return await self._operator.create_template(spec)
+
+    async def get_template_status(self, template_id: str) -> dict | None:
+        """Get template (Pool) status.
+
+        Delegates to operator. Non-K8s operators raise BadRequestRockError.
+        """
+        if self._operator is None:
+            raise BadRequestRockError("No operator configured")
+        return await self._operator.get_template_status(template_id)
+
+    async def delete_template(self, template_id: str) -> bool:
+        """Delete template (Pool CRD).
+
+        Returns True if deleted or not found, False if in use.
+        Delegates to operator. Non-K8s operators raise BadRequestRockError.
+        """
+        if self._operator is None:
+            raise BadRequestRockError("No operator configured")
+        return await self._operator.delete_template(template_id)
+
     def _init_archive_storage(self, rock_config: RockConfig) -> None:
         archive_cfg = rock_config.lifecycle.archive
         image_registry_cfg = archive_cfg.registry

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -1,0 +1,45 @@
+"""Smoke test configuration.
+
+Usage:
+    pytest tests/smoke/ --admin-url http://localhost:8080 --smoke-image python:3.11
+    pytest tests/smoke/  # defaults to http://localhost:8080, image=python:3.11
+"""
+
+import httpx
+import pytest
+
+API_PREFIX = "/apis/envs/sandbox/v1"
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--admin-url",
+        default="http://localhost:8080",
+        help="Admin service base URL (default: http://localhost:8080)",
+    )
+    parser.addoption(
+        "--smoke-image",
+        default="python:3.11",
+        help="Docker image for smoke tests (default: python:3.11)",
+    )
+
+
+@pytest.fixture(scope="session")
+def admin_url(request):
+    return request.config.getoption("--admin-url").rstrip("/")
+
+
+@pytest.fixture(scope="session")
+def smoke_image(request):
+    return request.config.getoption("--smoke-image")
+
+
+@pytest.fixture(scope="session")
+def api_base(admin_url):
+    return f"{admin_url}{API_PREFIX}"
+
+
+@pytest.fixture
+def client():
+    with httpx.Client(timeout=30) as c:
+        yield c

--- a/tests/smoke/test_template.py
+++ b/tests/smoke/test_template.py
@@ -1,6 +1,6 @@
 """Smoke tests for Template API (Warm path).
 
-Core chain: create → get → delete.
+Core chain: create → get → scale → get → delete.
 Run: pytest tests/smoke/test_template.py --admin-url http://localhost:8080 --smoke-image python:3.11
 """
 
@@ -23,28 +23,64 @@ def _create_template(client, api_base, image, **overrides):
     return result["templateID"]
 
 
+def _wait_ready(client, api_base, template_id):
+    """Poll template status until ready or error."""
+    status = None
+    for _ in range(60):  # timeout ~120s
+        resp = client.get(f"{api_base}/templates/{template_id}")
+        assert resp.status_code == 200, f"get failed: {resp.text}"
+        result = resp.json()["result"]
+        assert result["templateID"] == template_id
+        status = result["status"]
+        if status == "ready":
+            return result
+        if status == "error":
+            pytest.fail(f"template {template_id} error: {result.get('reason')}")
+        time.sleep(2)
+    pytest.fail(f"template {template_id} not ready after timeout, last status: {status}")
+
+
+def _wait_capacity(client, api_base, template_id, expected):
+    """Poll template status until capacity matches expected or timeout."""
+    for _ in range(15):  # timeout ~30s
+        resp = client.get(f"{api_base}/templates/{template_id}")
+        assert resp.status_code == 200, f"get failed: {resp.text}"
+        result = resp.json()["result"]
+        assert result["templateID"] == template_id
+        capacity_spec = result.get("capacity", {}).get("spec", {})
+        if all(capacity_spec.get(k) == v for k, v in expected.items()):
+            return result
+        time.sleep(2)
+    pytest.fail(f"template {template_id} capacity not updated to {expected}, got {capacity_spec}")
+
+
 def test_template_lifecycle(client, api_base, smoke_image):
-    """Full lifecycle: create → get → delete."""
+    """Full lifecycle: create → get → scale → get → delete."""
     # 1. Create
     template_id = _create_template(client, api_base, smoke_image)
 
     try:
-        # 2. Wait for template ready
-        for _ in range(60):  # timeout ~120s
-            resp = client.get(f"{api_base}/templates/{template_id}")
-            assert resp.status_code == 200, f"get failed: {resp.text}"
-            result = resp.json()["result"]
-            assert result["templateID"] == template_id
-            status = result["status"]
-            if status == "ready":
-                break
-            if status == "error":
-                pytest.fail(f"template {template_id} error: {result.get('reason')}")
-            time.sleep(2)
-        else:
-            pytest.fail(f"template {template_id} not ready after timeout, last status: {status}")
+        # 2. Wait for template ready and check capacity structure
+        result = _wait_ready(client, api_base, template_id)
+        capacity = result.get("capacity", {})
+        assert "spec" in capacity, f"missing capacity.spec: {capacity}"
+        assert "status" in capacity, f"missing capacity.status: {capacity}"
 
-        # 3. Delete
+        # 3. Scale capacity
+        scale_payload = {"poolMin": 2, "poolMax": 5}
+        resp = client.post(f"{api_base}/templates/{template_id}/scale", json=scale_payload)
+        assert resp.status_code == 200, f"scale failed: {resp.text}"
+        scale_result = resp.json()["result"]
+        assert scale_result["templateID"] == template_id
+        assert scale_result["capacity"]["spec"]["poolMin"] == 2
+        assert scale_result["capacity"]["spec"]["poolMax"] == 5
+
+        # 4. Verify scaled capacity via get (with retry for informer cache sync)
+        get_result = _wait_capacity(
+            client, api_base, template_id, {"poolMin": 2, "poolMax": 5}
+        )
+
+        # 5. Delete
         resp = client.delete(f"{api_base}/templates/{template_id}")
         assert resp.status_code == 200, f"delete failed: {resp.text}"
         assert "deleted" in resp.json()["result"]

--- a/tests/smoke/test_template.py
+++ b/tests/smoke/test_template.py
@@ -1,0 +1,63 @@
+"""Smoke tests for Template API (Warm path).
+
+Core chain: create → get → delete.
+Run: pytest tests/smoke/test_template.py --admin-url http://localhost:8080 --smoke-image python:3.11
+"""
+
+import time
+
+import pytest
+
+pytestmark = pytest.mark.need_admin
+
+
+def _create_template(client, api_base, image, **overrides):
+    payload = {"fromImage": image, "cpuCount": 2, "memoryMB": 2048}
+    payload.update(overrides)
+    resp = client.post(f"{api_base}/templates", json=payload)
+    assert resp.status_code == 200, f"create failed: {resp.text}"
+    data = resp.json()
+    assert data["status"] == "Success", f"create error: {data}"
+    result = data["result"]
+    assert result["templateID"].startswith("tpl-")
+    return result["templateID"]
+
+
+def test_template_lifecycle(client, api_base, smoke_image):
+    """Full lifecycle: create → get → delete."""
+    # 1. Create
+    template_id = _create_template(client, api_base, smoke_image)
+
+    try:
+        # 2. Wait for template ready
+        for _ in range(60):  # timeout ~120s
+            resp = client.get(f"{api_base}/templates/{template_id}")
+            assert resp.status_code == 200, f"get failed: {resp.text}"
+            result = resp.json()["result"]
+            assert result["templateID"] == template_id
+            status = result["status"]
+            if status == "ready":
+                break
+            if status == "error":
+                pytest.fail(f"template {template_id} error: {result.get('reason')}")
+            time.sleep(2)
+        else:
+            pytest.fail(f"template {template_id} not ready after timeout, last status: {status}")
+
+        # 3. Delete
+        resp = client.delete(f"{api_base}/templates/{template_id}")
+        assert resp.status_code == 200, f"delete failed: {resp.text}"
+        assert "deleted" in resp.json()["result"]
+    finally:
+        # Always cleanup, even on failure
+        client.delete(f"{api_base}/templates/{template_id}")
+
+
+def test_template_idempotent_create(client, api_base, smoke_image):
+    """Same spec produces the same template ID."""
+    tid1 = _create_template(client, api_base, smoke_image)
+    try:
+        tid2 = _create_template(client, api_base, smoke_image)
+        assert tid1 == tid2
+    finally:
+        client.delete(f"{api_base}/templates/{tid1}")

--- a/tests/unit/sandbox/operator/test_k8s_template_loader.py
+++ b/tests/unit/sandbox/operator/test_k8s_template_loader.py
@@ -385,10 +385,10 @@ class TestBuildPoolManifest:
 
     POOL_TEMPLATE = {
         "capacitySpec": {
-            "bufferMin": "{{ buffer_min | default(1) }}",
-            "bufferMax": "{{ buffer_max | default(3) }}",
-            "poolMin": "{{ pool_min | default(1) }}",
-            "poolMax": "{{ pool_max | default(10) }}",
+            "bufferMin": 1,
+            "bufferMax": 3,
+            "poolMin": 1,
+            "poolMax": 10,
         },
         "template": {
             "metadata": {"labels": {"app": "rock-pool"}},
@@ -457,7 +457,7 @@ class TestBuildPoolManifest:
         assert container["resources"]["limits"]["memory"] == "4096Mi"
 
     def test_build_pool_manifest_capacity_defaults(self, pool_loader):
-        """Capacity uses defaults and is converted to integers."""
+        """Capacity uses defaults from the pool template."""
         spec = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=2048)
         manifest = pool_loader.build_pool_manifest("tpl-abc123", spec)
 

--- a/tests/unit/sandbox/operator/test_k8s_template_loader.py
+++ b/tests/unit/sandbox/operator/test_k8s_template_loader.py
@@ -3,6 +3,7 @@
 import pytest
 
 from rock.sandbox.operator.k8s.constants import K8sConstants
+from rock.sandbox.operator.k8s.provider import TemplateSpec
 from rock.sandbox.operator.k8s.template_loader import K8sTemplateLoader
 
 
@@ -377,3 +378,102 @@ class TestK8sTemplateLoader:
 
         annotations = manifest["spec"]["template"]["metadata"]["annotations"]
         assert annotations["example.com/image-auth"] == "dGVzdC1lbmNyeXB0ZWQ="
+
+
+class TestBuildPoolManifest:
+    """Tests for Pool CRD manifest building via K8sTemplateLoader."""
+
+    POOL_TEMPLATE = {
+        "capacitySpec": {
+            "bufferMin": "{{ buffer_min | default(1) }}",
+            "bufferMax": "{{ buffer_max | default(3) }}",
+            "poolMin": "{{ pool_min | default(1) }}",
+            "poolMax": "{{ pool_max | default(10) }}",
+        },
+        "template": {
+            "metadata": {"labels": {"app": "rock-pool"}},
+            "spec": {
+                "tolerations": [{"operator": "Exists"}],
+                "containers": [{
+                    "name": "main",
+                    "image": "{{ from_image }}",
+                    "resources": {
+                        "limits": {
+                            "cpu": "{{ cpu_count }}",
+                            "memory": "{{ memory_mb }}Mi",
+                        },
+                        "requests": {
+                            "cpu": "{{ cpu_count }}",
+                            "memory": "{{ memory_mb }}Mi",
+                        },
+                    },
+                }],
+            },
+        },
+    }
+
+    @pytest.fixture
+    def pool_loader(self):
+        """Create a loader with a pool template."""
+        return K8sTemplateLoader(
+            templates={"default": {"ports": {"proxy": 8000}, "template": {"spec": {}}}},
+            default_namespace="rock-test",
+            pool_template=self.POOL_TEMPLATE,
+        )
+
+    def test_build_pool_manifest_basic(self, pool_loader):
+        """Pool CRD wrapper is assembled correctly."""
+        spec = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=2048)
+        manifest = pool_loader.build_pool_manifest("tpl-abc123", spec)
+
+        assert manifest["apiVersion"] == K8sConstants.CRD_API_VERSION
+        assert manifest["kind"] == K8sConstants.CRD_KIND_POOL
+        assert manifest["metadata"]["name"] == "tpl-abc123"
+        assert manifest["metadata"]["namespace"] == "rock-test"
+        assert manifest["metadata"]["labels"][K8sConstants.LABEL_MANAGED_BY] == K8sConstants.LABEL_MANAGED_BY_TEMPLATE_API
+
+    def test_build_pool_manifest_renders_image(self, pool_loader):
+        """Jinja2 renders from_image variable."""
+        spec = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=2048)
+        manifest = pool_loader.build_pool_manifest("tpl-abc123", spec)
+
+        container = manifest["spec"]["template"]["spec"]["containers"][0]
+        assert container["image"] == "python:3.11"
+
+    def test_build_pool_manifest_renders_cpu(self, pool_loader):
+        """Jinja2 renders cpu_count variable."""
+        spec = TemplateSpec(from_image="python:3.11", cpu_count=4, memory_mb=2048)
+        manifest = pool_loader.build_pool_manifest("tpl-abc123", spec)
+
+        container = manifest["spec"]["template"]["spec"]["containers"][0]
+        assert container["resources"]["limits"]["cpu"] == "4"
+
+    def test_build_pool_manifest_renders_memory(self, pool_loader):
+        """Jinja2 renders memory_mb variable."""
+        spec = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=4096)
+        manifest = pool_loader.build_pool_manifest("tpl-abc123", spec)
+
+        container = manifest["spec"]["template"]["spec"]["containers"][0]
+        assert container["resources"]["limits"]["memory"] == "4096Mi"
+
+    def test_build_pool_manifest_capacity_defaults(self, pool_loader):
+        """Capacity uses defaults and is converted to integers."""
+        spec = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=2048)
+        manifest = pool_loader.build_pool_manifest("tpl-abc123", spec)
+
+        cap = manifest["spec"]["capacitySpec"]
+        assert cap["bufferMin"] == 1
+        assert cap["bufferMax"] == 3
+        assert cap["poolMin"] == 1
+        assert cap["poolMax"] == 10
+
+    def test_build_pool_manifest_without_pool_template(self):
+        """Calling build_pool_manifest without a pool template raises ValueError."""
+        loader = K8sTemplateLoader(
+            templates={"default": {"ports": {"proxy": 8000}, "template": {"spec": {}}}},
+            default_namespace="rock-test",
+        )
+        spec = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=2048)
+
+        with pytest.raises(ValueError, match="No pool template configured"):
+            loader.build_pool_manifest("tpl-abc123", spec)

--- a/tests/unit/test_template_api.py
+++ b/tests/unit/test_template_api.py
@@ -1,0 +1,227 @@
+"""Unit tests for Template API (Warm path) implementation."""
+import copy
+
+import jinja2
+import pytest
+
+from rock.sandbox.operator.k8s.constants import K8sConstants
+from rock.sandbox.operator.k8s.provider import BatchSandboxProvider, TemplateSpec, generate_template_id
+from rock.utils.jinja_render import render_node
+
+
+class TestGenerateTemplateId:
+    """Tests for generate_template_id function."""
+
+    def test_same_spec_same_id(self):
+        """Same (fromImage, cpuCount, memoryMB) produce the same template ID."""
+        spec1 = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=2048)
+        spec2 = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=2048)
+        assert generate_template_id(spec1) == generate_template_id(spec2)
+
+    def test_different_image_different_id(self):
+        """Different fromImage produces different template IDs."""
+        spec1 = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=2048)
+        spec2 = TemplateSpec(from_image="python:3.12", cpu_count=2, memory_mb=2048)
+        assert generate_template_id(spec1) != generate_template_id(spec2)
+
+    def test_different_cpu_different_id(self):
+        """Different cpuCount produces different template IDs."""
+        spec1 = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=2048)
+        spec2 = TemplateSpec(from_image="python:3.11", cpu_count=4, memory_mb=2048)
+        assert generate_template_id(spec1) != generate_template_id(spec2)
+
+    def test_different_memory_different_id(self):
+        """Different memoryMB produces different template IDs."""
+        spec1 = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=2048)
+        spec2 = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=4096)
+        assert generate_template_id(spec1) != generate_template_id(spec2)
+
+    def test_placeholder_fields_ignored(self):
+        """Phase 1: diskGB, numGpus, acceleratorType don't affect template ID."""
+        spec1 = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=2048)
+        spec2 = TemplateSpec(
+            from_image="python:3.11", cpu_count=2, memory_mb=2048,
+            disk_gb=40, num_gpus=2, accelerator_type="A100",
+        )
+        assert generate_template_id(spec1) == generate_template_id(spec2)
+
+    def test_id_has_prefix(self):
+        """Template ID starts with the configured prefix."""
+        spec = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=2048)
+        tid = generate_template_id(spec)
+        assert tid.startswith(K8sConstants.TEMPLATE_ID_PREFIX)
+
+
+class TestTemplateSpec:
+    """Tests for TemplateSpec dataclass."""
+
+    def test_required_fields(self):
+        """Required fields are set correctly."""
+        spec = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=2048)
+        assert spec.from_image == "python:3.11"
+        assert spec.cpu_count == 2
+        assert spec.memory_mb == 2048
+
+    def test_optional_fields_default_none(self):
+        """Optional fields default to None."""
+        spec = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=2048)
+        assert spec.disk_gb is None
+        assert spec.num_gpus is None
+        assert spec.accelerator_type is None
+
+
+class TestBuildPoolManifest:
+    """Tests for Pool CRD manifest building (Jinja2 rendering)."""
+
+    POOL_TEMPLATE = {
+        "capacitySpec": {
+            "bufferMin": "{{ buffer_min | default(1) }}",
+            "bufferMax": "{{ buffer_max | default(3) }}",
+            "poolMin": "{{ pool_min | default(1) }}",
+            "poolMax": "{{ pool_max | default(10) }}",
+        },
+        "template": {
+            "metadata": {"labels": {"app": "rock-pool"}},
+            "spec": {
+                "tolerations": [{"operator": "Exists"}],
+                "containers": [{
+                    "name": "main",
+                    "image": "{{ from_image }}",
+                    "resources": {
+                        "limits": {
+                            "cpu": "{{ cpu_count }}",
+                            "memory": "{{ memory_mb }}Mi",
+                        },
+                        "requests": {
+                            "cpu": "{{ cpu_count }}",
+                            "memory": "{{ memory_mb }}Mi",
+                        },
+                    },
+                }],
+            },
+        },
+    }
+
+    def test_jinja_render_image(self):
+        """Jinja2 renders from_image variable."""
+        spec = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=2048)
+        ctx = {
+            "from_image": spec.from_image,
+            "cpu_count": spec.cpu_count,
+            "memory_mb": spec.memory_mb,
+        }
+        rendered = render_node(copy.deepcopy(self.POOL_TEMPLATE), jinja2.Environment(), ctx)
+        assert rendered["template"]["spec"]["containers"][0]["image"] == "python:3.11"
+
+    def test_jinja_render_cpu(self):
+        """Jinja2 renders cpu_count variable."""
+        spec = TemplateSpec(from_image="python:3.11", cpu_count=4, memory_mb=2048)
+        ctx = {
+            "from_image": spec.from_image,
+            "cpu_count": spec.cpu_count,
+            "memory_mb": spec.memory_mb,
+        }
+        rendered = render_node(copy.deepcopy(self.POOL_TEMPLATE), jinja2.Environment(), ctx)
+        assert rendered["template"]["spec"]["containers"][0]["resources"]["limits"]["cpu"] == "4"
+
+    def test_jinja_render_memory(self):
+        """Jinja2 renders memory_mb variable."""
+        spec = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=4096)
+        ctx = {
+            "from_image": spec.from_image,
+            "cpu_count": spec.cpu_count,
+            "memory_mb": spec.memory_mb,
+        }
+        rendered = render_node(copy.deepcopy(self.POOL_TEMPLATE), jinja2.Environment(), ctx)
+        assert rendered["template"]["spec"]["containers"][0]["resources"]["limits"]["memory"] == "4096Mi"
+
+    def test_jinja_render_capacity_default(self):
+        """Capacity uses defaults when not specified."""
+        spec = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=2048)
+        ctx = {
+            "from_image": spec.from_image,
+            "cpu_count": spec.cpu_count,
+            "memory_mb": spec.memory_mb,
+        }
+        rendered = render_node(copy.deepcopy(self.POOL_TEMPLATE), jinja2.Environment(), ctx)
+        assert rendered["capacitySpec"]["bufferMin"] == "1"
+        assert rendered["capacitySpec"]["bufferMax"] == "3"
+        assert rendered["capacitySpec"]["poolMin"] == "1"
+        assert rendered["capacitySpec"]["poolMax"] == "10"
+
+
+def _make_provider():
+    """Create a BatchSandboxProvider without calling __init__."""
+    return object.__new__(BatchSandboxProvider)
+
+
+class TestMapPoolToTemplateStatus:
+    """Tests for Pool CRD to template status mapping (design doc format)."""
+
+    def test_ready_pool(self):
+        """Pool with available > 0 maps to 'ready'."""
+        provider = _make_provider()
+        mock_pool = {
+            "metadata": {"name": "tpl-abc123", "creationTimestamp": "2026-08-03T06:00:00Z"},
+            "status": {"available": 2, "total": 3},
+        }
+        result = provider._map_pool_to_template_status(mock_pool)
+        assert result["template_id"] == "tpl-abc123"
+        assert result["status"] == "ready"
+        assert result["reason"] is None
+        assert result["created_at"] == "2026-08-03T06:00:00Z"
+
+    def test_building_pool(self):
+        """Pool with total but no available maps to 'building'."""
+        provider = _make_provider()
+        mock_pool = {
+            "metadata": {"name": "tpl-abc123", "creationTimestamp": "2026-08-03T06:00:00Z"},
+            "status": {"available": 0, "total": 3},
+        }
+        result = provider._map_pool_to_template_status(mock_pool)
+        assert result["status"] == "building"
+
+    def test_new_pool_no_status(self):
+        """Pool with no status section maps to 'building'."""
+        provider = _make_provider()
+        mock_pool = {
+            "metadata": {"name": "tpl-abc123", "creationTimestamp": "2026-08-03T06:00:00Z"},
+        }
+        result = provider._map_pool_to_template_status(mock_pool)
+        assert result["status"] == "building"
+        assert result["reason"] is None
+
+    def test_error_pool(self):
+        """Pool with Ready=False condition maps to 'error' with reason."""
+        provider = _make_provider()
+        mock_pool = {
+            "metadata": {"name": "tpl-abc123", "creationTimestamp": "2026-08-03T06:00:00Z"},
+            "status": {
+                "available": 0,
+                "total": 0,
+                "conditions": [{"type": "Ready", "status": "False", "message": "insufficient resources"}],
+            },
+        }
+        result = provider._map_pool_to_template_status(mock_pool)
+        assert result["status"] == "error"
+        assert result["reason"] is not None
+        assert result["reason"]["message"] == "insufficient resources"
+        assert result["reason"]["step"] == "create_fiber_pool"
+
+
+class TestK8sConstants:
+    """Tests for new K8sConstants entries."""
+
+    def test_pool_crd_constants(self):
+        """Pool CRD constants are set correctly."""
+        assert K8sConstants.CRD_PLURAL_POOL == "pools"
+        assert K8sConstants.CRD_KIND_POOL == "Pool"
+
+    def test_label_constants(self):
+        """Label constants are set correctly."""
+        assert K8sConstants.LABEL_MANAGED_BY == "rock.sandbox/managed-by"
+        assert K8sConstants.LABEL_MANAGED_BY_TEMPLATE_API == "template-api"
+
+    def test_template_id_prefix(self):
+        """Template ID prefix is set correctly."""
+        assert K8sConstants.TEMPLATE_ID_PREFIX == "tpl-"

--- a/tests/unit/test_template_api.py
+++ b/tests/unit/test_template_api.py
@@ -1,12 +1,10 @@
 """Unit tests for Template API (Warm path) implementation."""
-import copy
-
-import jinja2
 import pytest
 
+from rock.admin.proto.request import TemplateScaleRequest
 from rock.sandbox.operator.k8s.constants import K8sConstants
 from rock.sandbox.operator.k8s.provider import BatchSandboxProvider, TemplateSpec, generate_template_id
-from rock.utils.jinja_render import render_node
+from rock.sdk.common.exceptions import BadRequestRockError
 
 
 class TestGenerateTemplateId:
@@ -36,14 +34,21 @@ class TestGenerateTemplateId:
         spec2 = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=4096)
         assert generate_template_id(spec1) != generate_template_id(spec2)
 
-    def test_placeholder_fields_ignored(self):
-        """Phase 1: diskGB, numGpus, acceleratorType don't affect template ID."""
-        spec1 = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=2048)
-        spec2 = TemplateSpec(
-            from_image="python:3.11", cpu_count=2, memory_mb=2048,
-            disk_gb=40, num_gpus=2, accelerator_type="A100",
+    def test_optional_fields_affect_id(self):
+        """All non-null optional fields participate in template ID."""
+        base = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=2048)
+        with_disk = TemplateSpec(
+            from_image="python:3.11", cpu_count=2, memory_mb=2048, disk_gb=40,
         )
-        assert generate_template_id(spec1) == generate_template_id(spec2)
+        with_gpu = TemplateSpec(
+            from_image="python:3.11", cpu_count=2, memory_mb=2048, num_gpus=2,
+        )
+        with_accelerator = TemplateSpec(
+            from_image="python:3.11", cpu_count=2, memory_mb=2048, accelerator_type="A100",
+        )
+        assert generate_template_id(base) != generate_template_id(with_disk)
+        assert generate_template_id(base) != generate_template_id(with_gpu)
+        assert generate_template_id(base) != generate_template_id(with_accelerator)
 
     def test_id_has_prefix(self):
         """Template ID starts with the configured prefix."""
@@ -69,85 +74,15 @@ class TestTemplateSpec:
         assert spec.num_gpus is None
         assert spec.accelerator_type is None
 
-
-class TestBuildPoolManifest:
-    """Tests for Pool CRD manifest building (Jinja2 rendering)."""
-
-    POOL_TEMPLATE = {
-        "capacitySpec": {
-            "bufferMin": "{{ buffer_min | default(1) }}",
-            "bufferMax": "{{ buffer_max | default(3) }}",
-            "poolMin": "{{ pool_min | default(1) }}",
-            "poolMax": "{{ pool_max | default(10) }}",
-        },
-        "template": {
-            "metadata": {"labels": {"app": "rock-pool"}},
-            "spec": {
-                "tolerations": [{"operator": "Exists"}],
-                "containers": [{
-                    "name": "main",
-                    "image": "{{ from_image }}",
-                    "resources": {
-                        "limits": {
-                            "cpu": "{{ cpu_count }}",
-                            "memory": "{{ memory_mb }}Mi",
-                        },
-                        "requests": {
-                            "cpu": "{{ cpu_count }}",
-                            "memory": "{{ memory_mb }}Mi",
-                        },
-                    },
-                }],
-            },
-        },
-    }
-
-    def test_jinja_render_image(self):
-        """Jinja2 renders from_image variable."""
-        spec = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=2048)
-        ctx = {
-            "from_image": spec.from_image,
-            "cpu_count": spec.cpu_count,
-            "memory_mb": spec.memory_mb,
-        }
-        rendered = render_node(copy.deepcopy(self.POOL_TEMPLATE), jinja2.Environment(), ctx)
-        assert rendered["template"]["spec"]["containers"][0]["image"] == "python:3.11"
-
-    def test_jinja_render_cpu(self):
-        """Jinja2 renders cpu_count variable."""
-        spec = TemplateSpec(from_image="python:3.11", cpu_count=4, memory_mb=2048)
-        ctx = {
-            "from_image": spec.from_image,
-            "cpu_count": spec.cpu_count,
-            "memory_mb": spec.memory_mb,
-        }
-        rendered = render_node(copy.deepcopy(self.POOL_TEMPLATE), jinja2.Environment(), ctx)
-        assert rendered["template"]["spec"]["containers"][0]["resources"]["limits"]["cpu"] == "4"
-
-    def test_jinja_render_memory(self):
-        """Jinja2 renders memory_mb variable."""
-        spec = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=4096)
-        ctx = {
-            "from_image": spec.from_image,
-            "cpu_count": spec.cpu_count,
-            "memory_mb": spec.memory_mb,
-        }
-        rendered = render_node(copy.deepcopy(self.POOL_TEMPLATE), jinja2.Environment(), ctx)
-        assert rendered["template"]["spec"]["containers"][0]["resources"]["limits"]["memory"] == "4096Mi"
-
-    def test_jinja_render_capacity_default(self):
-        """Capacity uses defaults when not specified."""
-        spec = TemplateSpec(from_image="python:3.11", cpu_count=2, memory_mb=2048)
-        ctx = {
-            "from_image": spec.from_image,
-            "cpu_count": spec.cpu_count,
-            "memory_mb": spec.memory_mb,
-        }
-        rendered = render_node(copy.deepcopy(self.POOL_TEMPLATE), jinja2.Environment(), ctx)
-        assert rendered["capacitySpec"]["bufferMin"] == "1"
-        assert rendered["capacitySpec"]["bufferMax"] == "3"
-        assert rendered["capacitySpec"]["poolMin"] == "1"
-        assert rendered["capacitySpec"]["poolMax"] == "10"
+    def test_capacity_fields_removed(self):
+        """Capacity fields are excluded from TemplateSpec identity."""
+        with pytest.raises(TypeError):
+            TemplateSpec(
+                from_image="python:3.11",
+                cpu_count=2,
+                memory_mb=2048,
+                buffer_min=1,
+            )
 
 
 def _make_provider():
@@ -163,50 +98,192 @@ class TestMapPoolToTemplateStatus:
         provider = _make_provider()
         mock_pool = {
             "metadata": {"name": "tpl-abc123", "creationTimestamp": "2026-08-03T06:00:00Z"},
-            "status": {"available": 2, "total": 3},
+            "spec": {
+                "capacitySpec": {"poolMin": 1, "poolMax": 10, "bufferMin": 1, "bufferMax": 3},
+            },
+            "status": {"available": 2, "total": 3, "allocated": 1},
         }
         result = provider._map_pool_to_template_status(mock_pool)
         assert result["template_id"] == "tpl-abc123"
         assert result["status"] == "ready"
         assert result["reason"] is None
         assert result["created_at"] == "2026-08-03T06:00:00Z"
+        assert result["capacity"]["spec"]["pool_min"] == 1
+        assert result["capacity"]["status"]["available"] == 2
 
     def test_building_pool(self):
         """Pool with total but no available maps to 'building'."""
         provider = _make_provider()
         mock_pool = {
             "metadata": {"name": "tpl-abc123", "creationTimestamp": "2026-08-03T06:00:00Z"},
-            "status": {"available": 0, "total": 3},
+            "spec": {
+                "capacitySpec": {"poolMin": 1, "poolMax": 10, "bufferMin": 1, "bufferMax": 3},
+            },
+            "status": {"available": 0, "total": 3, "allocated": 0},
         }
         result = provider._map_pool_to_template_status(mock_pool)
         assert result["status"] == "building"
+        assert result["capacity"]["spec"]["pool_max"] == 10
+        assert result["capacity"]["status"]["total"] == 3
 
     def test_new_pool_no_status(self):
         """Pool with no status section maps to 'building'."""
         provider = _make_provider()
         mock_pool = {
             "metadata": {"name": "tpl-abc123", "creationTimestamp": "2026-08-03T06:00:00Z"},
+            "spec": {
+                "capacitySpec": {"poolMin": 1, "poolMax": 10, "bufferMin": 1, "bufferMax": 3},
+            },
         }
         result = provider._map_pool_to_template_status(mock_pool)
         assert result["status"] == "building"
         assert result["reason"] is None
+        assert result["capacity"]["spec"]["buffer_min"] == 1
+        assert result["capacity"]["status"]["available"] is None
 
-    def test_error_pool(self):
-        """Pool with Ready=False condition maps to 'error' with reason."""
+    def test_zero_capacity_pool_ready(self):
+        """Pool with poolMin=0 and bufferMin=0 maps to 'ready' without replicas."""
         provider = _make_provider()
         mock_pool = {
             "metadata": {"name": "tpl-abc123", "creationTimestamp": "2026-08-03T06:00:00Z"},
-            "status": {
-                "available": 0,
-                "total": 0,
-                "conditions": [{"type": "Ready", "status": "False", "message": "insufficient resources"}],
+            "spec": {
+                "capacitySpec": {"poolMin": 0, "bufferMin": 0, "poolMax": 0, "bufferMax": 0},
             },
+            "status": {"available": 0, "total": 0},
         }
         result = provider._map_pool_to_template_status(mock_pool)
-        assert result["status"] == "error"
-        assert result["reason"] is not None
-        assert result["reason"]["message"] == "insufficient resources"
-        assert result["reason"]["step"] == "create_fiber_pool"
+        assert result["status"] == "ready"
+        assert result["reason"] is None
+        assert result["capacity"]["spec"]["pool_min"] == 0
+        assert result["capacity"]["status"]["total"] == 0
+
+    def test_updated_at_fallback(self):
+        """updated_at falls back to creationTimestamp when status has no timestamp."""
+        provider = _make_provider()
+        mock_pool = {
+            "metadata": {"name": "tpl-abc123", "creationTimestamp": "2026-08-03T06:00:00Z"},
+            "spec": {
+                "capacitySpec": {"poolMin": 1, "poolMax": 10, "bufferMin": 1, "bufferMax": 3},
+            },
+            "status": {"available": 2, "total": 3},
+        }
+        result = provider._map_pool_to_template_status(mock_pool)
+        assert result["updated_at"] == "2026-08-03T06:00:00Z"
+
+
+class TestTemplateScaleRequest:
+    """Tests for TemplateScaleRequest validation."""
+
+    def test_valid_scale_request(self):
+        """All fields optional and valid."""
+        req = TemplateScaleRequest(pool_min=1, pool_max=10, buffer_min=1, buffer_max=3)
+        assert req.pool_min == 1
+        assert req.pool_max == 10
+        assert req.buffer_min == 1
+        assert req.buffer_max == 3
+
+    def test_patch_semantics_partial_fields(self):
+        """Only provided fields are set."""
+        req = TemplateScaleRequest(pool_min=5)
+        assert req.pool_min == 5
+        assert req.pool_max is None
+        assert req.buffer_min is None
+        assert req.buffer_max is None
+
+    def test_zero_capacity_allowed(self):
+        """pool_min=0 and buffer_min=0 are allowed."""
+        req = TemplateScaleRequest(pool_min=0, buffer_min=0)
+        assert req.pool_min == 0
+        assert req.buffer_min == 0
+
+    def test_negative_rejected(self):
+        """Negative capacity values are rejected."""
+        with pytest.raises(ValueError, match="pool_min must be >= 0"):
+            TemplateScaleRequest(pool_min=-1)
+
+    def test_min_exceeds_max_rejected(self):
+        """pool_min > pool_max and buffer_min > buffer_max are rejected."""
+        with pytest.raises(ValueError, match="pool_min must be <= pool_max"):
+            TemplateScaleRequest(pool_min=5, pool_max=3)
+        with pytest.raises(ValueError, match="buffer_min must be <= buffer_max"):
+            TemplateScaleRequest(buffer_min=5, buffer_max=3)
+
+
+@pytest.fixture
+def anyio_backend():
+    """Run anyio async tests on asyncio backend only."""
+    return "asyncio"
+
+
+class TestScaleTemplate:
+    """Tests for BatchSandboxProvider.scale_template."""
+
+    def _make_provider(self):
+        """Create a provider with mocked _pool_api and initialized flag."""
+        provider = object.__new__(BatchSandboxProvider)
+        provider._initialized = True
+        provider._pool_api = MockPoolApi()
+        return provider
+
+    @pytest.mark.anyio
+    async def test_scale_updates_capacity(self):
+        """Scale patches capacitySpec and returns mapped status."""
+        provider = self._make_provider()
+        provider._pool_api.existing_pool = {
+            "metadata": {"name": "tpl-abc", "creationTimestamp": "2026-08-03T06:00:00Z"},
+            "spec": {"capacitySpec": {"poolMin": 1, "poolMax": 10, "bufferMin": 1, "bufferMax": 3}},
+            "status": {"available": 2, "total": 3},
+        }
+
+        result = await provider.scale_template("tpl-abc", {"pool_min": 2, "pool_max": 20})
+
+        assert result["template_id"] == "tpl-abc"
+        assert result["status"] == "ready"
+        assert result["capacity"]["spec"]["pool_min"] == 1
+        assert result["capacity"]["status"]["available"] == 2
+        assert provider._pool_api.last_patch == {
+            "spec": {"capacitySpec": {"poolMin": 2, "poolMax": 20}}
+        }
+
+    @pytest.mark.anyio
+    async def test_scale_not_found(self):
+        """Scaling a non-existent template raises BadRequestRockError."""
+        provider = self._make_provider()
+        provider._pool_api.existing_pool = None
+
+        with pytest.raises(BadRequestRockError, match="Template tpl-missing not found"):
+            await provider.scale_template("tpl-missing", {"pool_min": 1})
+
+    @pytest.mark.anyio
+    async def test_scale_empty_capacity(self):
+        """Empty capacity dict raises BadRequestRockError."""
+        provider = self._make_provider()
+
+        with pytest.raises(BadRequestRockError, match="No capacity fields provided"):
+            await provider.scale_template("tpl-abc", {})
+
+    @pytest.mark.anyio
+    async def test_scale_invalid_field(self):
+        """Invalid capacity field raises BadRequestRockError."""
+        provider = self._make_provider()
+
+        with pytest.raises(BadRequestRockError, match="Invalid capacity fields"):
+            await provider.scale_template("tpl-abc", {"pool_min": 1, "unknown": 5})
+
+
+class MockPoolApi:
+    """Minimal mock for provider scale tests."""
+
+    def __init__(self):
+        self.existing_pool = None
+        self.last_patch = None
+
+    async def get_custom_object(self, name: str):
+        return self.existing_pool
+
+    async def update_custom_object(self, name: str, body: dict):
+        self.last_patch = body
+        return self.existing_pool
 
 
 class TestK8sConstants:


### PR DESCRIPTION
## What does this PR do?

Implements Template API for sandbox warm pool management via K8s Pool CRD. Resolves #1310.

## Changes

- **Template API endpoints** (`template_api.py`): POST/GET/DELETE `/apis/envs/sandbox/v1/templates`
- **K8s Provider** (`provider.py`): Pool informer + `create_template`/`get_template_status`/`delete_template` methods
- **SandboxManager** (`sandbox_manager.py`): proxy methods for template operations
- **Config** (`config.py`): `pool_template` field for Jinja2-rendered Pool CRD config
- **Constants** (`constants.py`): Pool CRD constants, `TEMPLATE_ID_PREFIX = "tpl-"`, managed-by label
- **Proto** (`request.py`/`response.py`): `TemplateCreateRequest`/`TemplateStatusResponse`

## Design

- `templateID = tpl-{sha256(non-null spec fields)[:16]}` — same spec always produces same ID
- Pool CRD is the source of truth (no DB), Informer cache for reads
- 409 Conflict on duplicate create = idempotent
- Status mapping: `available > 0` → ready, `available == 0, total > 0` → building

## Testing

- **Unit tests** (`tests/unit/test_template_api.py`): 19 cases — ID generation, Spec, Jinja2 rendering, status mapping, constants
- **Smoke tests** (`tests/smoke/test_template.py`): lifecycle (create → wait ready → delete) + idempotent create, with `--admin-url` and `--smoke-image` CLI options

```
pytest tests/unit/test_template_api.py     # 19 passed
pytest tests/smoke/ --smoke-image <image>  # 2 passed
```
